### PR TITLE
Use $.attribute_id if there's no source provided

### DIFF
--- a/output/marshal.go
+++ b/output/marshal.go
@@ -98,7 +98,7 @@ func MarshalEntries(ctx context.Context, output *Output, entries []source.Entry,
 	)
 	for _, attr := range output.Attributes {
 		// Use the attribute ID by default if source isn't explicitly provided.
-		source := attr.ID
+		source := "$." + attr.ID
 		if attr.Source.Valid {
 			source = attr.Source.String
 		}


### PR DESCRIPTION
This was a regression from V1: previously, you could emit source, and we'd look for the attribute ID in the source data. We now do the same, by prepending `$.` onto the attribute id.