### PR TITLE
Support ranks in the catalog importer

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -194,6 +194,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 				result, err := cl.CatalogV2CreateTypeWithResponse(ctx, client.CreateTypeRequestBody{
 					Name:        model.Name,
 					Description: model.Description,
+					Ranked:      &model.Ranked,
 					TypeName:    lo.ToPtr(model.TypeName),
 					Annotations: lo.ToPtr(getAnnotations(cfg.SyncID)),
 				})
@@ -263,6 +264,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 				result, err := cl.CatalogV2UpdateTypeWithResponse(ctx, catalogType.Id, client.CatalogV2UpdateTypeJSONRequestBody{
 					Name:        model.Name,
 					Description: model.Description,
+					Ranked:      &model.Ranked,
 					Annotations: lo.ToPtr(getAnnotations(cfg.SyncID)),
 				})
 				if err != nil {

--- a/output/output.go
+++ b/output/output.go
@@ -14,6 +14,7 @@ type Output struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
 	TypeName    string       `json:"type_name"`
+	Ranked      bool         `json:"ranked"`
 	Source      SourceConfig `json:"source"`
 	Attributes  []*Attribute `json:"attributes"`
 }
@@ -35,6 +36,7 @@ type SourceConfig struct {
 	Filter     null.String `json:"filter"`
 	Name       string      `json:"name"`
 	ExternalID string      `json:"external_id"`
+	Rank       null.String `json:"rank"`
 	Aliases    []string    `json:"aliases"`
 }
 


### PR DESCRIPTION
You can now use the catalog importer to define a ranked type, and specify ranks against your entries.