### PR TITLE
Publish container image to Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
           git tag "${CURRENT_VERSION}"
           git push --tags
       -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_PUBLISHER_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PUBLISHER_KEY }}
+      -
         name: Run GoReleaser
         continue-on-error: true
         uses: goreleaser/goreleaser-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:20230329 AS runtime
+
+# goreleaser supplies this for us
+COPY catalog-importer /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/catalog-importer"]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -33,3 +33,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://incident.io/
     description: Official incident.io catalog importer, for syncing catalog entries.
+
+dockers:
+  - image_templates:
+    - incidentio/{{.ProjectName}}


### PR DESCRIPTION
To make usage of this easier, in a containerised environment, build a container image and publish that to a publicly-available repo on Docker Hub.