### PR TITLE
catalog-importer backstage

### DIFF
--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -52,6 +52,10 @@ var (
 	// Validate
 	validate        = app.Command("validate", "Validate configuration")
 	validateOptions = new(ValidateOptions).Bind(validate)
+
+	// Backstage
+	backstageCmd     = app.Command("backstage", "Syncs catalog entries directly from Backstage API into incident.io")
+	backstageOptions = new(BackstageOptions).Bind(backstageCmd)
 )
 
 func Run(ctx context.Context) (err error) {
@@ -87,13 +91,15 @@ func Run(ctx context.Context) (err error) {
 	case typesCmd.FullCommand():
 		return typesOptions.Run(ctx, logger)
 	case sync.FullCommand():
-		return syncOptions.Run(ctx, logger)
+		return syncOptions.Run(ctx, logger, nil)
 	case sourceCmd.FullCommand():
 		return sourceOptions.Run(ctx, logger)
 	case jsonnetCmd.FullCommand():
 		return jsonnetOptions.Run(ctx, logger)
 	case validate.FullCommand():
 		return validateOptions.Run(ctx, logger)
+	case backstageCmd.FullCommand():
+		return backstageOptions.Run(ctx, logger)
 	default:
 		return fmt.Errorf("unrecognised command: %s", command)
 	}

--- a/cmd/catalog-importer/cmd/backstage.go
+++ b/cmd/catalog-importer/cmd/backstage.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/alecthomas/kingpin/v2"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/incident-io/catalog-importer/config"
+	"github.com/incident-io/catalog-importer/docs"
+	"github.com/incident-io/catalog-importer/source"
+	"github.com/pkg/errors"
+)
+
+type BackstageOptions struct {
+	APIEndpoint       string
+	APIKey            string
+	BackstageEndpoint string
+}
+
+func (opt *BackstageOptions) Bind(cmd *kingpin.CmdClause) *BackstageOptions {
+	cmd.Flag("api-endpoint", "Endpoint of the incident.io API").
+		Default("https://api.incident.io").
+		Envar("INCIDENT_ENDPOINT").
+		StringVar(&opt.APIEndpoint)
+	cmd.Flag("api-key", "API key for incident.io").
+		Envar("INCIDENT_API_KEY").
+		StringVar(&opt.APIKey)
+	cmd.Flag("backstage-endpoint", "Endpoint of the Backstage entries API").
+		Default("http://localhost:7007/api/catalog/entities").
+		Envar("BACKSTAGE_ENDPOINT").
+		StringVar(&opt.BackstageEndpoint)
+
+	return opt
+}
+
+func (opt *BackstageOptions) Run(ctx context.Context, logger kitlog.Logger) error {
+	data, err := docs.EvaluateJsonnet("backstage", "importer.jsonnet")
+	if err != nil {
+		return err
+	}
+
+	var cfg config.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return errors.Wrap(err, "parsing Backstage config")
+	}
+
+	// Find the local file pipeline and change the source to point at Backstage.
+	for _, pipeline := range cfg.Pipelines {
+		if len(pipeline.Sources) > 0 && pipeline.Sources[0].Local != nil {
+			pipeline.Sources = []*source.Source{
+				{
+					Backstage: &source.SourceBackstage{
+						Endpoint: opt.BackstageEndpoint,
+					},
+				},
+			}
+		}
+	}
+
+	syncOpt := *syncOptions
+	syncOpt.APIEndpoint = opt.APIEndpoint
+	syncOpt.APIKey = opt.APIKey
+	syncOpt.AllowDeleteAll = true
+
+	if err := syncOpt.Run(ctx, logger, &cfg); err != nil {
+		return errors.Wrap(err, "running sync")
+	}
+
+	return nil
+}

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 
 	"github.com/incident-io/catalog-importer/client"
+	"github.com/incident-io/catalog-importer/config"
 	"github.com/incident-io/catalog-importer/output"
 	"github.com/incident-io/catalog-importer/reconcile"
 	"github.com/incident-io/catalog-importer/source"
@@ -58,7 +59,7 @@ func (opt *SyncOptions) Bind(cmd *kingpin.CmdClause) *SyncOptions {
 	return opt
 }
 
-func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
+func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *config.Config) error {
 	if opt.Prune && opt.DryRun {
 		return errors.New("cannot use --dry-run with --prune")
 	}
@@ -66,10 +67,13 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 		return errors.New("cannot use --targets with --prune")
 	}
 
-	// Load config
-	cfg, err := loadConfigOrError(ctx, opt.ConfigFile)
-	if err != nil {
-		return err
+	// Load config if it hasn't been provided.
+	if cfg == nil {
+		var err error
+		cfg, err = loadConfigOrError(ctx, opt.ConfigFile)
+		if err != nil {
+			return err
+		}
 	}
 	{
 		if len(opt.Targets) > 0 {

--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -251,7 +251,7 @@
       type_name: 'Custom["BackstageUser"]',
       source: {
         filter: 'apiVersion == "backstage.io/v1alpha1" && kind == "User"',
-        name: 'spec.profile.displayName',
+        name: 'metadata.name',
         external_id: 'metadata.namespace + "/" + metadata.name',
         aliases: [
           'metadata.name',


### PR DESCRIPTION
Run a sync from a Backstage API without requiring a config file, for use with the Backstage plugin.