### PR TITLE
Improve errors around sources

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -282,9 +282,11 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 		{
 			OUT("\n  ↻ Loading data from sources...")
 			for _, source := range pipeline.Sources {
+				sourceLabel := lo.Must(source.Backend()).String()
+
 				sourceEntries, err := source.Load(ctx)
 				if err != nil {
-					return errors.Wrap(err, fmt.Sprintf("loading entries from source %v", source))
+					return errors.Wrap(err, fmt.Sprintf("loading entries from source: %s", sourceLabel))
 				}
 
 				for _, sourceEntry := range sourceEntries {
@@ -296,7 +298,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 					sourcedEntries = append(sourcedEntries, parsedEntries...)
 				}
 
-				OUT("    ✔ %s (found %d entries)", source.Name(), len(sourcedEntries))
+				OUT("    ✔ %s (found %d entries)", sourceLabel, len(sourcedEntries))
 			}
 		}
 

--- a/source/source_exec.go
+++ b/source/source_exec.go
@@ -23,6 +23,10 @@ func (s SourceExec) Validate() error {
 	)
 }
 
+func (s SourceExec) String() string {
+	return fmt.Sprintf("exec (command=%s)", strings.Join(s.Command, ","))
+}
+
 func (s SourceExec) Load(ctx context.Context) ([]*SourceEntry, error) {
 	var (
 		command = s.Command[0]

--- a/source/source_inline.go
+++ b/source/source_inline.go
@@ -17,6 +17,10 @@ func (s SourceInline) Validate() error {
 	return validation.ValidateStruct(&s)
 }
 
+func (s SourceInline) String() string {
+	return "inline" // we can't put all entries here, that would be too much
+}
+
 func (s SourceInline) Load(ctx context.Context) ([]*SourceEntry, error) {
 	entries := []*SourceEntry{}
 	for idx, entry := range s.Entries {

--- a/source/source_local.go
+++ b/source/source_local.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/pkg/errors"
@@ -19,6 +20,10 @@ func (s SourceLocal) Validate() error {
 		validation.Field(&s.Files, validation.Length(1, 0).
 			Error("must provide at least one file when using local source")),
 	)
+}
+
+func (s SourceLocal) String() string {
+	return fmt.Sprintf("local (files=%s)", strings.Join(s.Files, ","))
 }
 
 func (s SourceLocal) Load(ctx context.Context) ([]*SourceEntry, error) {


### PR DESCRIPTION
Have each source implement a String() that helps understand what you're referencing when it's printed in output.

```
  ↻ Loading data from sources...
    ✔ local (files=*/multi-doc.yaml) (found 857 entries)
```