### PR TITLE
Dont log debug output to StdOut

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -341,14 +341,14 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 			OUT("\n    ↻ %s", outputType.TypeName)
 
 			// Filter source for each of the output types
-			entries, err := output.Collect(ctx, outputType, sourcedEntries, logger)
+			entries, err := output.Collect(ctx, logger, outputType, sourcedEntries)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("outputs.%d (type_name='%s')", idx, outputType.TypeName))
 			}
 			OUT("      ✔ Building entries... (found %d entries matching filters)", len(entries))
 
 			// Marshal entries using the JS expressions.
-			entryModels, err := output.MarshalEntries(ctx, outputType, entries, logger)
+			entryModels, err := output.MarshalEntries(ctx, logger, outputType, entries)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("outputs.%d (type_name='%s')", idx, outputType.TypeName))
 			}

--- a/expr/js_eval_test.go
+++ b/expr/js_eval_test.go
@@ -44,41 +44,41 @@ var _ = Describe("Javascript evaluation", func() {
 	When("parsing attribute sources", func() {
 		It("returns the correct top-level attribute", func() {
 			topLevelSrc := "$.name"
-			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*evaluatedResult).To(Equal(sourceEntry["name"]))
 		})
 
 		It("returns a bool as expected", func() {
 			topLevelSrc := "$.important"
-			evaluatedResult, err := EvaluateSingleValue[bool](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[bool](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*evaluatedResult).To(Equal(sourceEntry["important"]))
 		})
 
 		It("returns a number as expected", func() {
 			topLevelSrc := "$.importance_score"
-			evaluatedResult, err := EvaluateSingleValue[int](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[int](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*evaluatedResult).To(Equal(sourceEntry["importance_score"]))
 		})
 
 		It("returns a string as expected", func() {
 			topLevelSrc := "$.description"
-			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*evaluatedResult).To(Equal(sourceEntry["description"]))
 		})
 
 		It("does not parse a value if given the wrong type", func() {
 			topLevelSrc := "$.description"
-			_, err := EvaluateSingleValue[int](ctx, topLevelSrc, sourceEntry, logger)
+			_, err := EvaluateSingleValue[int](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).To(HaveOccurred(), "could not convert result of string to int")
 		})
 
 		It("returns nil if the type is not supported", func() {
 			topLevelSrc := "$.metadata"
-			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluatedResult).To(BeNil())
 		})
@@ -86,21 +86,21 @@ var _ = Describe("Javascript evaluation", func() {
 
 	It("manipulates string values as expected", func() {
 		topLevelSrc := "$.name.replace('Component', 'Replacement')"
-		evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+		evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*evaluatedResult).To(Equal("Replacement name"))
 	})
 
 	It("parses nested values as expected", func() {
 		topLevelSrc := "$.metadata.namespace"
-		evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+		evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*evaluatedResult).To(Equal(sourceEntry["metadata"].(map[string]any)["namespace"]))
 	})
 
 	It("handles possible null values with _.get", func() {
 		nestedSrc := "_.get($.metadata, \"badKey\", \"default value\")"
-		evaluatedResult, err := EvaluateSingleValue[string](ctx, nestedSrc, sourceEntry, logger)
+		evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, nestedSrc, sourceEntry)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*evaluatedResult).To(Equal("default value"))
 	})
@@ -111,14 +111,14 @@ var _ = Describe("Javascript evaluation", func() {
 			entryName, ok := sourceEntryWithArray["name"].(string)
 			Expect(ok).To(BeTrue())
 			expectedResult := []string{entryName}
-			evaluatedResult, err := EvaluateArray[string](ctx, topLevelSrc, sourceEntryWithArray, logger)
+			evaluatedResult, err := EvaluateArray[string](ctx, logger, topLevelSrc, sourceEntryWithArray)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluatedResult).To(Equal(expectedResult))
 		})
 
 		It("works as expected when given actual array input", func() {
 			topLevelSrc := "$.domains"
-			evaluatedResult, err := EvaluateArray[string](ctx, topLevelSrc, sourceEntryWithArray, logger)
+			evaluatedResult, err := EvaluateArray[string](ctx, logger, topLevelSrc, sourceEntryWithArray)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluatedResult).To(Equal(sourceEntryWithArray["domains"]))
 		})
@@ -127,14 +127,14 @@ var _ = Describe("Javascript evaluation", func() {
 	When("sending invalid source javascript", func() {
 		It("returns nothing if I send a key that isn't present on the entry", func() {
 			topLevelSrc := "$.ghostkey"
-			evaluatedResult, err := EvaluateSingleValue[string](ctx, topLevelSrc, sourceEntry, logger)
+			evaluatedResult, err := EvaluateSingleValue[string](ctx, logger, topLevelSrc, sourceEntry)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluatedResult).To(BeNil())
 		})
 
 		It("returns nil if my JS is invalid", func() {
 			topLevelSrc := "$badKey"
-			evaluatedResult, err := EvaluateArray[string](ctx, topLevelSrc, sourceEntryWithArray, logger)
+			evaluatedResult, err := EvaluateArray[string](ctx, logger, topLevelSrc, sourceEntryWithArray)
 			Expect(err).NotTo(HaveOccurred())
 			// Expecting an array with an empty string here, as that is the empty state for this function
 			Expect(evaluatedResult).To(BeNil())

--- a/output/collect.go
+++ b/output/collect.go
@@ -11,7 +11,7 @@ import (
 
 // Collect filters the list of entries against the source filter on the output, returning
 // a list of all entries which pass the filter.
-func Collect(ctx context.Context, output *Output, entries []source.Entry, logger kitlog.Logger) ([]source.Entry, error) {
+func Collect(ctx context.Context, logger kitlog.Logger, output *Output, entries []source.Entry) ([]source.Entry, error) {
 	if !output.Source.Filter.Valid {
 		return entries, nil // no-op, the filter is blank
 	}
@@ -20,7 +20,7 @@ func Collect(ctx context.Context, output *Output, entries []source.Entry, logger
 
 	filteredEntries := []source.Entry{}
 	for _, entry := range entries {
-		result, err := expr.EvaluateSingleValue[bool](ctx, src, entry, logger)
+		result, err := expr.EvaluateSingleValue[bool](ctx, logger, src, entry)
 		if err != nil {
 			return nil, errors.Wrap(err, "evaluating filter for entry")
 		}

--- a/output/marshal_test.go
+++ b/output/marshal_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Marshalling data", func() {
 
 				entries := []source.Entry{sourceEntry}
 
-				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+				res, err := MarshalEntries(ctx, logger, catalogTypeOutput, entries)
 
 				expectedAliasResult := []string{"aliasInAnArray", "anotherAliasInAnArray"}
 				Expect(err).NotTo(HaveOccurred())
@@ -68,7 +68,7 @@ var _ = Describe("Marshalling data", func() {
 					"aliases":     "singleAlias",
 				}
 				entries := []source.Entry{sourceEntry}
-				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+				res, err := MarshalEntries(ctx, logger, catalogTypeOutput, entries)
 				expectedAliasResult := []string{"singleAlias"}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res[0].Aliases).To(Equal(expectedAliasResult))
@@ -99,7 +99,7 @@ var _ = Describe("Marshalling data", func() {
 					"description": "A super important component. A structurally integral component tbh.",
 				}
 				entries := []source.Entry{sourceEntry}
-				res, err := MarshalEntries(ctx, catalogTypeOutput, entries, logger)
+				res, err := MarshalEntries(ctx, logger, catalogTypeOutput, entries)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res[0].AttributeValues).To(BeEmpty())
 			})


### PR DESCRIPTION
Logging 'asumming this is handled separately' isn't useful information - now we log this on our logger which'll only pipe to StdOut in debug mode.

Additionally makes logger the second argument to our functions as that's a more common pattern.