### PR TITLE
Fix marshalling logic to correctly handle array of aliases

### DIFF
--- a/output/marshal.go
+++ b/output/marshal.go
@@ -139,7 +139,7 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 			if alias == "" {
 				aliasArray, arrayErr := expr.EvaluateArray[string](ctx, aliasSource, entry, logger)
 				if arrayErr != nil {
-					return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias array", idx))
+					return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias", idx))
 				}
 				toAdd = append(toAdd, aliasArray...)
 			} else {

--- a/output/marshal_test.go
+++ b/output/marshal_test.go
@@ -1,0 +1,71 @@
+package output
+
+import (
+	"context"
+	"os"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/incident-io/catalog-importer/v2/source"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Marshalling data", func() {
+	var (
+		ctx               context.Context
+		catalogTypeOutput *Output
+		entries           []source.Entry
+		logger            kitlog.Logger
+	)
+
+	ctx = context.Background()
+
+	sourceEntry1 := source.Entry{
+		"id":               "P123",
+		"name":             "Component name",
+		"important":        true,
+		"importance_score": 100,
+		"description":      "A super important component. A structurally integral component tbh.",
+		"metadata": map[string]any{
+			"namespace": "Infrastructure",
+			"aliases":   []string{"oneAlias", "anotherAlias"},
+		},
+	}
+	sourceEntry2 := source.Entry{
+		"id":               "P123",
+		"name":             "Component name",
+		"important":        true,
+		"importance_score": 100,
+		"description":      "A super important component. A structurally integral component tbh.",
+		"metadata": map[string]any{
+			"namespace": "Infrastructure",
+		},
+		"aliases": []string{"andAnotherAlias"},
+	}
+
+	sourceConfig := SourceConfig{
+		Name:       "$.name",
+		ExternalID: "$.external_id",
+		Aliases:    []string{"$.aliases"},
+	}
+
+	catalogTypeOutput = &Output{
+		Name:        "name",
+		Description: "description",
+		Source:      sourceConfig,
+	}
+
+	entries = append(entries, sourceEntry1, sourceEntry2)
+
+	logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+
+	When("doing the thing with the aliases", func() {
+		It("does the right shit", func() {
+			res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+			expectedResult := []string{"oneAlias", "anotherAlias"}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res[0].Aliases).To(Equal(expectedResult))
+		})
+
+	})
+})

--- a/output/output_suite_test.go
+++ b/output/output_suite_test.go
@@ -1,0 +1,13 @@
+package output_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOutput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Output Suite")
+}


### PR DESCRIPTION
## tldr
We want to handle the situation where the result of a JS expression returns an array. 

## The changes
* Update `MarshalEntries` to check if the result from `expr.EvaluateSingleValue` is empty, rather than checking for an error
  * Recently when moving from CEL to JS, we changed the [behaviour of EvaluateResultType to no longer return an error](https://github.com/incident-io/catalog-importer/commit/e129b5e62ab17cf82a960be2b8d1aff54b6a671a#diff-1aae2de3e6230d839cdd6f350fb7e882af7702b88ed8496632b7f951b457f7a2R199). The logic in the marshaling of arrays of aliases was [relying on this error being returned](https://github.com/incident-io/catalog-importer/blob/17ad757c0c3a159766765da4f8ab9103dc5e05f5/output/marshal.go#L137-L142), and so we were no longer hitting it 
* Update the logic in MarshalEntries that is dealing with arrays to use `expr.EvaluateArray` rather than `expr.EvaluateSingleValue` (an existing bug from before cel -> js we believe)

## Some extra context if needed

We want to be able to handle marshalling aliases in the situation where catalog entries have different numbers of aliases. Currently you can set the alias source like: `aliases: ['$.aliases[0]', '$.aliases[1]','$.aliases[2]']`, but this doesn't work in the situation above where the lengths could differ.
For example, a jsonnet with: 

```
      sources: [
        {
          inline: {
            entries: [
              {
                name: 'Low',
                external_id: 'low',
                description:
                  'Non-essential features that customers are happy to wait for PR to fix issues with.',
                aliases: ['low'],
              },
              {
                name: 'Medium',
                external_id: 'medium',
                description:
                  'Needs immediate triaging but may not require immediate response. This is the default criticality if left unspecified.',
                aliases: ['medium', 'med', 'mid'], 
              },
              {
                name: 'High',
                external_id: 'high',
                description:
                  'Immediate response required as this impacts a critical part of the customer experience.',
                aliases: ['high', 'max'],
              },
            ],
          },
        },
      ],
```
We want to be able to set the source like:

```
source: {
            name: '$.name',
            external_id: '$.external_id',
            aliases: ['$.aliases'],
          },
```
 and have this be handled correctly. 

