### PR TITLE
Don't set attributes that aren't in the input

### DIFF
--- a/expr/js_eval_test.go
+++ b/expr/js_eval_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Javascript evaluation", func() {
 			topLevelSrc := "$.metadata"
 			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*evaluatedResult).To(Equal(""))
+			Expect(evaluatedResult).To(BeNil())
 		})
 	})
 

--- a/expr/js_eval_test.go
+++ b/expr/js_eval_test.go
@@ -46,28 +46,28 @@ var _ = Describe("Javascript evaluation", func() {
 			topLevelSrc := "$.name"
 			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(sourceEntry["name"]))
+			Expect(*evaluatedResult).To(Equal(sourceEntry["name"]))
 		})
 
 		It("returns a bool as expected", func() {
 			topLevelSrc := "$.important"
 			evaluatedResult, err := EvaluateSingleValue[bool](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(sourceEntry["important"]))
+			Expect(*evaluatedResult).To(Equal(sourceEntry["important"]))
 		})
 
 		It("returns a number as expected", func() {
 			topLevelSrc := "$.importance_score"
 			evaluatedResult, err := EvaluateSingleValue[int](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(sourceEntry["importance_score"]))
+			Expect(*evaluatedResult).To(Equal(sourceEntry["importance_score"]))
 		})
 
 		It("returns a string as expected", func() {
 			topLevelSrc := "$.description"
 			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(sourceEntry["description"]))
+			Expect(*evaluatedResult).To(Equal(sourceEntry["description"]))
 		})
 
 		It("does not parse a value if given the wrong type", func() {
@@ -80,7 +80,7 @@ var _ = Describe("Javascript evaluation", func() {
 			topLevelSrc := "$.metadata"
 			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(""))
+			Expect(*evaluatedResult).To(Equal(""))
 		})
 	})
 
@@ -88,21 +88,21 @@ var _ = Describe("Javascript evaluation", func() {
 		topLevelSrc := "$.name.replace('Component', 'Replacement')"
 		evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(evaluatedResult).To(Equal("Replacement name"))
+		Expect(*evaluatedResult).To(Equal("Replacement name"))
 	})
 
 	It("parses nested values as expected", func() {
 		topLevelSrc := "$.metadata.namespace"
 		evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(evaluatedResult).To(Equal(sourceEntry["metadata"].(map[string]any)["namespace"]))
+		Expect(*evaluatedResult).To(Equal(sourceEntry["metadata"].(map[string]any)["namespace"]))
 	})
 
 	It("handles possible null values with _.get", func() {
 		nestedSrc := "_.get($.metadata, \"badKey\", \"default value\")"
 		evaluatedResult, err := EvaluateSingleValue[string](ctx, nestedSrc, sourceEntry, logger)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(evaluatedResult).To(Equal("default value"))
+		Expect(*evaluatedResult).To(Equal("default value"))
 	})
 
 	When("parsing array values", func() {
@@ -129,16 +129,15 @@ var _ = Describe("Javascript evaluation", func() {
 			topLevelSrc := "$.ghostkey"
 			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(evaluatedResult).To(Equal(""))
+			Expect(evaluatedResult).To(BeNil())
 		})
 
-		It("returns empty if my JS is invalid", func() {
+		It("returns nil if my JS is invalid", func() {
 			topLevelSrc := "$badKey"
 			evaluatedResult, err := EvaluateArray[string](ctx, topLevelSrc, sourceEntryWithArray, logger)
 			Expect(err).NotTo(HaveOccurred())
 			// Expecting an array with an empty string here, as that is the empty state for this function
-			expectedResult := []string{""}
-			Expect(evaluatedResult).To(Equal(expectedResult))
+			Expect(evaluatedResult).To(BeNil())
 		})
 	})
 

--- a/output/collect.go
+++ b/output/collect.go
@@ -25,7 +25,7 @@ func Collect(ctx context.Context, output *Output, entries []source.Entry, logger
 			return nil, errors.Wrap(err, "evaluating filter for entry")
 		}
 
-		if result {
+		if result != nil && *result {
 			filteredEntries = append(filteredEntries, entry)
 		}
 	}

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -136,7 +136,7 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias", idx))
 			}
-			if alias == nil || *alias == "" {
+			if alias == nil {
 				aliasArray, arrayErr := expr.EvaluateArray[string](ctx, aliasSource, entry, logger)
 				if arrayErr != nil {
 					return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias", idx))

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -118,7 +118,7 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 			return nil, errors.Wrap(err, "evaluating entry external ID")
 		}
 
-		var rank int
+		var rank *int
 		if rankSource := output.Source.Rank; rankSource.Valid && rankSource.String != "" {
 			var err error
 			rank, err = expr.EvaluateSingleValue[int](ctx, rankSource.String, entry, logger)
@@ -136,14 +136,14 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias", idx))
 			}
-			if alias == "" {
+			if alias == nil || *alias == "" {
 				aliasArray, arrayErr := expr.EvaluateArray[string](ctx, aliasSource, entry, logger)
 				if arrayErr != nil {
 					return nil, errors.Wrap(err, fmt.Sprintf("aliases.%d: evaluating entry alias", idx))
 				}
 				toAdd = append(toAdd, aliasArray...)
 			} else {
-				toAdd = append(toAdd, alias)
+				toAdd = append(toAdd, *alias)
 			}
 
 			for _, alias := range toAdd {
@@ -165,6 +165,9 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 				if err != nil {
 					return catalogEntryModels, errors.Wrap(err, "evaluating attribute")
 				}
+				if valueLiterals == nil {
+					continue
+				}
 
 				arrayValue := []client.CatalogAttributeValuePayloadV2{}
 				for _, literalAny := range valueLiterals {
@@ -181,33 +184,42 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 				binding.ArrayValue = &arrayValue
 			} else {
 				literal, err := evaluateEntryWithAttributeType(ctx, src, entry, attributeByID[attributeID], logger)
-
 				if err != nil {
 					return catalogEntryModels, errors.Wrap(err, "evaluating attribute")
 				}
+				if literal == nil {
+					continue
+				}
 
 				binding.Value = &client.CatalogAttributeValuePayloadV2{
-					Literal: lo.ToPtr(literal),
+					Literal: literal,
 				}
 			}
 
 			attributeValues[attributeID] = binding
 		}
 
-		catalogEntryModels = append(catalogEntryModels, &CatalogEntryModel{
-			Name:            name,
-			ExternalID:      externalID,
-			Rank:            int32(rank),
+		catalogEntryModel := CatalogEntryModel{
 			Aliases:         aliases,
 			AttributeValues: attributeValues,
-		})
+		}
+		if name != nil {
+			catalogEntryModel.Name = *name
+		}
+		if externalID != nil {
+			catalogEntryModel.ExternalID = *externalID
+		}
+		if rank != nil {
+			catalogEntryModel.Rank = int32(*rank)
+		}
+		catalogEntryModels = append(catalogEntryModels, &catalogEntryModel)
 	}
 
 	return catalogEntryModels, nil
 }
 
-func evaluateEntryWithAttributeType(ctx context.Context, src string, entry map[string]any, attribute *Attribute, logger kitlog.Logger) (string, error) {
-	var literal string
+func evaluateEntryWithAttributeType(ctx context.Context, src string, entry map[string]any, attribute *Attribute, logger kitlog.Logger) (*string, error) {
+	var literal *string
 
 	// If we have an attribute type of type Bool or Number, we can try to evaluate the program against the scope
 	// with the appropriate type.
@@ -217,17 +229,17 @@ func evaluateEntryWithAttributeType(ctx context.Context, src string, entry map[s
 		switch attribute.Type.String {
 		case "Bool":
 			literal, _ = evaluateEntryWithType[bool](ctx, src, entry, logger)
-			if literal != "" {
+			if literal != nil {
 				return literal, nil
 			}
 		case "Number":
 			// Number accepts float or int, so we'll try to evaluate as a float first.
 			literal, _ = evaluateEntryWithType[float64](ctx, src, entry, logger)
-			if literal != "" {
+			if literal != nil {
 				return literal, nil
 			}
 			literal, _ = evaluateEntryWithType[int64](ctx, src, entry, logger)
-			if literal != "" {
+			if literal != nil {
 				return literal, nil
 			}
 		}
@@ -238,11 +250,14 @@ func evaluateEntryWithAttributeType(ctx context.Context, src string, entry map[s
 	return evaluateEntryWithType[string](ctx, src, entry, logger)
 }
 
-func evaluateEntryWithType[ReturnType any](ctx context.Context, src string, entry map[string]any, logger kitlog.Logger) (string, error) {
+func evaluateEntryWithType[ReturnType any](ctx context.Context, src string, entry map[string]any, logger kitlog.Logger) (*string, error) {
 	literal, err := expr.EvaluateSingleValue[ReturnType](ctx, src, entry, logger)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	if literal == nil {
+		return nil, nil
 	}
 
-	return fmt.Sprintf("%v", literal), nil
+	return lo.ToPtr(fmt.Sprintf("%v", *literal)), nil
 }

--- a/output/marshal_test.go
+++ b/output/marshal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/incident-io/catalog-importer/v2/source"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/guregu/null.v3"
 )
 
 var _ = Describe("Marshalling data", func() {
@@ -17,55 +18,91 @@ var _ = Describe("Marshalling data", func() {
 		logger            kitlog.Logger
 	)
 
-	ctx = context.Background()
+	BeforeEach(func() {
+		ctx = context.Background()
 
-	sourceConfig := SourceConfig{
-		Name:       "$.name",
-		ExternalID: "$.external_id",
-		Aliases:    []string{"$.aliases"},
-	}
+		logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+	})
 
-	catalogTypeOutput = &Output{
-		Name:        "name",
-		Description: "description",
-		Source:      sourceConfig,
-	}
-
-	logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
-
-	When("Marshalling alias data where the entry has an array of aliases", func() {
-		It("correctly populates the array on the resulting entry with all values", func() {
-			sourceEntry := source.Entry{
-				"id":          "P1234",
-				"name":        "Component name 1",
-				"description": "A super important component. A structurally integral component tbh.",
-				"aliases":     []string{"aliasInAnArray", "anotherAliasInAnArray"},
+	Describe("aliases", func() {
+		BeforeEach(func() {
+			sourceConfig := SourceConfig{
+				Name:       "$.name",
+				ExternalID: "$.external_id",
+				Aliases:    []string{"$.aliases"},
 			}
 
-			entries := []source.Entry{sourceEntry}
+			catalogTypeOutput = &Output{
+				Name:        "name",
+				Description: "description",
+				Source:      sourceConfig,
+			}
+		})
 
-			res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+		When("Marshalling alias data where the entry has an array of aliases", func() {
+			It("correctly populates the array on the resulting entry with all values", func() {
+				sourceEntry := source.Entry{
+					"id":          "P1234",
+					"name":        "Component name 1",
+					"description": "A super important component. A structurally integral component tbh.",
+					"aliases":     []string{"aliasInAnArray", "anotherAliasInAnArray"},
+				}
 
-			expectedAliasResult := []string{"aliasInAnArray", "anotherAliasInAnArray"}
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res[0].Aliases).To(Equal(expectedAliasResult))
+				entries := []source.Entry{sourceEntry}
 
+				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+
+				expectedAliasResult := []string{"aliasInAnArray", "anotherAliasInAnArray"}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res[0].Aliases).To(Equal(expectedAliasResult))
+
+			})
+		})
+
+		When("Marshalling alias data where the entry has a single string alias", func() {
+			It("correctly populates the alias array on the resulting entry with the single value", func() {
+				sourceEntry := source.Entry{
+					"id":          "P1235",
+					"name":        "Component name 2",
+					"description": "A super important component. A structurally integral component tbh.",
+					"aliases":     "singleAlias",
+				}
+				entries := []source.Entry{sourceEntry}
+				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+				expectedAliasResult := []string{"singleAlias"}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res[0].Aliases).To(Equal(expectedAliasResult))
+			})
 		})
 	})
 
-	When("Marshalling alias data where the entry has a single string alias", func() {
-		It("correctly populates the alias array on the resulting entry with the single value", func() {
-			sourceEntry := source.Entry{
-				"id":          "P1235",
-				"name":        "Component name 2",
-				"description": "A super important component. A structurally integral component tbh.",
-				"aliases":     "singleAlias",
+	Describe("attributes", func() {
+		BeforeEach(func() {
+			sourceConfig := SourceConfig{
+				Name:       "$.name",
+				ExternalID: "$.external_id",
 			}
-			entries := []source.Entry{sourceEntry}
-			res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
-			expectedAliasResult := []string{"singleAlias"}
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res[0].Aliases).To(Equal(expectedAliasResult))
+
+			catalogTypeOutput = &Output{
+				Name:        "name",
+				Description: "description",
+				Source:      sourceConfig,
+				Attributes:  []*Attribute{{ID: "an_attribute", Name: "An attribute", Type: null.StringFrom("String"), Source: null.StringFrom("$.an_attribute")}},
+			}
+		})
+
+		When("Marshalling attributes that aren't present in the source entry", func() {
+			It("doesn't include the attribute in the resulting entry", func() {
+				sourceEntry := source.Entry{
+					"id":          "P1235",
+					"name":        "Component name 2",
+					"description": "A super important component. A structurally integral component tbh.",
+				}
+				entries := []source.Entry{sourceEntry}
+				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res[0].AttributeValues).To(BeEmpty())
+			})
 		})
 	})
 })


### PR DESCRIPTION
When an attribute wasn't in the input data, we weren't handling that correctly and would set the value of the attribute in the catalog to the Go empty value (for example, we'd set a number attribute to 0 if that attribute wasn't set in the input for an entry).

This has been fixed by distinguishing when the value we get back from Otto is null or undefined, and not including that attribute.