### PR TITLE
Add incident.io User source to template

### DIFF
--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -271,7 +271,7 @@
           source: 'spec.memberOf',
           array: true,
         },
-        // Include the below to connect your users within Backstage to users within Incident.io
+        // Include the below to connect your users within Backstage to users within incident.io
         {
           id: 'user',
           name: 'incident.io User',

--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -265,12 +265,6 @@
       },
       attributes: [
         {
-          id: 'email',
-          name: 'Email',
-          type: 'String',
-          source: 'spec.profile.email',
-        },
-        {
           id: 'groups',
           name: 'Groups',
           type: 'Custom["BackstageGroup"]',

--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -277,6 +277,13 @@
           source: 'spec.memberOf',
           array: true,
         },
+        // Include the below to connect your users within Backstage to users within Incident.io
+        {
+          id: 'user',
+          name: 'incident.io User',
+          type: 'User',
+          source: 'spec.profile.email',
+        },
       ],
     },
 

--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -264,19 +264,19 @@
         ],
       },
       attributes: [
+        // Include this attribute to connect your users within Backstage to users within incident.io
+        {
+          id: 'user',
+          name: 'incident.io User',
+          type: 'User',
+          source: 'spec.profile.email',
+        },
         {
           id: 'groups',
           name: 'Groups',
           type: 'Custom["BackstageGroup"]',
           source: 'spec.memberOf',
           array: true,
-        },
-        // Include the below to connect your users within Backstage to users within incident.io
-        {
-          id: 'user',
-          name: 'incident.io User',
-          type: 'User',
-          source: 'spec.profile.email',
         },
       ],
     },


### PR DESCRIPTION
Simple change that adds the User type sourced from the email field. IMO this should replace the email field (users can always add it themselves, but it's objectively less useful than the User object)