### PR TITLE
ES 6 expressions aren't supported

### DIFF
--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -109,7 +109,7 @@ the functions that we removed, along with their JavaScript equivalent:
 ```
 
 - Before: `coalesce(subject)`
-- After: `$.subject.filter(v => v)`
+- After: `$.subject.filter(function(v){return v})`
 
 Both would result in `["one", "two"]`.
 


### PR DESCRIPTION
Switch JS expression example from ES 6 arrow function expression to a regular function