### PR TITLE
Turn off HTTP debug logging

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, apiKey, apiEndpoint, version string, opts ...Clien
 	}
 
 	retryClient := retryablehttp.NewClient()
-
+	retryClient.Logger = nil
 	retryClient.RetryMax = maxRetries
 	retryClient.RetryWaitMin = minRetryWait
 	retryClient.RetryWaitMax = maxRetryWait


### PR DESCRIPTION
[go-retryablehttp logs DEBUG to stdout by default](https://github.com/hashicorp/go-retryablehttp/blob/4165cf8897205a879a06b20d1ed0a2a76fbb6a17/client.go#L56). This PR disables that functionality. It may be worth wiring to `--debug` at some point. 