### PR TITLE
Only run release against master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       -
         id: tag
         name: Tag if new version
+        if: github.ref == 'refs/heads/master'
         run: |
           CURRENT_VERSION="v$(cat cmd/catalog-importer/cmd/VERSION)"
           if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
@@ -46,12 +47,14 @@ jobs:
           git push --tags
       -
         name: Login to Docker Hub
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_PUBLISHER_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PUBLISHER_KEY }}
       -
         name: Run GoReleaser
+        if: github.ref == 'refs/heads/master'
         continue-on-error: true
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
Without this configuration, we tag new versions and releases on branches, which is not the behaviour we want.