### PR TITLE
Add release instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ docker run \
 
 We're happy to accept open-source contributions or feedback. Just open a
 PR/issue and we'll get back to you. This repo contains details on
-[how to get started with local development](./development.md).
+[how to get started with local development](./development.md), and [how to publish a new release](./release.md).

--- a/release.md
+++ b/release.md
@@ -1,0 +1,6 @@
+# Releasing
+
+We have a workflow for building & releasing, which can be found in [.github/workflows](.github/workflows).
+This uses a tool called [goreleaser](https://goreleaser.com/), which handles most of the release process for us (creating git tag, publishing docker images, etc).
+
+To cut a new release, simply make a new PR with the version updated in [VERSION](cmd/catalog-importer/cmd/VERSION).


### PR DESCRIPTION
I had to ask Sam how to release (e.g, do i need to create github tag, etc).. so am adding instructions to readme for future new peeps (i think this is correct, I haven't actually cut a new release yet 😅 will update later if it's wrong) 