### PR TITLE
Reject unknown keys from importer config

### DIFF
--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parse", func() {
+	It("parses valid config", func() {
+		cfg, err := parse([]byte(`
+{
+	"sync_id": "something",
+	"pipelines": [
+		{
+			"sources": [
+				{
+					"inline": {
+						"entries": [{
+							"external_id": "entry-external-id",
+							"name": "entry-name",
+							"description": "entry-description",
+						}]
+					}
+				}
+			],
+			"outputs": []
+		}
+	]
+}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Pipelines).To(HaveLen(1))
+		Expect(cfg.Pipelines[0].Sources).To(HaveLen(1))
+	})
+
+	It("parses valid config", func() {
+		_, err := parse([]byte(`
+{
+	"sync_id": "something",
+	"pipelines": [
+		{
+			"invalid_key": [
+				{
+					"inline": {
+						"entries": [{
+							"external_id": "entry-external-id",
+							"name": "entry-name",
+							"description": "entry-description",
+						}]
+					}
+				}
+			]
+		}
+	]
+}`))
+		Expect(err).To(MatchError(ContainSubstring("unknown field \"invalid_key\"")))
+	})
+})

--- a/config/suite_test.go
+++ b/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "config")
+}


### PR DESCRIPTION
This tripped up a customer where they typo'd `outputs` as `output` and wondered why their config did nothing.

I don't love the output when we fail to load the config file right now (it can be improved a lot!) but this commit makes sure we fail with an error like so:

```
main: error: loading config: parsing config: json: unknown field "invalid_key"
```

In the situation where we don't recognise keys in the config.