### PR TITLE
Add v to docker major tag

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -36,6 +36,6 @@ brews:
 
 dockers:
   - image_templates:
-    - incidentio/{{ .ProjectName }}:latest
-    - incidentio/{{ .ProjectName }}:{{ .Tag }}
-    - incidentio/{{ .ProjectName }}:{{ .Major }}
+      - incidentio/{{ .ProjectName }}:latest
+      - incidentio/{{ .ProjectName }}:{{ .Tag }}
+      - incidentio/{{ .ProjectName }}:v{{ .Major }}


### PR DESCRIPTION
Am silly and didn't notice the cheeky lil `v` in[ the docs](https://goreleaser.com/customization/docker/#keeping-docker-images-updated-for-current-major), adding it in so docker tags follow convention
<img width="568" alt="image" src="https://github.com/incident-io/catalog-importer/assets/20378963/456e64f3-080b-4809-b1b8-4f9b34dfbb15">
