### PR TITLE
catalog-importer types

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -26,6 +26,13 @@ const (
 	Outstanding ActionV1Status = "outstanding"
 )
 
+// Defines values for CatalogResourceV2Category.
+const (
+	CatalogResourceV2CategoryCustom    CatalogResourceV2Category = "custom"
+	CatalogResourceV2CategoryExternal  CatalogResourceV2Category = "external"
+	CatalogResourceV2CategoryPrimitive CatalogResourceV2Category = "primitive"
+)
+
 // Defines values for CatalogTypeV2Color.
 const (
 	CatalogTypeV2ColorBlue   CatalogTypeV2Color = "blue"
@@ -215,6 +222,8 @@ const (
 
 // Defines values for IdentityV1Roles.
 const (
+	IdentityV1RolesCatalogEditor   IdentityV1Roles = "catalog_editor"
+	IdentityV1RolesCatalogViewer   IdentityV1Roles = "catalog_viewer"
 	IdentityV1RolesGlobalAccess    IdentityV1Roles = "global_access"
 	IdentityV1RolesIncidentCreator IdentityV1Roles = "incident_creator"
 	IdentityV1RolesIncidentEditor  IdentityV1Roles = "incident_editor"
@@ -224,9 +233,9 @@ const (
 
 // Defines values for IncidentRoleV1RoleType.
 const (
-	Custom   IncidentRoleV1RoleType = "custom"
-	Lead     IncidentRoleV1RoleType = "lead"
-	Reporter IncidentRoleV1RoleType = "reporter"
+	IncidentRoleV1RoleTypeCustom   IncidentRoleV1RoleType = "custom"
+	IncidentRoleV1RoleTypeLead     IncidentRoleV1RoleType = "lead"
+	IncidentRoleV1RoleTypeReporter IncidentRoleV1RoleType = "reporter"
 )
 
 // Defines values for IncidentStatusV1Category.
@@ -286,6 +295,36 @@ const (
 	UpdateRequestBody2RequiredAlways        UpdateRequestBody2Required = "always"
 	UpdateRequestBody2RequiredBeforeClosure UpdateRequestBody2Required = "before_closure"
 	UpdateRequestBody2RequiredNever         UpdateRequestBody2Required = "never"
+)
+
+// Defines values for UpdateTypeRequestBodyColor.
+const (
+	Blue   UpdateTypeRequestBodyColor = "blue"
+	Green  UpdateTypeRequestBodyColor = "green"
+	Red    UpdateTypeRequestBodyColor = "red"
+	Slate  UpdateTypeRequestBodyColor = "slate"
+	Violet UpdateTypeRequestBodyColor = "violet"
+	Yellow UpdateTypeRequestBodyColor = "yellow"
+)
+
+// Defines values for UpdateTypeRequestBodyIcon.
+const (
+	Bolt      UpdateTypeRequestBodyIcon = "bolt"
+	Box       UpdateTypeRequestBodyIcon = "box"
+	Briefcase UpdateTypeRequestBodyIcon = "briefcase"
+	Browser   UpdateTypeRequestBodyIcon = "browser"
+	Bulb      UpdateTypeRequestBodyIcon = "bulb"
+	Clock     UpdateTypeRequestBodyIcon = "clock"
+	Cog       UpdateTypeRequestBodyIcon = "cog"
+	Database  UpdateTypeRequestBodyIcon = "database"
+	Doc       UpdateTypeRequestBodyIcon = "doc"
+	Email     UpdateTypeRequestBodyIcon = "email"
+	Server    UpdateTypeRequestBodyIcon = "server"
+	Severity  UpdateTypeRequestBodyIcon = "severity"
+	Star      UpdateTypeRequestBodyIcon = "star"
+	Tag       UpdateTypeRequestBodyIcon = "tag"
+	User      UpdateTypeRequestBodyIcon = "user"
+	Users     UpdateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for UserV1Role.
@@ -446,6 +485,27 @@ type CatalogEntryV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// CatalogResourceV2 defines model for CatalogResourceV2.
+type CatalogResourceV2 struct {
+	// Category Which category of resource
+	Category CatalogResourceV2Category `json:"category"`
+
+	// Description Human readable description for this resource
+	Description string `json:"description"`
+
+	// Label Label for this catalog resource type
+	Label string `json:"label"`
+
+	// Type Catalog type name for this resource
+	Type string `json:"type"`
+
+	// ValueDocstring Documentation for the literal string value of this resource
+	ValueDocstring string `json:"value_docstring"`
+}
+
+// CatalogResourceV2Category Which category of resource
+type CatalogResourceV2Category string
+
 // CatalogTypeAttributePayloadV2 defines model for CatalogTypeAttributePayloadV2.
 type CatalogTypeAttributePayloadV2 struct {
 	// Array Whether this attribute is an array
@@ -527,7 +587,7 @@ type CatalogTypeV2 struct {
 	// SemanticType Semantic type of this resource
 	SemanticType string `json:"semantic_type"`
 
-	// TypeName The type name of this catalog type, to be used when defining attributes
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
 	TypeName string `json:"type_name"`
 
 	// UpdatedAt When this type was last updated
@@ -800,7 +860,7 @@ type CreateTypeRequestBody struct {
 	// SemanticType Semantic type of this resource
 	SemanticType *string `json:"semantic_type,omitempty"`
 
-	// TypeName The type name of this catalog type, to be used when defining attributes
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
 	TypeName *string `json:"type_name,omitempty"`
 }
 
@@ -1357,6 +1417,11 @@ type ListEntriesResponseBody struct {
 	PaginationMeta PaginationMetaResult `json:"pagination_meta"`
 }
 
+// ListResourcesResponseBody defines model for ListResourcesResponseBody.
+type ListResourcesResponseBody struct {
+	Resources []CatalogResourceV2 `json:"resources"`
+}
+
 // ListResponseBody defines model for ListResponseBody.
 type ListResponseBody struct {
 	Actions []ActionV1 `json:"actions"`
@@ -1427,7 +1492,7 @@ type ListTypesResponseBody struct {
 
 // PaginationMetaResult defines model for PaginationMetaResult.
 type PaginationMetaResult struct {
-	// After If provided, were records after a particular ID
+	// After If provided, pass this as the 'after' param to load the next page
 	After *string `json:"after,omitempty"`
 
 	// PageSize What was the maximum number of results requested
@@ -1436,7 +1501,7 @@ type PaginationMetaResult struct {
 
 // PaginationMetaResultWithTotal defines model for PaginationMetaResultWithTotal.
 type PaginationMetaResultWithTotal struct {
-	// After If provided, were records after a particular ID
+	// After If provided, pass this as the 'after' param to load the next page
 	After *string `json:"after,omitempty"`
 
 	// PageSize What was the maximum number of results requested
@@ -1609,6 +1674,36 @@ type UpdateRequestBody4 struct {
 	// Name Unique name of this status
 	Name string `json:"name"`
 }
+
+// UpdateTypeRequestBody defines model for UpdateTypeRequestBody.
+type UpdateTypeRequestBody struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color *UpdateTypeRequestBodyColor `json:"color,omitempty"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *UpdateTypeRequestBodyIcon `json:"icon,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
+	// SemanticType Semantic type of this resource
+	SemanticType *string `json:"semantic_type,omitempty"`
+}
+
+// UpdateTypeRequestBodyColor Sets the display color of this type in the dashboard
+type UpdateTypeRequestBodyColor string
+
+// UpdateTypeRequestBodyIcon Sets the display icon of this type in the dashboard
+type UpdateTypeRequestBodyIcon string
 
 // UpdateTypeSchemaRequestBody defines model for UpdateTypeSchemaRequestBody.
 type UpdateTypeSchemaRequestBody struct {
@@ -1797,7 +1892,7 @@ type CatalogV2UpdateEntryJSONRequestBody = UpdateEntryRequestBody
 type CatalogV2CreateTypeJSONRequestBody = CreateTypeRequestBody
 
 // CatalogV2UpdateTypeJSONRequestBody defines body for CatalogV2UpdateType for application/json ContentType.
-type CatalogV2UpdateTypeJSONRequestBody = CreateTypeRequestBody
+type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
 
 // CatalogV2UpdateTypeSchemaJSONRequestBody defines body for CatalogV2UpdateTypeSchema for application/json ContentType.
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
@@ -2034,6 +2129,9 @@ type ClientInterface interface {
 	CatalogV2UpdateEntryWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CatalogV2UpdateEntry(ctx context.Context, id string, body CatalogV2UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV2ListResources request
+	CatalogV2ListResources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CatalogV2ListTypes request
 	CatalogV2ListTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2747,6 +2845,18 @@ func (c *Client) CatalogV2UpdateEntryWithBody(ctx context.Context, id string, co
 
 func (c *Client) CatalogV2UpdateEntry(ctx context.Context, id string, body CatalogV2UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCatalogV2UpdateEntryRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV2ListResources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV2ListResourcesRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -4695,6 +4805,33 @@ func NewCatalogV2UpdateEntryRequestWithBody(server string, id string, contentTyp
 	return req, nil
 }
 
+// NewCatalogV2ListResourcesRequest generates requests for CatalogV2ListResources
+func NewCatalogV2ListResourcesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/catalog_resources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewCatalogV2ListTypesRequest generates requests for CatalogV2ListTypes
 func NewCatalogV2ListTypesRequest(server string) (*http.Request, error) {
 	var err error
@@ -5524,6 +5661,9 @@ type ClientWithResponsesInterface interface {
 	CatalogV2UpdateEntryWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV2UpdateEntryResponse, error)
 
 	CatalogV2UpdateEntryWithResponse(ctx context.Context, id string, body CatalogV2UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV2UpdateEntryResponse, error)
+
+	// CatalogV2ListResources request
+	CatalogV2ListResourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV2ListResourcesResponse, error)
 
 	// CatalogV2ListTypes request
 	CatalogV2ListTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV2ListTypesResponse, error)
@@ -6492,6 +6632,28 @@ func (r CatalogV2UpdateEntryResponse) StatusCode() int {
 	return 0
 }
 
+type CatalogV2ListResourcesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResourcesResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV2ListResourcesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV2ListResourcesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type CatalogV2ListTypesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -7265,6 +7427,15 @@ func (c *ClientWithResponses) CatalogV2UpdateEntryWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseCatalogV2UpdateEntryResponse(rsp)
+}
+
+// CatalogV2ListResourcesWithResponse request returning *CatalogV2ListResourcesResponse
+func (c *ClientWithResponses) CatalogV2ListResourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV2ListResourcesResponse, error) {
+	rsp, err := c.CatalogV2ListResources(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV2ListResourcesResponse(rsp)
 }
 
 // CatalogV2ListTypesWithResponse request returning *CatalogV2ListTypesResponse
@@ -8436,6 +8607,32 @@ func ParseCatalogV2UpdateEntryResponse(rsp *http.Response) (*CatalogV2UpdateEntr
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ShowEntryResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV2ListResourcesResponse parses an HTTP response from a CatalogV2ListResourcesWithResponse call
+func ParseCatalogV2ListResourcesResponse(rsp *http.Response) (*CatalogV2ListResourcesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV2ListResourcesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResourcesResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/client/openapi3.json
+++ b/client/openapi3.json
@@ -2282,13 +2282,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   },
                   "pagination_meta": {
@@ -2523,13 +2523,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2665,15 +2665,48 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/catalog_resources": {
+      "get": {
+        "tags": [
+          "Catalog V2"
+        ],
+        "summary": "ListResources Catalog V2",
+        "description": "List available engine resources for the catalog",
+        "operationId": "Catalog V2#ListResources",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResourcesResponseBody"
+                },
+                "example": {
+                  "resources": [
+                    {
+                      "category": "custom",
+                      "description": "Boolean true or false value",
+                      "label": "GitHub Repository",
+                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                      "value_docstring": "Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website"
+                    }
+                  ]
                 }
               }
             }
@@ -2722,13 +2755,13 @@
                             "array": false,
                             "id": "01GW2G3V0S59R238FAHPDS1R66",
                             "name": "tier",
-                            "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                            "type": "Custom[\"Service\"]"
                           }
                         ],
                         "version": 1
                       },
                       "semantic_type": "custom",
-                      "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                      "type_name": "Custom[\"BackstageGroup\"]",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
                   ]
@@ -2762,7 +2795,7 @@
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "semantic_type": "custom",
-                "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]"
+                "type_name": "Custom[\"BackstageGroup\"]"
               }
             }
           }
@@ -2799,13 +2832,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2896,13 +2929,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2937,7 +2970,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateTypeRequestBody"
+                "$ref": "#/components/schemas/UpdateTypeRequestBody"
               },
               "example": {
                 "annotations": {
@@ -2948,8 +2981,7 @@
                 "icon": "bolt",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
-                "semantic_type": "custom",
-                "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]"
+                "semantic_type": "custom"
               }
             }
           }
@@ -2986,13 +3018,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -3037,7 +3069,7 @@
                     "array": false,
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
                     "name": "tier",
-                    "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                    "type": "Custom[\"Service\"]"
                   }
                 ],
                 "version": 1
@@ -3077,13 +3109,13 @@
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                          "type": "Custom[\"Service\"]"
                         }
                       ],
                       "version": 1
                     },
                     "semantic_type": "custom",
-                    "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                    "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -5343,6 +5375,56 @@
           "updated_at"
         ]
       },
+      "CatalogResourceV2": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Which category of resource",
+            "example": "custom",
+            "enum": [
+              "primitive",
+              "custom",
+              "external"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readable description for this resource",
+            "example": "Boolean true or false value"
+          },
+          "label": {
+            "type": "string",
+            "description": "Label for this catalog resource type",
+            "example": "GitHub Repository"
+          },
+          "type": {
+            "type": "string",
+            "description": "Catalog type name for this resource",
+            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+          },
+          "value_docstring": {
+            "type": "string",
+            "description": "Documentation for the literal string value of this resource",
+            "example": "Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website"
+          }
+        },
+        "example": {
+          "category": "custom",
+          "description": "Boolean true or false value",
+          "label": "GitHub Repository",
+          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+          "value_docstring": "Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website"
+        },
+        "required": [
+          "type",
+          "label",
+          "description",
+          "value_docstring",
+          "category",
+          "config"
+        ]
+      },
       "CatalogTypeAttributePayloadV2": {
         "type": "object",
         "properties": {
@@ -5364,14 +5446,14 @@
           "type": {
             "type": "string",
             "description": "Catalog type name for this attribute",
-            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+            "example": "Custom[\"Service\"]"
           }
         },
         "example": {
           "array": false,
           "id": "01GW2G3V0S59R238FAHPDS1R66",
           "name": "tier",
-          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+          "type": "Custom[\"Service\"]"
         },
         "required": [
           "name",
@@ -5400,14 +5482,14 @@
           "type": {
             "type": "string",
             "description": "Catalog type name for this attribute",
-            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+            "example": "Custom[\"Service\"]"
           }
         },
         "example": {
           "array": false,
           "id": "01GW2G3V0S59R238FAHPDS1R66",
           "name": "tier",
-          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+          "type": "Custom[\"Service\"]"
         },
         "required": [
           "id",
@@ -5430,7 +5512,7 @@
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                "type": "Custom[\"Service\"]"
               }
             ]
           },
@@ -5447,7 +5529,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+              "type": "Custom[\"Service\"]"
             }
           ],
           "version": 1
@@ -5570,8 +5652,8 @@
           },
           "type_name": {
             "type": "string",
-            "description": "The type name of this catalog type, to be used when defining attributes",
-            "example": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]"
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
+            "example": "Custom[\"BackstageGroup\"]"
           },
           "updated_at": {
             "type": "string",
@@ -5603,13 +5685,13 @@
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                "type": "Custom[\"Service\"]"
               }
             ],
             "version": 1
           },
           "semantic_type": "custom",
-          "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+          "type_name": "Custom[\"BackstageGroup\"]",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
@@ -5952,8 +6034,7 @@
           "instructions": {
             "type": "string",
             "description": "Provided to whoever is nominated for the role",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "minLength": 1
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
           },
           "name": {
             "type": "string",
@@ -6484,8 +6565,8 @@
           },
           "type_name": {
             "type": "string",
-            "description": "The type name of this catalog type, to be used when defining attributes",
-            "example": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]"
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
+            "example": "Custom[\"BackstageGroup\"]"
           }
         },
         "example": {
@@ -6498,7 +6579,7 @@
           "name": "Kubernetes Cluster",
           "ranked": true,
           "semantic_type": "custom",
-          "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]"
+          "type_name": "Custom[\"BackstageGroup\"]"
         },
         "required": [
           "name",
@@ -6536,13 +6617,13 @@
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                  "type": "Custom[\"Service\"]"
                 }
               ],
               "version": 1
             },
             "semantic_type": "custom",
-            "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+            "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
@@ -7181,7 +7262,9 @@
                 "incident_creator",
                 "incident_editor",
                 "manage_settings",
-                "global_access"
+                "global_access",
+                "catalog_viewer",
+                "catalog_editor"
               ]
             },
             "description": "Which roles have been enabled for this key",
@@ -7424,8 +7507,7 @@
           "instructions": {
             "type": "string",
             "description": "Provided to whoever is nominated for the role",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "minLength": 1
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
           },
           "name": {
             "type": "string",
@@ -8623,13 +8705,13 @@
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                  "type": "Custom[\"Service\"]"
                 }
               ],
               "version": 1
             },
             "semantic_type": "custom",
-            "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+            "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
           "pagination_meta": {
@@ -8641,6 +8723,40 @@
           "catalog_type",
           "catalog_entries",
           "pagination_meta"
+        ]
+      },
+      "ListResourcesResponseBody": {
+        "type": "object",
+        "properties": {
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogResourceV2"
+            },
+            "example": [
+              {
+                "category": "custom",
+                "description": "Boolean true or false value",
+                "label": "GitHub Repository",
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                "value_docstring": "Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website"
+              }
+            ]
+          }
+        },
+        "example": {
+          "resources": [
+            {
+              "category": "custom",
+              "description": "Boolean true or false value",
+              "label": "GitHub Repository",
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+              "value_docstring": "Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website"
+            }
+          ]
+        },
+        "required": [
+          "resources"
         ]
       },
       "ListResponseBody": {
@@ -9680,13 +9796,13 @@
                       "array": false,
                       "id": "01GW2G3V0S59R238FAHPDS1R66",
                       "name": "tier",
-                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                      "type": "Custom[\"Service\"]"
                     }
                   ],
                   "version": 1
                 },
                 "semantic_type": "custom",
-                "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+                "type_name": "Custom[\"BackstageGroup\"]",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
             ]
@@ -9717,13 +9833,13 @@
                     "array": false,
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
                     "name": "tier",
-                    "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                    "type": "Custom[\"Service\"]"
                   }
                 ],
                 "version": 1
               },
               "semantic_type": "custom",
-              "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+              "type_name": "Custom[\"BackstageGroup\"]",
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
           ]
@@ -9737,7 +9853,7 @@
         "properties": {
           "after": {
             "type": "string",
-            "description": "If provided, were records after a particular ID",
+            "description": "If provided, pass this as the 'after' param to load the next page",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "page_size": {
@@ -9761,7 +9877,7 @@
         "properties": {
           "after": {
             "type": "string",
-            "description": "If provided, were records after a particular ID",
+            "description": "If provided, pass this as the 'after' param to load the next page",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "page_size": {
@@ -10647,13 +10763,13 @@
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                  "type": "Custom[\"Service\"]"
                 }
               ],
               "version": 1
             },
             "semantic_type": "custom",
-            "type_name": "CatalogEntry[\"01FCNDV6P870EA6S7TK1DSYDG2\"]",
+            "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
@@ -11299,8 +11415,7 @@
           "instructions": {
             "type": "string",
             "description": "Provided to whoever is nominated for the role",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "minLength": 1
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
           },
           "name": {
             "type": "string",
@@ -11366,6 +11481,93 @@
           "updated_at"
         ]
       },
+      "UpdateTypeRequestBody": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "color": {
+            "type": "string",
+            "description": "Sets the display color of this type in the dashboard",
+            "example": "slate",
+            "enum": [
+              "slate",
+              "red",
+              "yellow",
+              "green",
+              "blue",
+              "violet"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE."
+          },
+          "icon": {
+            "type": "string",
+            "description": "Sets the display icon of this type in the dashboard",
+            "example": "bolt",
+            "enum": [
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "clock",
+              "cog",
+              "database",
+              "doc",
+              "email",
+              "server",
+              "severity",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster"
+          },
+          "ranked": {
+            "type": "boolean",
+            "description": "If this type should be ranked",
+            "example": true
+          },
+          "semantic_type": {
+            "type": "string",
+            "description": "Semantic type of this resource",
+            "example": "custom"
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "color": "slate",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "bolt",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "semantic_type": "custom"
+        },
+        "required": [
+          "name",
+          "description"
+        ]
+      },
       "UpdateTypeSchemaRequestBody": {
         "type": "object",
         "properties": {
@@ -11379,7 +11581,7 @@
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+                "type": "Custom[\"Service\"]"
               }
             ]
           },
@@ -11395,7 +11597,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
+              "type": "Custom[\"Service\"]"
             }
           ],
           "version": 1

--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -33,6 +33,10 @@ var (
 	initCmd     = app.Command("init", "Initialises a new config from a template")
 	initOptions = new(InitOptions).Bind(initCmd)
 
+	// Types
+	typesCmd     = app.Command("types", "Shows all the types that can be used for this account")
+	typesOptions = new(TypesOptions).Bind(typesCmd)
+
 	// Sync
 	sync        = app.Command("sync", "Sync data from catalog sources into incident.io")
 	syncOptions = new(SyncOptions).Bind(sync)
@@ -80,6 +84,8 @@ func Run(ctx context.Context) (err error) {
 	switch command {
 	case initCmd.FullCommand():
 		return initOptions.Run(ctx, logger)
+	case typesCmd.FullCommand():
+		return typesOptions.Run(ctx, logger)
 	case sync.FullCommand():
 		return syncOptions.Run(ctx, logger)
 	case sourceCmd.FullCommand():

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -263,7 +263,6 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 				result, err := cl.CatalogV2UpdateTypeWithResponse(ctx, catalogType.Id, client.CatalogV2UpdateTypeJSONRequestBody{
 					Name:        model.Name,
 					Description: model.Description,
-					TypeName:    lo.ToPtr(model.TypeName),
 					Annotations: lo.ToPtr(getAnnotations(cfg.SyncID)),
 				})
 				if err != nil {

--- a/cmd/catalog-importer/cmd/types.go
+++ b/cmd/catalog-importer/cmd/types.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/fatih/color"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/incident-io/catalog-importer/client"
+	"github.com/pkg/errors"
+	"github.com/rodaine/table"
+)
+
+type TypesOptions struct {
+	APIEndpoint string
+	APIKey      string
+}
+
+func (opt *TypesOptions) Bind(cmd *kingpin.CmdClause) *TypesOptions {
+	cmd.Flag("api-endpoint", "Endpoint of the incident.io API").
+		Default("https://api.incident.io").
+		Envar("INCIDENT_ENDPOINT").
+		StringVar(&opt.APIEndpoint)
+	cmd.Flag("api-key", "API key for incident.io").
+		Envar("INCIDENT_API_KEY").
+		StringVar(&opt.APIKey)
+
+	return opt
+}
+
+func (opt *TypesOptions) Run(ctx context.Context, logger kitlog.Logger) error {
+	if opt.APIKey == "" {
+		return fmt.Errorf("no API key provided as --api-key or in INCIDENT_API_KEY")
+	}
+
+	// Build incident.io client
+	cl, err := client.New(ctx, opt.APIKey, opt.APIEndpoint, Version())
+	if err != nil {
+		return err
+	}
+
+	resp, err := cl.CatalogV2ListResourcesWithResponse(ctx)
+	if err != nil {
+		return errors.Wrap(err, "finding catalog resources")
+	}
+
+	headerFmt := color.New(color.Bold).SprintfFunc()
+	columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+	tbl := table.New("Name", "Type name", "Category", "Description", "Value")
+	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+	ranks := map[client.CatalogResourceV2Category]int{
+		client.CatalogResourceV2CategoryPrimitive: 1,
+		client.CatalogResourceV2CategoryCustom:    2,
+		client.CatalogResourceV2CategoryExternal:  3,
+	}
+
+	resources := resp.JSON200.Resources
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Category == resources[j].Category {
+			return resources[i].Type < resources[j].Type
+		}
+
+		return ranks[resources[i].Category] < ranks[resources[j].Category]
+	})
+
+	for _, resource := range resources {
+		tbl.AddRow(
+			resource.Label, resource.Type, resource.Category, resource.Description, resource.ValueDocstring,
+		)
+	}
+
+	tbl.Print()
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rodaine/table v1.1.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
@@ -129,6 +130,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rodaine/table v1.1.0 h1:/fUlCSdjamMY8VifdQRIu3VWZXYLY7QHFkVorS8NTr4=
+github.com/rodaine/table v1.1.0/go.mod h1:Qu3q5wi1jTQD6B6HsP6szie/S4w1QUQ8pq22pz9iL8g=
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=


### PR DESCRIPTION
To list all the types that are available, their type names (for use when specifying this as an attribute type_name) and how to construct a value string.

It outputs something like this:

```
Name                              Type name                         Category   Description                                                               Value
Bool                              Bool                              primitive  Boolean true or false value.                                              Bool in text form, e.g. true or false.
Number                            Number                            primitive  Floating point number                                                     Number in text form, e.g. 123 or 123.567
String                            String                            primitive  Simple text without formatting                                            The text itself, e.g. "some message without formatting"
Text                              Text                              primitive  Rich text supporting formatting like italic, bold and otherwise           JSON encoded templated text structure, e.g. {"content":[{"type":"paragraph"}],"type":"doc"}, ...}
PagerDuty Escalation Policy       PagerDutyEscalationPolicy         external   PagerDuty escalation policies synced from connected PagerDuty account.    The ID of the escalation policy in PagerDuty, e.g. PLTCZGJ.
PagerDuty Service                 PagerDutyService                  external   PagerDuty services synced from connected PagerDuty account.               The ID of the service in PagerDuty, e.g. PKQX0N5.
Sentry Team                       SentryTeam                        external   Sentry teams synced from connected Sentry organisations.                  Either the Sentry team ID or the team slug, e.g. payments.
Slack User Group                  SlackUserGroup                    external   Slack user groups synced from connected Slack workspaces.                 Either the Slack user group ID or the group handle, e.g. admins.
GitHub Repository                 GitHubRepository                  external   GitHub repositories synced from connected GitHub organisations.           Either the GraphQL node ID of the repository or a string of <owner>/<repo>, e.g. incident-io/website.
Splunk On-Call Team               SplunkOnCallTeam                  external   Splunk On-Call teams synced from connected Splunk account.                The slug of the team in Splunk, e.g. banking-team.
Jira Cloud Project                JiraCloudProject                  external   Jira projects synced from connected Jira Cloud account.                   Either the Jira project ID or the project key, e.g. TEST.
Linear Project                    LinearProject                     external   Linear projects synced from connected Linear account.                     Either the Linear project ID or the project slug, e.g. df43db41dd10.
PagerDuty Team                    PagerDutyTeam                     external   PagerDuty teams synced from connected PagerDuty account.                  The ID of the team in PagerDuty, e.g. PKQX0N5.
Sentry Project                    SentryProject                     external   Sentry projects synced from connected Sentry organisations.               Either the Sentry project ID or the project slug, e.g. website.
Jira Cloud Issue Type             JiraCloudIssueType                external   Jira issue types synced from connected Jira Cloud account.                Either the Jira team ID or the project key, e.g. df43db41dd10.
Jira Cloud Project Category       JiraCloudProjectCategory          external   Jira project categories synced from connected Jira Cloud account.         Either the Jira team ID or the project key, e.g. df43db41dd10.
Linear Team                       LinearTeam                        external   Linear teams synced from connected Linear account.                        Either the Linear team ID or the team key, e.g. PM.
Slack User                        SlackUser                         external   Slack users synced from connected Slack workspaces.                       Either the Slack user ID or the users email, e.g. lawrence@example.com.
Splunk On-Call Escalation Policy  SplunkOnCallEscalationPolicy      external   Splunk On-Call escalation policies synced from connected Splunk account.  The ID of the escalation policy in Splunk, e.g. pol-LQjZHlexiT4e6aeb.
Team                              Custom["Team"]                    custom     Product Development teams.                                                Either the ID of the catalog entry or its alias (if set).
Feature                           Custom["Feature"]                 custom     Product features that would be recognisable to customers.                 Either the ID of the catalog entry or its alias (if set).
Backstage API Type                Custom["BackstageAPIType"]        custom     Type or format of the API.                                                Either the ID of the catalog entry or its alias (if set).
Business Criticality              Custom["BusinessCriticality"]     custom     How critical components are to business operations.                       Either the ID of the catalog entry or its alias (if set).
Backstage Component Type          Custom["BackstageComponentType"]  custom     Type of a component.                                                      Either the ID of the catalog entry or its alias (if set).
Backstage API                     Custom["BackstageAPI"]            custom     APIs synced from Backstage.                                               Either the ID of the catalog entry or its alias (if set).
Backstage Tag                     Custom["BackstageTag"]            custom     Component tags for searching.                                             Either the ID of the catalog entry or its alias (if set).
Backstage Component               Custom["BackstageComponent"]      custom     Components synced from Backstage.                                         Either the ID of the catalog entry or its alias (if set).
Backstage Domain                  Custom["BackstageDomain"]         custom     Groups of systems that share terminology or purpose.                      Either the ID of the catalog entry or its alias (if set).
Backstage Group Type              Custom["BackstageGroupType"]      custom     Type of Backstage groups.                                                 Either the ID of the catalog entry or its alias (if set).
Backstage Group                   Custom["BackstageGroup"]          custom     Groups syned from Backstage.                                              Either the ID of the catalog entry or its alias (if set).
Backstage User                    Custom["BackstageUser"]           custom     Users syned from Backstage.                                               Either the ID of the catalog entry or its alias (if set).
Backstage System                  Custom["BackstageSystem"]         custom     Collections of resources.                                                 Either the ID of the catalog entry or its alias (if set).
Backstage Lifecycle               Custom["BackstageLifecycle"]      custom     Component lifecycle stage.                                                Either the ID of the catalog entry or its alias (if set).
```