### PR TITLE
Fix bug with equality that meant diff failed

### DIFF
--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -211,7 +211,7 @@ func Entries(ctx context.Context, logger kitlog.Logger, cl EntriesClient, catalo
 			if entry != nil {
 				isSame :=
 					entry.Name == model.Name &&
-						reflect.DeepEqual(entry.Aliases, model.Aliases) && entry.Rank != model.Rank
+						reflect.DeepEqual(entry.Aliases, model.Aliases) && entry.Rank == model.Rank
 
 				currentBindings := map[string]client.CatalogAttributeBindingPayloadV2{}
 				for attributeID, value := range entry.AttributeValues {


### PR DESCRIPTION
We were always updating everything because we had an incorrect equality check. Things are the same if ranks are equal, and different if they are not.