### PR TITLE
Fix module name so that v2 can be go install'd

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install catalog-importer
 Otherwise, ensure that the go runtime is installed and then:
 
 ```console
-go install github.com/incident-io/catalog-importer/cmd/catalog-importer/v2@latest
+go install github.com/incident-io/catalog-importer/cmd/catalog-importer@latest
 ```
 
 Once installed, see [documentation](docs) for example catalogs and CI config.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install catalog-importer
 Otherwise, ensure that the go runtime is installed and then:
 
 ```console
-go install github.com/incident-io/catalog-importer/cmd/catalog-importer@latest
+go install github.com/incident-io/catalog-importer/cmd/catalog-importer/v2@latest
 ```
 
 Once installed, see [documentation](docs) for example catalogs and CI config.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/incident-io/catalog-importer
+module github.com/incident-io/catalog-importer/v2
 
 go 1.20
 


### PR DESCRIPTION
Fixes the module name so that this succeeds:

```
go install github.com/incident-io/catalog-importer/cmd/catalog-importer@latest
```

Tmodule path must match the major version, but we neglected to do this when we released v2.