### PR TITLE
Correctly handle error when prompting for template path

### DIFF
--- a/cmd/catalog-importer/cmd/init.go
+++ b/cmd/catalog-importer/cmd/init.go
@@ -62,7 +62,7 @@ func (opt *InitOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 			Default: ".",
 		}
 
-		chosenDest, _ = prompt.Run()
+		chosenDest, err = prompt.Run()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Saves us from a linting error, and handling errors is good.