### PR TITLE
Show catalog type name on creation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 data/
 /config.jsonnet
 __debug_bin
+.idea/

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -7,17 +7,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/kingpin/v2"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/catalog-importer/client"
 	"github.com/incident-io/catalog-importer/output"
 	"github.com/incident-io/catalog-importer/reconcile"
 	"github.com/incident-io/catalog-importer/source"
-	"github.com/pkg/errors"
-	"github.com/samber/lo"
-	"github.com/schollz/progressbar/v3"
 )
 
 type SyncOptions struct {
@@ -199,7 +198,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 					Annotations: lo.ToPtr(getAnnotations(cfg.SyncID)),
 				})
 				if err != nil {
-					return errors.Wrap(err, "creating catalog type")
+					return errors.Wrap(err, fmt.Sprintf("creating catalog type with name %s", model.TypeName))
 				}
 
 				createdCatalogType = result.JSON201.CatalogType
@@ -268,7 +267,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 					Annotations: lo.ToPtr(getAnnotations(cfg.SyncID)),
 				})
 				if err != nil {
-					return errors.Wrap(err, "updating catalog type")
+					return errors.Wrap(err, fmt.Sprintf("updating catalog type with name %s", model.TypeName))
 				}
 
 				version := result.JSON200.CatalogType.Schema.Version

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin/v2"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"github.com/schollz/progressbar/v3"
 
 	"github.com/incident-io/catalog-importer/client"
 	"github.com/incident-io/catalog-importer/output"


### PR DESCRIPTION
The catalog-importer should show the catalog type name if it attempts to create a catalog type that already exists, to be more useful. The catalog-importer does check for existing catalog types before attempting to create new ones from an importer config, but that list of existing catalog types ignores any catalog types that are not managed by an importer or managed by a different importer, so this might explain why that could have happened.

https://linear.app/incident-io/issue/RESP-135/improve-importer-error-handling