### PR TITLE
Alias support and Backstage is namespace aware

### DIFF
--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -10,7 +10,7 @@
     {
       'local': {
         files: [
-          'catalog-info.json',
+          'catalog-info.yaml',
         ],
       },
     },
@@ -53,7 +53,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "API"',
         name: 'metadata.name',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         {
@@ -104,7 +107,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "Component"',
         name: 'metadata.name',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         {
@@ -182,7 +188,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "Domain"',
         name: 'metadata.name',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         {
@@ -209,7 +218,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "Group"',
         name: 'metadata.name',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         {
@@ -240,7 +252,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "User"',
         name: 'spec.profile.displayName',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         {
@@ -268,7 +283,10 @@
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "System"',
         name: 'metadata.name',
-        external_id: 'metadata.name',
+        external_id: 'metadata.namespace + "/" + metadata.name',
+        aliases: [
+          'metadata.name',
+        ],
       },
       attributes: [
         // Default fields

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2
 	github.com/bmatcuk/doublestar/v4 v4.6.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/fatih/color v1.12.0
 	github.com/ghodss/yaml v1.0.0
@@ -22,6 +23,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
+	github.com/rodaine/table v1.1.0
 	github.com/samber/lo v1.38.1
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/yargevad/filepathx v1.0.0
@@ -60,7 +62,6 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rodaine/table v1.1.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect


### PR DESCRIPTION
Our support for aliases was a bit borked, so this commit fixes it by accepting either a string or an []string from any of the alias CEL expressions and combining them together.

Then we change Backstage so:
- The external ID is namespace/name, supporting people who have many resources with the same name
- Use the name as an alias to ensure we continue to match for those without duplicates

The effect is that Backstage users can get all the benefits of namespace'ing but only if they want it, while others who use a single namespace shouldn't notice the difference.