### PR TITLE
Don't log error when evaluating aliases array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/
 /config.jsonnet
 __debug_bin
 .idea/
+*.DS_Store

--- a/expr/js_eval.go
+++ b/expr/js_eval.go
@@ -215,15 +215,17 @@ func EvaluateResultType[ReturnType any](ctx context.Context, source string, resu
 
 	case result.IsUndefined():
 		// do nothing, undefined gets skipped
+		return resultValue, nil
+
+	case result.IsObject():
+		// objects / slices need to be handled explicitly elsewhere
+		fmt.Fprintf(os.Stdout, "\n  Source %s evaluates to an object or array. Falling through\n", source)
+		return resultValue, nil
 
 	default:
-		fmt.Fprintf(os.Stderr, "\n  Unsupported Javascript value type found by expression %s: %s.\n", source, map[string]any{
-			"result": result,
-		})
+		fmt.Fprintf(os.Stderr, "\n  Unsupported Javascript value type found by expression %s: %+v.\n", source, result)
 		return resultValue, nil
 	}
-
-	return resultValue, nil
 }
 
 func SafelyGo(do func()) {

--- a/expr/js_eval.go
+++ b/expr/js_eval.go
@@ -78,11 +78,6 @@ func EvaluateJavascript(ctx context.Context, source string, subject any, logger 
 
 }
 
-func isArray(value otto.Value) bool {
-	return value.IsObject() &&
-		(value.Object().Class() == "Array" || value.Object().Class() == "GoSlice")
-}
-
 func EvaluateArray[ReturnType any](ctx context.Context, source string, subject any, logger kitlog.Logger) ([]ReturnType, error) {
 	result, err := EvaluateJavascript(ctx, source, subject, logger)
 	if err != nil {
@@ -239,4 +234,9 @@ func SafelyGo(do func()) {
 
 		do()
 	}()
+}
+
+func isArray(value otto.Value) bool {
+	return value.IsObject() &&
+		(value.Object().Class() == "Array" || value.Object().Class() == "GoSlice")
 }

--- a/expr/js_eval.go
+++ b/expr/js_eval.go
@@ -217,7 +217,7 @@ func EvaluateResultType[ReturnType any](ctx context.Context, source string, resu
 		return resultValue, nil
 
 	case isArray(result):
-		fmt.Fprintf(os.Stdout, "\n  Source %s evaluates to an array. Handling separately\n", source)
+		fmt.Fprintf(os.Stdout, "\n  Source %s evaluates to an array. Assuming this is handled separately\n", source)
 		return resultValue, nil
 
 	default:


### PR DESCRIPTION
when parsing aliases we 
 - accept an array of source references
 - evaluate each source reference, attempting to parse its result as a string
 - if that fails, evaluate it again, attempting to parse its result as an array of strings
 
 this flow results in an error being logged.
 this PR prevents that error log