### PR TITLE
Update goreleaser to publish tag of current major version

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -38,3 +38,4 @@ dockers:
   - image_templates:
     - incidentio/{{ .ProjectName }}:latest
     - incidentio/{{ .ProjectName }}:{{ .Tag }}
+    - incidentio/{{ .ProjectName }}:{{ .Major }}


### PR DESCRIPTION
Part of work to make it easier to manage github types externally. 

We want to be able to configure github workflows to pull the latest tag of a specific major version (i.e 2.X.X), rather than having to specify either latest (which might break if major version shift), or specific version (which would require users to update their configs if we made minor changes).