### PR TITLE
Add some documentation on local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ Once installed, see [documentation](docs) for example catalogs and CI config.
 ## Contributing
 
 We're happy to accept open-source contributions or feedback. Just open a
-PR/issue and we'll get back to you.
+PR/issue and we'll get back to you. This repo contains details on
+[how to get started with local development](./development.md).

--- a/development.md
+++ b/development.md
@@ -9,9 +9,9 @@ go test ./...
 ```
 
 To build the binary, run `make`: this will place a built version of the tool in
-the `bin` directory. If you have a local instance of incident.io running, then
-you can point it to your local environment using the `--api-key` flag, or an
-environment variable:
+the `bin` directory. If you work for incident.io and have a local instance of 
+the app running, then you can point it to your local environment using the
+`--api-key` flag, or an environment variable:
 
 ```
 export INCIDENT_ENDPOINT="http://localhost:3001/api/public"

--- a/development.md
+++ b/development.md
@@ -1,0 +1,20 @@
+# Development
+
+You'll need [Go installed][go] to be able to contribute to `catalog-importer`.
+
+You can run all of the tests using `go test`:
+
+```
+go test ./...
+```
+
+To build the binary, run `make`: this will place a built version of the tool in
+the `bin` directory. If you have a local instance of incident.io running, then
+you can point it to your local environment using the `--api-key` flag, or an
+environment variable:
+
+```
+export INCIDENT_ENDPOINT="http://localhost:3001/api/public"
+```
+
+[go]: https://go.dev/doc/install


### PR DESCRIPTION
It's not immediately obvious how to build the tool and point it at your local environment: this PR adds a bit of documentation to fix that.