### PR TITLE
Set up a launch config for debugging in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": [
                 "sync", 
                 "--config", 
-                "/tmp/config.jsonnet" // Point to an actual config file
+                "/tmp/config.jsonnet"
             ],
             "env": {
                 "INCIDENT_API_KEY": "inc_..."

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug catalog-importer sync",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/catalog-importer",
+            "args": [
+                "sync", 
+                "--config", 
+                "/tmp/config.jsonnet" // Point to an actual config file
+            ],
+            "env": {
+                "INCIDENT_API_KEY": "inc_..."
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This pull request makes it easier for people to debug `catalog-importer` from within VSCode. To be able to perform a sync successfully, the `INCIDENT_API_KEY` env config will need to be changed, and you'll need to point the config at a valid `config.jsonnet` file.