### PR TITLE
Support backlink attributes via the importer

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -20,10 +20,18 @@ import (
 
 // Defines values for ActionV1Status.
 const (
-	Completed   ActionV1Status = "completed"
-	Deleted     ActionV1Status = "deleted"
-	NotDoing    ActionV1Status = "not_doing"
-	Outstanding ActionV1Status = "outstanding"
+	ActionV1StatusCompleted   ActionV1Status = "completed"
+	ActionV1StatusDeleted     ActionV1Status = "deleted"
+	ActionV1StatusNotDoing    ActionV1Status = "not_doing"
+	ActionV1StatusOutstanding ActionV1Status = "outstanding"
+)
+
+// Defines values for ActionV2Status.
+const (
+	ActionV2StatusCompleted   ActionV2Status = "completed"
+	ActionV2StatusDeleted     ActionV2Status = "deleted"
+	ActionV2StatusNotDoing    ActionV2Status = "not_doing"
+	ActionV2StatusOutstanding ActionV2Status = "outstanding"
 )
 
 // Defines values for CatalogResourceV2Category.
@@ -33,34 +41,98 @@ const (
 	CatalogResourceV2CategoryPrimitive CatalogResourceV2Category = "primitive"
 )
 
+// Defines values for CatalogTypeAttributePayloadV2Mode.
+const (
+	CatalogTypeAttributePayloadV2ModeBacklink CatalogTypeAttributePayloadV2Mode = "backlink"
+	CatalogTypeAttributePayloadV2ModeDynamic  CatalogTypeAttributePayloadV2Mode = "dynamic"
+	CatalogTypeAttributePayloadV2ModeEmpty    CatalogTypeAttributePayloadV2Mode = ""
+	CatalogTypeAttributePayloadV2ModeExternal CatalogTypeAttributePayloadV2Mode = "external"
+	CatalogTypeAttributePayloadV2ModeInternal CatalogTypeAttributePayloadV2Mode = "internal"
+	CatalogTypeAttributePayloadV2ModeManual   CatalogTypeAttributePayloadV2Mode = "manual"
+)
+
+// Defines values for CatalogTypeAttributeV2Mode.
+const (
+	Backlink CatalogTypeAttributeV2Mode = "backlink"
+	Dynamic  CatalogTypeAttributeV2Mode = "dynamic"
+	Empty    CatalogTypeAttributeV2Mode = ""
+	External CatalogTypeAttributeV2Mode = "external"
+	Internal CatalogTypeAttributeV2Mode = "internal"
+	Manual   CatalogTypeAttributeV2Mode = "manual"
+)
+
 // Defines values for CatalogTypeV2Color.
 const (
 	CatalogTypeV2ColorBlue   CatalogTypeV2Color = "blue"
+	CatalogTypeV2ColorCyan   CatalogTypeV2Color = "cyan"
 	CatalogTypeV2ColorGreen  CatalogTypeV2Color = "green"
-	CatalogTypeV2ColorRed    CatalogTypeV2Color = "red"
-	CatalogTypeV2ColorSlate  CatalogTypeV2Color = "slate"
+	CatalogTypeV2ColorOrange CatalogTypeV2Color = "orange"
+	CatalogTypeV2ColorPink   CatalogTypeV2Color = "pink"
 	CatalogTypeV2ColorViolet CatalogTypeV2Color = "violet"
 	CatalogTypeV2ColorYellow CatalogTypeV2Color = "yellow"
 )
 
 // Defines values for CatalogTypeV2Icon.
 const (
-	CatalogTypeV2IconBolt      CatalogTypeV2Icon = "bolt"
-	CatalogTypeV2IconBox       CatalogTypeV2Icon = "box"
-	CatalogTypeV2IconBriefcase CatalogTypeV2Icon = "briefcase"
-	CatalogTypeV2IconBrowser   CatalogTypeV2Icon = "browser"
-	CatalogTypeV2IconBulb      CatalogTypeV2Icon = "bulb"
-	CatalogTypeV2IconClock     CatalogTypeV2Icon = "clock"
-	CatalogTypeV2IconCog       CatalogTypeV2Icon = "cog"
-	CatalogTypeV2IconDatabase  CatalogTypeV2Icon = "database"
-	CatalogTypeV2IconDoc       CatalogTypeV2Icon = "doc"
-	CatalogTypeV2IconEmail     CatalogTypeV2Icon = "email"
-	CatalogTypeV2IconServer    CatalogTypeV2Icon = "server"
-	CatalogTypeV2IconSeverity  CatalogTypeV2Icon = "severity"
-	CatalogTypeV2IconStar      CatalogTypeV2Icon = "star"
-	CatalogTypeV2IconTag       CatalogTypeV2Icon = "tag"
-	CatalogTypeV2IconUser      CatalogTypeV2Icon = "user"
-	CatalogTypeV2IconUsers     CatalogTypeV2Icon = "users"
+	CatalogTypeV2IconBolt       CatalogTypeV2Icon = "bolt"
+	CatalogTypeV2IconBox        CatalogTypeV2Icon = "box"
+	CatalogTypeV2IconBriefcase  CatalogTypeV2Icon = "briefcase"
+	CatalogTypeV2IconBrowser    CatalogTypeV2Icon = "browser"
+	CatalogTypeV2IconBulb       CatalogTypeV2Icon = "bulb"
+	CatalogTypeV2IconCalendar   CatalogTypeV2Icon = "calendar"
+	CatalogTypeV2IconClock      CatalogTypeV2Icon = "clock"
+	CatalogTypeV2IconCog        CatalogTypeV2Icon = "cog"
+	CatalogTypeV2IconComponents CatalogTypeV2Icon = "components"
+	CatalogTypeV2IconDatabase   CatalogTypeV2Icon = "database"
+	CatalogTypeV2IconDoc        CatalogTypeV2Icon = "doc"
+	CatalogTypeV2IconEmail      CatalogTypeV2Icon = "email"
+	CatalogTypeV2IconFiles      CatalogTypeV2Icon = "files"
+	CatalogTypeV2IconFlag       CatalogTypeV2Icon = "flag"
+	CatalogTypeV2IconFolder     CatalogTypeV2Icon = "folder"
+	CatalogTypeV2IconGlobe      CatalogTypeV2Icon = "globe"
+	CatalogTypeV2IconMoney      CatalogTypeV2Icon = "money"
+	CatalogTypeV2IconServer     CatalogTypeV2Icon = "server"
+	CatalogTypeV2IconSeverity   CatalogTypeV2Icon = "severity"
+	CatalogTypeV2IconStar       CatalogTypeV2Icon = "star"
+	CatalogTypeV2IconStore      CatalogTypeV2Icon = "store"
+	CatalogTypeV2IconTag        CatalogTypeV2Icon = "tag"
+	CatalogTypeV2IconUser       CatalogTypeV2Icon = "user"
+	CatalogTypeV2IconUsers      CatalogTypeV2Icon = "users"
+)
+
+// Defines values for CreateHTTPRequestBodyStatus.
+const (
+	Firing   CreateHTTPRequestBodyStatus = "firing"
+	Resolved CreateHTTPRequestBodyStatus = "resolved"
+)
+
+// Defines values for CreateHTTPResponseBodyDeduplicationKey.
+const (
+	UniqueKey CreateHTTPResponseBodyDeduplicationKey = "unique-key"
+)
+
+// Defines values for CreateHTTPResponseBodyMessage.
+const (
+	EventAcceptedForProcessing CreateHTTPResponseBodyMessage = "Event accepted for processing"
+)
+
+// Defines values for CreateHTTPResponseBodyStatus.
+const (
+	Success CreateHTTPResponseBodyStatus = "success"
+)
+
+// Defines values for CreateRequestBody10Mode.
+const (
+	CreateRequestBody10ModeRetrospective CreateRequestBody10Mode = "retrospective"
+	CreateRequestBody10ModeStandard      CreateRequestBody10Mode = "standard"
+	CreateRequestBody10ModeTest          CreateRequestBody10Mode = "test"
+	CreateRequestBody10ModeTutorial      CreateRequestBody10Mode = "tutorial"
+)
+
+// Defines values for CreateRequestBody10Visibility.
+const (
+	CreateRequestBody10VisibilityPrivate CreateRequestBody10Visibility = "private"
+	CreateRequestBody10VisibilityPublic  CreateRequestBody10Visibility = "public"
 )
 
 // Defines values for CreateRequestBody2FieldType.
@@ -79,88 +151,103 @@ const (
 	CreateRequestBody2RequiredNever         CreateRequestBody2Required = "never"
 )
 
-// Defines values for CreateRequestBody3ResourceResourceType.
+// Defines values for CreateRequestBody2RequiredV2.
 const (
-	CreateRequestBody3ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody3ResourceResourceType = "atlassian_statuspage_incident"
-	CreateRequestBody3ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody3ResourceResourceType = "datadog_monitor_alert"
-	CreateRequestBody3ResourceResourceTypeGithubPullRequest           CreateRequestBody3ResourceResourceType = "github_pull_request"
-	CreateRequestBody3ResourceResourceTypeOpsgenieAlert               CreateRequestBody3ResourceResourceType = "opsgenie_alert"
-	CreateRequestBody3ResourceResourceTypePagerDutyIncident           CreateRequestBody3ResourceResourceType = "pager_duty_incident"
-	CreateRequestBody3ResourceResourceTypeSentryIssue                 CreateRequestBody3ResourceResourceType = "sentry_issue"
-	CreateRequestBody3ResourceResourceTypeStatuspageIncident          CreateRequestBody3ResourceResourceType = "statuspage_incident"
-	CreateRequestBody3ResourceResourceTypeZendeskTicket               CreateRequestBody3ResourceResourceType = "zendesk_ticket"
+	CreateRequestBody2RequiredV2Always           CreateRequestBody2RequiredV2 = "always"
+	CreateRequestBody2RequiredV2BeforeResolution CreateRequestBody2RequiredV2 = "before_resolution"
+	CreateRequestBody2RequiredV2Never            CreateRequestBody2RequiredV2 = "never"
 )
 
-// Defines values for CreateRequestBody5Category.
+// Defines values for CreateRequestBody3FieldType.
 const (
-	CreateRequestBody5CategoryClosed CreateRequestBody5Category = "closed"
-	CreateRequestBody5CategoryLive   CreateRequestBody5Category = "live"
+	CreateRequestBody3FieldTypeLink         CreateRequestBody3FieldType = "link"
+	CreateRequestBody3FieldTypeMultiSelect  CreateRequestBody3FieldType = "multi_select"
+	CreateRequestBody3FieldTypeNumeric      CreateRequestBody3FieldType = "numeric"
+	CreateRequestBody3FieldTypeSingleSelect CreateRequestBody3FieldType = "single_select"
+	CreateRequestBody3FieldTypeText         CreateRequestBody3FieldType = "text"
 )
 
-// Defines values for CreateRequestBody6Mode.
+// Defines values for CreateRequestBody4ResourceResourceType.
 const (
-	CreateRequestBody6ModeReal CreateRequestBody6Mode = "real"
-	CreateRequestBody6ModeTest CreateRequestBody6Mode = "test"
+	CreateRequestBody4ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody4ResourceResourceType = "atlassian_statuspage_incident"
+	CreateRequestBody4ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody4ResourceResourceType = "datadog_monitor_alert"
+	CreateRequestBody4ResourceResourceTypeGithubPullRequest           CreateRequestBody4ResourceResourceType = "github_pull_request"
+	CreateRequestBody4ResourceResourceTypeGitlabMergeRequest          CreateRequestBody4ResourceResourceType = "gitlab_merge_request"
+	CreateRequestBody4ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody4ResourceResourceType = "google_calendar_event"
+	CreateRequestBody4ResourceResourceTypeOpsgenieAlert               CreateRequestBody4ResourceResourceType = "opsgenie_alert"
+	CreateRequestBody4ResourceResourceTypePagerDutyIncident           CreateRequestBody4ResourceResourceType = "pager_duty_incident"
+	CreateRequestBody4ResourceResourceTypeScrubbed                    CreateRequestBody4ResourceResourceType = "scrubbed"
+	CreateRequestBody4ResourceResourceTypeSentryIssue                 CreateRequestBody4ResourceResourceType = "sentry_issue"
+	CreateRequestBody4ResourceResourceTypeStatuspageIncident          CreateRequestBody4ResourceResourceType = "statuspage_incident"
+	CreateRequestBody4ResourceResourceTypeZendeskTicket               CreateRequestBody4ResourceResourceType = "zendesk_ticket"
 )
 
-// Defines values for CreateRequestBody6Status.
+// Defines values for CreateRequestBody8Category.
 const (
-	CreateRequestBody6StatusClosed        CreateRequestBody6Status = "closed"
-	CreateRequestBody6StatusDeclined      CreateRequestBody6Status = "declined"
-	CreateRequestBody6StatusFixing        CreateRequestBody6Status = "fixing"
-	CreateRequestBody6StatusInvestigating CreateRequestBody6Status = "investigating"
-	CreateRequestBody6StatusMonitoring    CreateRequestBody6Status = "monitoring"
-	CreateRequestBody6StatusTriage        CreateRequestBody6Status = "triage"
+	CreateRequestBody8CategoryClosed   CreateRequestBody8Category = "closed"
+	CreateRequestBody8CategoryLearning CreateRequestBody8Category = "learning"
+	CreateRequestBody8CategoryLive     CreateRequestBody8Category = "live"
 )
 
-// Defines values for CreateRequestBody6Visibility.
+// Defines values for CreateRequestBody9Mode.
 const (
-	CreateRequestBody6VisibilityPrivate CreateRequestBody6Visibility = "private"
-	CreateRequestBody6VisibilityPublic  CreateRequestBody6Visibility = "public"
+	CreateRequestBody9ModeReal CreateRequestBody9Mode = "real"
+	CreateRequestBody9ModeTest CreateRequestBody9Mode = "test"
 )
 
-// Defines values for CreateRequestBody7Mode.
+// Defines values for CreateRequestBody9Status.
 const (
-	CreateRequestBody7ModeRetrospective CreateRequestBody7Mode = "retrospective"
-	CreateRequestBody7ModeStandard      CreateRequestBody7Mode = "standard"
-	CreateRequestBody7ModeTest          CreateRequestBody7Mode = "test"
-	CreateRequestBody7ModeTutorial      CreateRequestBody7Mode = "tutorial"
+	CreateRequestBody9StatusClosed        CreateRequestBody9Status = "closed"
+	CreateRequestBody9StatusDeclined      CreateRequestBody9Status = "declined"
+	CreateRequestBody9StatusFixing        CreateRequestBody9Status = "fixing"
+	CreateRequestBody9StatusInvestigating CreateRequestBody9Status = "investigating"
+	CreateRequestBody9StatusMonitoring    CreateRequestBody9Status = "monitoring"
+	CreateRequestBody9StatusTriage        CreateRequestBody9Status = "triage"
 )
 
-// Defines values for CreateRequestBody7Visibility.
+// Defines values for CreateRequestBody9Visibility.
 const (
-	CreateRequestBody7VisibilityPrivate CreateRequestBody7Visibility = "private"
-	CreateRequestBody7VisibilityPublic  CreateRequestBody7Visibility = "public"
+	CreateRequestBody9VisibilityPrivate CreateRequestBody9Visibility = "private"
+	CreateRequestBody9VisibilityPublic  CreateRequestBody9Visibility = "public"
 )
 
 // Defines values for CreateTypeRequestBodyColor.
 const (
 	CreateTypeRequestBodyColorBlue   CreateTypeRequestBodyColor = "blue"
+	CreateTypeRequestBodyColorCyan   CreateTypeRequestBodyColor = "cyan"
 	CreateTypeRequestBodyColorGreen  CreateTypeRequestBodyColor = "green"
-	CreateTypeRequestBodyColorRed    CreateTypeRequestBodyColor = "red"
-	CreateTypeRequestBodyColorSlate  CreateTypeRequestBodyColor = "slate"
+	CreateTypeRequestBodyColorOrange CreateTypeRequestBodyColor = "orange"
+	CreateTypeRequestBodyColorPink   CreateTypeRequestBodyColor = "pink"
 	CreateTypeRequestBodyColorViolet CreateTypeRequestBodyColor = "violet"
 	CreateTypeRequestBodyColorYellow CreateTypeRequestBodyColor = "yellow"
 )
 
 // Defines values for CreateTypeRequestBodyIcon.
 const (
-	CreateTypeRequestBodyIconBolt      CreateTypeRequestBodyIcon = "bolt"
-	CreateTypeRequestBodyIconBox       CreateTypeRequestBodyIcon = "box"
-	CreateTypeRequestBodyIconBriefcase CreateTypeRequestBodyIcon = "briefcase"
-	CreateTypeRequestBodyIconBrowser   CreateTypeRequestBodyIcon = "browser"
-	CreateTypeRequestBodyIconBulb      CreateTypeRequestBodyIcon = "bulb"
-	CreateTypeRequestBodyIconClock     CreateTypeRequestBodyIcon = "clock"
-	CreateTypeRequestBodyIconCog       CreateTypeRequestBodyIcon = "cog"
-	CreateTypeRequestBodyIconDatabase  CreateTypeRequestBodyIcon = "database"
-	CreateTypeRequestBodyIconDoc       CreateTypeRequestBodyIcon = "doc"
-	CreateTypeRequestBodyIconEmail     CreateTypeRequestBodyIcon = "email"
-	CreateTypeRequestBodyIconServer    CreateTypeRequestBodyIcon = "server"
-	CreateTypeRequestBodyIconSeverity  CreateTypeRequestBodyIcon = "severity"
-	CreateTypeRequestBodyIconStar      CreateTypeRequestBodyIcon = "star"
-	CreateTypeRequestBodyIconTag       CreateTypeRequestBodyIcon = "tag"
-	CreateTypeRequestBodyIconUser      CreateTypeRequestBodyIcon = "user"
-	CreateTypeRequestBodyIconUsers     CreateTypeRequestBodyIcon = "users"
+	CreateTypeRequestBodyIconBolt       CreateTypeRequestBodyIcon = "bolt"
+	CreateTypeRequestBodyIconBox        CreateTypeRequestBodyIcon = "box"
+	CreateTypeRequestBodyIconBriefcase  CreateTypeRequestBodyIcon = "briefcase"
+	CreateTypeRequestBodyIconBrowser    CreateTypeRequestBodyIcon = "browser"
+	CreateTypeRequestBodyIconBulb       CreateTypeRequestBodyIcon = "bulb"
+	CreateTypeRequestBodyIconCalendar   CreateTypeRequestBodyIcon = "calendar"
+	CreateTypeRequestBodyIconClock      CreateTypeRequestBodyIcon = "clock"
+	CreateTypeRequestBodyIconCog        CreateTypeRequestBodyIcon = "cog"
+	CreateTypeRequestBodyIconComponents CreateTypeRequestBodyIcon = "components"
+	CreateTypeRequestBodyIconDatabase   CreateTypeRequestBodyIcon = "database"
+	CreateTypeRequestBodyIconDoc        CreateTypeRequestBodyIcon = "doc"
+	CreateTypeRequestBodyIconEmail      CreateTypeRequestBodyIcon = "email"
+	CreateTypeRequestBodyIconFiles      CreateTypeRequestBodyIcon = "files"
+	CreateTypeRequestBodyIconFlag       CreateTypeRequestBodyIcon = "flag"
+	CreateTypeRequestBodyIconFolder     CreateTypeRequestBodyIcon = "folder"
+	CreateTypeRequestBodyIconGlobe      CreateTypeRequestBodyIcon = "globe"
+	CreateTypeRequestBodyIconMoney      CreateTypeRequestBodyIcon = "money"
+	CreateTypeRequestBodyIconServer     CreateTypeRequestBodyIcon = "server"
+	CreateTypeRequestBodyIconSeverity   CreateTypeRequestBodyIcon = "severity"
+	CreateTypeRequestBodyIconStar       CreateTypeRequestBodyIcon = "star"
+	CreateTypeRequestBodyIconStore      CreateTypeRequestBodyIcon = "store"
+	CreateTypeRequestBodyIconTag        CreateTypeRequestBodyIcon = "tag"
+	CreateTypeRequestBodyIconUser       CreateTypeRequestBodyIcon = "user"
+	CreateTypeRequestBodyIconUsers      CreateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for CustomFieldTypeInfoV1FieldType.
@@ -174,11 +261,11 @@ const (
 
 // Defines values for CustomFieldV1FieldType.
 const (
-	Link         CustomFieldV1FieldType = "link"
-	MultiSelect  CustomFieldV1FieldType = "multi_select"
-	Numeric      CustomFieldV1FieldType = "numeric"
-	SingleSelect CustomFieldV1FieldType = "single_select"
-	Text         CustomFieldV1FieldType = "text"
+	CustomFieldV1FieldTypeLink         CustomFieldV1FieldType = "link"
+	CustomFieldV1FieldTypeMultiSelect  CustomFieldV1FieldType = "multi_select"
+	CustomFieldV1FieldTypeNumeric      CustomFieldV1FieldType = "numeric"
+	CustomFieldV1FieldTypeSingleSelect CustomFieldV1FieldType = "single_select"
+	CustomFieldV1FieldTypeText         CustomFieldV1FieldType = "text"
 )
 
 // Defines values for CustomFieldV1Required.
@@ -188,10 +275,28 @@ const (
 	CustomFieldV1RequiredNever         CustomFieldV1Required = "never"
 )
 
+// Defines values for CustomFieldV1RequiredV2.
+const (
+	CustomFieldV1RequiredV2Always           CustomFieldV1RequiredV2 = "always"
+	CustomFieldV1RequiredV2BeforeResolution CustomFieldV1RequiredV2 = "before_resolution"
+	CustomFieldV1RequiredV2Never            CustomFieldV1RequiredV2 = "never"
+)
+
+// Defines values for CustomFieldV2FieldType.
+const (
+	Link         CustomFieldV2FieldType = "link"
+	MultiSelect  CustomFieldV2FieldType = "multi_select"
+	Numeric      CustomFieldV2FieldType = "numeric"
+	SingleSelect CustomFieldV2FieldType = "single_select"
+	Text         CustomFieldV2FieldType = "text"
+)
+
 // Defines values for ExternalIssueReferenceV1Provider.
 const (
 	ExternalIssueReferenceV1ProviderAsana      ExternalIssueReferenceV1Provider = "asana"
+	ExternalIssueReferenceV1ProviderClickUp    ExternalIssueReferenceV1Provider = "click_up"
 	ExternalIssueReferenceV1ProviderGithub     ExternalIssueReferenceV1Provider = "github"
+	ExternalIssueReferenceV1ProviderGitlab     ExternalIssueReferenceV1Provider = "gitlab"
 	ExternalIssueReferenceV1ProviderJira       ExternalIssueReferenceV1Provider = "jira"
 	ExternalIssueReferenceV1ProviderJiraServer ExternalIssueReferenceV1Provider = "jira_server"
 	ExternalIssueReferenceV1ProviderLinear     ExternalIssueReferenceV1Provider = "linear"
@@ -201,7 +306,9 @@ const (
 // Defines values for ExternalIssueReferenceV2Provider.
 const (
 	ExternalIssueReferenceV2ProviderAsana      ExternalIssueReferenceV2Provider = "asana"
+	ExternalIssueReferenceV2ProviderClickUp    ExternalIssueReferenceV2Provider = "click_up"
 	ExternalIssueReferenceV2ProviderGithub     ExternalIssueReferenceV2Provider = "github"
+	ExternalIssueReferenceV2ProviderGitlab     ExternalIssueReferenceV2Provider = "gitlab"
 	ExternalIssueReferenceV2ProviderJira       ExternalIssueReferenceV2Provider = "jira"
 	ExternalIssueReferenceV2ProviderJiraServer ExternalIssueReferenceV2Provider = "jira_server"
 	ExternalIssueReferenceV2ProviderLinear     ExternalIssueReferenceV2Provider = "linear"
@@ -213,22 +320,34 @@ const (
 	ExternalResourceV1ResourceTypeAtlassianStatuspageIncident ExternalResourceV1ResourceType = "atlassian_statuspage_incident"
 	ExternalResourceV1ResourceTypeDatadogMonitorAlert         ExternalResourceV1ResourceType = "datadog_monitor_alert"
 	ExternalResourceV1ResourceTypeGithubPullRequest           ExternalResourceV1ResourceType = "github_pull_request"
+	ExternalResourceV1ResourceTypeGitlabMergeRequest          ExternalResourceV1ResourceType = "gitlab_merge_request"
+	ExternalResourceV1ResourceTypeGoogleCalendarEvent         ExternalResourceV1ResourceType = "google_calendar_event"
 	ExternalResourceV1ResourceTypeOpsgenieAlert               ExternalResourceV1ResourceType = "opsgenie_alert"
 	ExternalResourceV1ResourceTypePagerDutyIncident           ExternalResourceV1ResourceType = "pager_duty_incident"
+	ExternalResourceV1ResourceTypeScrubbed                    ExternalResourceV1ResourceType = "scrubbed"
 	ExternalResourceV1ResourceTypeSentryIssue                 ExternalResourceV1ResourceType = "sentry_issue"
 	ExternalResourceV1ResourceTypeStatuspageIncident          ExternalResourceV1ResourceType = "statuspage_incident"
 	ExternalResourceV1ResourceTypeZendeskTicket               ExternalResourceV1ResourceType = "zendesk_ticket"
 )
 
+// Defines values for FollowUpV2Status.
+const (
+	Completed   FollowUpV2Status = "completed"
+	Deleted     FollowUpV2Status = "deleted"
+	NotDoing    FollowUpV2Status = "not_doing"
+	Outstanding FollowUpV2Status = "outstanding"
+)
+
 // Defines values for IdentityV1Roles.
 const (
-	IdentityV1RolesCatalogEditor   IdentityV1Roles = "catalog_editor"
-	IdentityV1RolesCatalogViewer   IdentityV1Roles = "catalog_viewer"
-	IdentityV1RolesGlobalAccess    IdentityV1Roles = "global_access"
-	IdentityV1RolesIncidentCreator IdentityV1Roles = "incident_creator"
-	IdentityV1RolesIncidentEditor  IdentityV1Roles = "incident_editor"
-	IdentityV1RolesManageSettings  IdentityV1Roles = "manage_settings"
-	IdentityV1RolesViewer          IdentityV1Roles = "viewer"
+	IdentityV1RolesCatalogEditor             IdentityV1Roles = "catalog_editor"
+	IdentityV1RolesCatalogViewer             IdentityV1Roles = "catalog_viewer"
+	IdentityV1RolesGlobalAccess              IdentityV1Roles = "global_access"
+	IdentityV1RolesIncidentCreator           IdentityV1Roles = "incident_creator"
+	IdentityV1RolesIncidentEditor            IdentityV1Roles = "incident_editor"
+	IdentityV1RolesIncidentMembershipsEditor IdentityV1Roles = "incident_memberships_editor"
+	IdentityV1RolesManageSettings            IdentityV1Roles = "manage_settings"
+	IdentityV1RolesViewer                    IdentityV1Roles = "viewer"
 )
 
 // Defines values for IncidentRoleV1RoleType.
@@ -238,12 +357,22 @@ const (
 	IncidentRoleV1RoleTypeReporter IncidentRoleV1RoleType = "reporter"
 )
 
+// Defines values for IncidentRoleV2RoleType.
+const (
+	IncidentRoleV2RoleTypeCustom   IncidentRoleV2RoleType = "custom"
+	IncidentRoleV2RoleTypeLead     IncidentRoleV2RoleType = "lead"
+	IncidentRoleV2RoleTypeReporter IncidentRoleV2RoleType = "reporter"
+)
+
 // Defines values for IncidentStatusV1Category.
 const (
+	IncidentStatusV1CategoryCanceled IncidentStatusV1Category = "canceled"
 	IncidentStatusV1CategoryClosed   IncidentStatusV1Category = "closed"
 	IncidentStatusV1CategoryDeclined IncidentStatusV1Category = "declined"
+	IncidentStatusV1CategoryLearning IncidentStatusV1Category = "learning"
 	IncidentStatusV1CategoryLive     IncidentStatusV1Category = "live"
 	IncidentStatusV1CategoryMerged   IncidentStatusV1Category = "merged"
+	IncidentStatusV1CategoryPaused   IncidentStatusV1Category = "paused"
 	IncidentStatusV1CategoryTriage   IncidentStatusV1Category = "triage"
 )
 
@@ -297,34 +426,50 @@ const (
 	UpdateRequestBody2RequiredNever         UpdateRequestBody2Required = "never"
 )
 
+// Defines values for UpdateRequestBody2RequiredV2.
+const (
+	Always           UpdateRequestBody2RequiredV2 = "always"
+	BeforeResolution UpdateRequestBody2RequiredV2 = "before_resolution"
+	Never            UpdateRequestBody2RequiredV2 = "never"
+)
+
 // Defines values for UpdateTypeRequestBodyColor.
 const (
 	Blue   UpdateTypeRequestBodyColor = "blue"
+	Cyan   UpdateTypeRequestBodyColor = "cyan"
 	Green  UpdateTypeRequestBodyColor = "green"
-	Red    UpdateTypeRequestBodyColor = "red"
-	Slate  UpdateTypeRequestBodyColor = "slate"
+	Orange UpdateTypeRequestBodyColor = "orange"
+	Pink   UpdateTypeRequestBodyColor = "pink"
 	Violet UpdateTypeRequestBodyColor = "violet"
 	Yellow UpdateTypeRequestBodyColor = "yellow"
 )
 
 // Defines values for UpdateTypeRequestBodyIcon.
 const (
-	Bolt      UpdateTypeRequestBodyIcon = "bolt"
-	Box       UpdateTypeRequestBodyIcon = "box"
-	Briefcase UpdateTypeRequestBodyIcon = "briefcase"
-	Browser   UpdateTypeRequestBodyIcon = "browser"
-	Bulb      UpdateTypeRequestBodyIcon = "bulb"
-	Clock     UpdateTypeRequestBodyIcon = "clock"
-	Cog       UpdateTypeRequestBodyIcon = "cog"
-	Database  UpdateTypeRequestBodyIcon = "database"
-	Doc       UpdateTypeRequestBodyIcon = "doc"
-	Email     UpdateTypeRequestBodyIcon = "email"
-	Server    UpdateTypeRequestBodyIcon = "server"
-	Severity  UpdateTypeRequestBodyIcon = "severity"
-	Star      UpdateTypeRequestBodyIcon = "star"
-	Tag       UpdateTypeRequestBodyIcon = "tag"
-	User      UpdateTypeRequestBodyIcon = "user"
-	Users     UpdateTypeRequestBodyIcon = "users"
+	Bolt       UpdateTypeRequestBodyIcon = "bolt"
+	Box        UpdateTypeRequestBodyIcon = "box"
+	Briefcase  UpdateTypeRequestBodyIcon = "briefcase"
+	Browser    UpdateTypeRequestBodyIcon = "browser"
+	Bulb       UpdateTypeRequestBodyIcon = "bulb"
+	Calendar   UpdateTypeRequestBodyIcon = "calendar"
+	Clock      UpdateTypeRequestBodyIcon = "clock"
+	Cog        UpdateTypeRequestBodyIcon = "cog"
+	Components UpdateTypeRequestBodyIcon = "components"
+	Database   UpdateTypeRequestBodyIcon = "database"
+	Doc        UpdateTypeRequestBodyIcon = "doc"
+	Email      UpdateTypeRequestBodyIcon = "email"
+	Files      UpdateTypeRequestBodyIcon = "files"
+	Flag       UpdateTypeRequestBodyIcon = "flag"
+	Folder     UpdateTypeRequestBodyIcon = "folder"
+	Globe      UpdateTypeRequestBodyIcon = "globe"
+	Money      UpdateTypeRequestBodyIcon = "money"
+	Server     UpdateTypeRequestBodyIcon = "server"
+	Severity   UpdateTypeRequestBodyIcon = "severity"
+	Star       UpdateTypeRequestBodyIcon = "star"
+	Store      UpdateTypeRequestBodyIcon = "store"
+	Tag        UpdateTypeRequestBodyIcon = "tag"
+	User       UpdateTypeRequestBodyIcon = "user"
+	Users      UpdateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for UserV1Role.
@@ -336,11 +481,20 @@ const (
 	UserV1RoleViewer        UserV1Role = "viewer"
 )
 
+// Defines values for UserWithRolesV2Role.
+const (
+	Administrator UserWithRolesV2Role = "administrator"
+	Owner         UserWithRolesV2Role = "owner"
+	Responder     UserWithRolesV2Role = "responder"
+	Unset         UserWithRolesV2Role = "unset"
+	Viewer        UserWithRolesV2Role = "viewer"
+)
+
 // Defines values for ActionsV1ListParamsIncidentMode.
 const (
-	Real     ActionsV1ListParamsIncidentMode = "real"
-	Test     ActionsV1ListParamsIncidentMode = "test"
-	Tutorial ActionsV1ListParamsIncidentMode = "tutorial"
+	ActionsV1ListParamsIncidentModeReal     ActionsV1ListParamsIncidentMode = "real"
+	ActionsV1ListParamsIncidentModeTest     ActionsV1ListParamsIncidentMode = "test"
+	ActionsV1ListParamsIncidentModeTutorial ActionsV1ListParamsIncidentMode = "tutorial"
 )
 
 // Defines values for IncidentAttachmentsV1ListParamsResourceType.
@@ -348,11 +502,30 @@ const (
 	AtlassianStatuspageIncident IncidentAttachmentsV1ListParamsResourceType = "atlassian_statuspage_incident"
 	DatadogMonitorAlert         IncidentAttachmentsV1ListParamsResourceType = "datadog_monitor_alert"
 	GithubPullRequest           IncidentAttachmentsV1ListParamsResourceType = "github_pull_request"
+	GitlabMergeRequest          IncidentAttachmentsV1ListParamsResourceType = "gitlab_merge_request"
+	GoogleCalendarEvent         IncidentAttachmentsV1ListParamsResourceType = "google_calendar_event"
 	OpsgenieAlert               IncidentAttachmentsV1ListParamsResourceType = "opsgenie_alert"
 	PagerDutyIncident           IncidentAttachmentsV1ListParamsResourceType = "pager_duty_incident"
+	Scrubbed                    IncidentAttachmentsV1ListParamsResourceType = "scrubbed"
 	SentryIssue                 IncidentAttachmentsV1ListParamsResourceType = "sentry_issue"
 	StatuspageIncident          IncidentAttachmentsV1ListParamsResourceType = "statuspage_incident"
 	ZendeskTicket               IncidentAttachmentsV1ListParamsResourceType = "zendesk_ticket"
+)
+
+// Defines values for ActionsV2ListParamsIncidentMode.
+const (
+	ActionsV2ListParamsIncidentModeRetrospective ActionsV2ListParamsIncidentMode = "retrospective"
+	ActionsV2ListParamsIncidentModeStandard      ActionsV2ListParamsIncidentMode = "standard"
+	ActionsV2ListParamsIncidentModeTest          ActionsV2ListParamsIncidentMode = "test"
+	ActionsV2ListParamsIncidentModeTutorial      ActionsV2ListParamsIncidentMode = "tutorial"
+)
+
+// Defines values for FollowUpsV2ListParamsIncidentMode.
+const (
+	Retrospective FollowUpsV2ListParamsIncidentMode = "retrospective"
+	Standard      FollowUpsV2ListParamsIncidentMode = "standard"
+	Test          FollowUpsV2ListParamsIncidentMode = "test"
+	Tutorial      FollowUpsV2ListParamsIncidentMode = "tutorial"
 )
 
 // APIKeyV2 defines model for APIKeyV2.
@@ -397,54 +570,46 @@ type ActionV1 struct {
 // ActionV1Status Status of the action
 type ActionV1Status string
 
+// ActionV2 defines model for ActionV2.
+type ActionV2 struct {
+	Assignee *UserV1 `json:"assignee,omitempty"`
+
+	// CompletedAt When the action was completed
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// CreatedAt When the action was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Description of the action
+	Description string `json:"description"`
+
+	// Id Unique identifier for the action
+	Id string `json:"id"`
+
+	// IncidentId Unique identifier of the incident the action belongs to
+	IncidentId string `json:"incident_id"`
+
+	// Status Status of the action
+	Status ActionV2Status `json:"status"`
+
+	// UpdatedAt When the action was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ActionV2Status Status of the action
+type ActionV2Status string
+
 // ActorV2 defines model for ActorV2.
 type ActorV2 struct {
 	ApiKey *APIKeyV2 `json:"api_key,omitempty"`
 	User   *UserV1   `json:"user,omitempty"`
 }
 
-// CatalogAttributeBindingPayloadV2 defines model for CatalogAttributeBindingPayloadV2.
-type CatalogAttributeBindingPayloadV2 struct {
-	// ArrayValue If set, this is the array value of the attribute
-	ArrayValue *[]CatalogAttributeValuePayloadV2 `json:"array_value,omitempty"`
-	Value      *CatalogAttributeValuePayloadV2   `json:"value,omitempty"`
-}
-
-// CatalogAttributeBindingV2 defines model for CatalogAttributeBindingV2.
-type CatalogAttributeBindingV2 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]CatalogAttributeValueV2 `json:"array_value,omitempty"`
-	Value      *CatalogAttributeValueV2   `json:"value,omitempty"`
-}
-
-// CatalogAttributeValuePayloadV2 defines model for CatalogAttributeValuePayloadV2.
-type CatalogAttributeValuePayloadV2 struct {
-	// Literal The literal value of this attribute
-	Literal *string `json:"literal,omitempty"`
-}
-
-// CatalogAttributeValueV2 defines model for CatalogAttributeValueV2.
-type CatalogAttributeValueV2 struct {
-	CatalogEntry *CatalogEntryReferenceV2 `json:"catalog_entry,omitempty"`
-
-	// ImageUrl If appropriate, URL to an image that can be displayed alongside the option
-	ImageUrl *string `json:"image_url,omitempty"`
-
-	// IsImageSlackIcon If true, the image_url is a Slack icon and should be displayed as such
-	IsImageSlackIcon *bool `json:"is_image_slack_icon,omitempty"`
-
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// SortKey Gives an indication of how to sort the options when displayed to the user
-	SortKey string `json:"sort_key"`
-}
-
 // CatalogEntryReferenceV2 defines model for CatalogEntryReferenceV2.
 type CatalogEntryReferenceV2 struct {
+	// ArchivedAt When this entry was archived
+	ArchivedAt *time.Time `json:"archived_at,omitempty"`
+
 	// CatalogEntryId ID of this catalog entry
 	CatalogEntryId string `json:"catalog_entry_id"`
 
@@ -460,8 +625,11 @@ type CatalogEntryV2 struct {
 	// Aliases Optional aliases that can be used to reference this entry
 	Aliases []string `json:"aliases"`
 
+	// ArchivedAt When this entry was archived
+	ArchivedAt *time.Time `json:"archived_at,omitempty"`
+
 	// AttributeValues Values of this entry
-	AttributeValues map[string]CatalogAttributeBindingV2 `json:"attribute_values"`
+	AttributeValues map[string]EngineParamBindingV2 `json:"attribute_values"`
 
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `json:"catalog_type_id"`
@@ -472,7 +640,7 @@ type CatalogEntryV2 struct {
 	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
 	ExternalId *string `json:"external_id,omitempty"`
 
-	// Id ID of this resource
+	// Id ID of this catalog entry
 	Id string `json:"id"`
 
 	// Name Name is the human readable name of this entry
@@ -511,8 +679,14 @@ type CatalogTypeAttributePayloadV2 struct {
 	// Array Whether this attribute is an array
 	Array bool `json:"array"`
 
+	// BacklinkAttribute The attribute to use (if this is a backlink)
+	BacklinkAttribute *string `json:"backlink_attribute,omitempty"`
+
 	// Id The ID of this attribute
 	Id *string `json:"id,omitempty"`
+
+	// Mode Controls how this attribute is modified
+	Mode *CatalogTypeAttributePayloadV2Mode `json:"mode,omitempty"`
 
 	// Name Unique name of this attribute
 	Name string `json:"name"`
@@ -520,14 +694,23 @@ type CatalogTypeAttributePayloadV2 struct {
 	// Type Catalog type name for this attribute
 	Type string `json:"type"`
 }
+
+// CatalogTypeAttributePayloadV2Mode Controls how this attribute is modified
+type CatalogTypeAttributePayloadV2Mode string
 
 // CatalogTypeAttributeV2 defines model for CatalogTypeAttributeV2.
 type CatalogTypeAttributeV2 struct {
 	// Array Whether this attribute is an array
 	Array bool `json:"array"`
 
+	// BacklinkAttribute The attribute to use (if this is a backlink)
+	BacklinkAttribute *string `json:"backlink_attribute,omitempty"`
+
 	// Id The ID of this attribute
 	Id string `json:"id"`
+
+	// Mode Controls how this attribute is modified
+	Mode CatalogTypeAttributeV2Mode `json:"mode"`
 
 	// Name Unique name of this attribute
 	Name string `json:"name"`
@@ -535,6 +718,9 @@ type CatalogTypeAttributeV2 struct {
 	// Type Catalog type name for this attribute
 	Type string `json:"type"`
 }
+
+// CatalogTypeAttributeV2Mode Controls how this attribute is modified
+type CatalogTypeAttributeV2Mode string
 
 // CatalogTypeSchemaV2 defines model for CatalogTypeSchemaV2.
 type CatalogTypeSchemaV2 struct {
@@ -559,20 +745,23 @@ type CatalogTypeV2 struct {
 	// Description Human readble description of this type
 	Description string `json:"description"`
 
+	// DynamicResourceParameter If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.
+	DynamicResourceParameter *string `json:"dynamic_resource_parameter,omitempty"`
+
 	// EstimatedCount If populated, gives an estimated count of entries for this type
 	EstimatedCount *int64 `json:"estimated_count,omitempty"`
-
-	// ExternalType The external resource this type is synced from, if any
-	ExternalType *string `json:"external_type,omitempty"`
 
 	// Icon Sets the display icon of this type in the dashboard
 	Icon CatalogTypeV2Icon `json:"icon"`
 
-	// Id ID of this resource
+	// Id ID of this catalog type
 	Id string `json:"id"`
 
 	// IsEditable Catalog types that are synced with external resources can't be edited
 	IsEditable bool `json:"is_editable"`
+
+	// LastSyncedAt When this type was last synced (if it's ever been sync'd)
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
 
 	// Name Name is the human readable name of this type
 	Name string `json:"name"`
@@ -580,11 +769,14 @@ type CatalogTypeV2 struct {
 	// Ranked If this type should be ranked
 	Ranked bool `json:"ranked"`
 
+	// RegistryType The registry resource this type is synced from, if any
+	RegistryType *string `json:"registry_type,omitempty"`
+
 	// RequiredIntegrations If populated, the integrations required for this type
 	RequiredIntegrations *[]string           `json:"required_integrations,omitempty"`
 	Schema               CatalogTypeSchemaV2 `json:"schema"`
 
-	// SemanticType Semantic type of this resource
+	// SemanticType Semantic type of this resource (unused)
 	SemanticType string `json:"semantic_type"`
 
 	// SourceRepoUrl The url of the external repository where this type is managed
@@ -609,7 +801,7 @@ type CreateEntryRequestBody struct {
 	Aliases *[]string `json:"aliases,omitempty"`
 
 	// AttributeValues Values of this entry
-	AttributeValues map[string]CatalogAttributeBindingPayloadV2 `json:"attribute_values"`
+	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
 
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `json:"catalog_type_id"`
@@ -629,6 +821,51 @@ type CreateEntryResponseBody struct {
 	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
 }
 
+// CreateHTTPRequestBody defines model for CreateHTTPRequestBody.
+type CreateHTTPRequestBody struct {
+	// DeduplicationKey A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.
+	DeduplicationKey *string `json:"deduplication_key,omitempty"`
+
+	// Description Description that optionally adds more detail to title
+	Description *string `json:"description,omitempty"`
+
+	// Metadata Any additional metadata that you've configured your alert source to parse
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// SourceUrl If applicable, a link to the alert in the upstream system
+	SourceUrl *string `json:"source_url,omitempty"`
+
+	// Status Current status of this alert
+	Status CreateHTTPRequestBodyStatus `json:"status"`
+
+	// Title Alert title which is used when summarising the alert
+	Title string `json:"title"`
+}
+
+// CreateHTTPRequestBodyStatus Current status of this alert
+type CreateHTTPRequestBodyStatus string
+
+// CreateHTTPResponseBody defines model for CreateHTTPResponseBody.
+type CreateHTTPResponseBody struct {
+	// DeduplicationKey The deduplication key that the event has been processed with
+	DeduplicationKey CreateHTTPResponseBodyDeduplicationKey `json:"deduplication_key"`
+
+	// Message Human readable message giving detail about the event
+	Message CreateHTTPResponseBodyMessage `json:"message"`
+
+	// Status Status of the event
+	Status CreateHTTPResponseBodyStatus `json:"status"`
+}
+
+// CreateHTTPResponseBodyDeduplicationKey The deduplication key that the event has been processed with
+type CreateHTTPResponseBodyDeduplicationKey string
+
+// CreateHTTPResponseBodyMessage Human readable message giving detail about the event
+type CreateHTTPResponseBodyMessage string
+
+// CreateHTTPResponseBodyStatus Status of the event
+type CreateHTTPResponseBodyStatus string
+
 // CreateRequestBody defines model for CreateRequestBody.
 type CreateRequestBody struct {
 	// CustomFieldId ID of the custom field this option belongs to
@@ -641,141 +878,8 @@ type CreateRequestBody struct {
 	Value string `json:"value"`
 }
 
-// CreateRequestBody2 defines model for CreateRequestBody2.
-type CreateRequestBody2 struct {
-	// Description Description of the custom field
-	Description string `json:"description"`
-
-	// FieldType Type of custom field
-	FieldType CreateRequestBody2FieldType `json:"field_type"`
-
-	// Name Human readable name for the custom field
-	Name string `json:"name"`
-
-	// Required When this custom field must be set during the incident lifecycle.
-	Required CreateRequestBody2Required `json:"required"`
-
-	// ShowBeforeClosure Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.
-	ShowBeforeClosure bool `json:"show_before_closure"`
-
-	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
-	ShowBeforeCreation bool `json:"show_before_creation"`
-
-	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
-	ShowBeforeUpdate bool `json:"show_before_update"`
-
-	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
-	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
-}
-
-// CreateRequestBody2FieldType Type of custom field
-type CreateRequestBody2FieldType string
-
-// CreateRequestBody2Required When this custom field must be set during the incident lifecycle.
-type CreateRequestBody2Required string
-
-// CreateRequestBody3 defines model for CreateRequestBody3.
-type CreateRequestBody3 struct {
-	// IncidentId ID of the incident to add an attachment to
-	IncidentId string `json:"incident_id"`
-	Resource   struct {
-		// ExternalId ID of the resource in the external system
-		ExternalId string `json:"external_id"`
-
-		// ResourceType E.g. PagerDuty: the external system that holds the resource
-		ResourceType CreateRequestBody3ResourceResourceType `json:"resource_type"`
-	} `json:"resource"`
-}
-
-// CreateRequestBody3ResourceResourceType E.g. PagerDuty: the external system that holds the resource
-type CreateRequestBody3ResourceResourceType string
-
-// CreateRequestBody4 defines model for CreateRequestBody4.
-type CreateRequestBody4 struct {
-	// Description Describes the purpose of the role
-	Description string `json:"description"`
-
-	// Instructions Provided to whoever is nominated for the role
-	Instructions string `json:"instructions"`
-
-	// Name Human readable name of the incident role
-	Name string `json:"name"`
-
-	// Required Whether incident require this role to be set
-	Required bool `json:"required"`
-
-	// Shortform Short human readable name for Slack
-	Shortform string `json:"shortform"`
-}
-
-// CreateRequestBody5 defines model for CreateRequestBody5.
-type CreateRequestBody5 struct {
-	// Category Whether the status should be considered 'live' or 'closed'. The triage and declined statuses cannot be created or modified.
-	Category CreateRequestBody5Category `json:"category"`
-
-	// Description Rich text description of the incident status
-	Description string `json:"description"`
-
-	// Name Unique name of this status
-	Name string `json:"name"`
-}
-
-// CreateRequestBody5Category Whether the status should be considered 'live' or 'closed'. The triage and declined statuses cannot be created or modified.
-type CreateRequestBody5Category string
-
-// CreateRequestBody6 defines model for CreateRequestBody6.
-type CreateRequestBody6 struct {
-	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
-
-	// IdempotencyKey Unique string used to de-duplicate incident create requests
-	IdempotencyKey string `json:"idempotency_key"`
-
-	// IncidentRoleAssignments Assign incident roles to these people
-	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
-
-	// IncidentTypeId Incident type to create this incident as
-	IncidentTypeId *string `json:"incident_type_id,omitempty"`
-
-	// Mode Whether the incident is real or test
-	Mode *CreateRequestBody6Mode `json:"mode,omitempty"`
-
-	// Name Explanation of the incident
-	Name *string `json:"name,omitempty"`
-
-	// SeverityId Severity to create incident as
-	SeverityId *string `json:"severity_id,omitempty"`
-
-	// SlackTeamId ID of the Slack team / workspace
-	SlackTeamId *string `json:"slack_team_id,omitempty"`
-
-	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
-	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
-
-	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
-	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
-
-	// Status Current status of the incident
-	Status *CreateRequestBody6Status `json:"status,omitempty"`
-
-	// Summary Detailed description of the incident
-	Summary *string `json:"summary,omitempty"`
-
-	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody6Visibility `json:"visibility"`
-}
-
-// CreateRequestBody6Mode Whether the incident is real or test
-type CreateRequestBody6Mode string
-
-// CreateRequestBody6Status Current status of the incident
-type CreateRequestBody6Status string
-
-// CreateRequestBody6Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody6Visibility string
-
-// CreateRequestBody7 defines model for CreateRequestBody7.
-type CreateRequestBody7 struct {
+// CreateRequestBody10 defines model for CreateRequestBody10.
+type CreateRequestBody10 struct {
 	// CustomFieldEntries Set the incident's custom fields to these values
 	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
 
@@ -798,7 +902,7 @@ type CreateRequestBody7 struct {
 	IncidentTypeId *string `json:"incident_type_id,omitempty"`
 
 	// Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-	Mode *CreateRequestBody7Mode `json:"mode,omitempty"`
+	Mode *CreateRequestBody10Mode `json:"mode,omitempty"`
 
 	// Name Explanation of the incident
 	Name                         *string                         `json:"name,omitempty"`
@@ -807,6 +911,9 @@ type CreateRequestBody7 struct {
 	// SeverityId Severity to create incident as
 	SeverityId *string `json:"severity_id,omitempty"`
 
+	// SlackChannelNameOverride Name of the Slack channel to create for this incident
+	SlackChannelNameOverride *string `json:"slack_channel_name_override,omitempty"`
+
 	// SlackTeamId Slack Team to create the incident in
 	SlackTeamId *string `json:"slack_team_id,omitempty"`
 
@@ -814,17 +921,17 @@ type CreateRequestBody7 struct {
 	Summary *string `json:"summary,omitempty"`
 
 	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody7Visibility `json:"visibility"`
+	Visibility CreateRequestBody10Visibility `json:"visibility"`
 }
 
-// CreateRequestBody7Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-type CreateRequestBody7Mode string
+// CreateRequestBody10Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+type CreateRequestBody10Mode string
 
-// CreateRequestBody7Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody7Visibility string
+// CreateRequestBody10Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type CreateRequestBody10Visibility string
 
-// CreateRequestBody8 defines model for CreateRequestBody8.
-type CreateRequestBody8 struct {
+// CreateRequestBody11 defines model for CreateRequestBody11.
+type CreateRequestBody11 struct {
 	// Description Description of the severity
 	Description string `json:"description"`
 
@@ -835,9 +942,189 @@ type CreateRequestBody8 struct {
 	Rank *int64 `json:"rank,omitempty"`
 }
 
+// CreateRequestBody2 defines model for CreateRequestBody2.
+type CreateRequestBody2 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CreateRequestBody2FieldType `json:"field_type"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+
+	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+	Required *CreateRequestBody2Required `json:"required,omitempty"`
+
+	// RequiredV2 When this custom field must be set during the incident lifecycle.
+	RequiredV2 *CreateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
+
+	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
+	ShowBeforeClosure bool `json:"show_before_closure"`
+
+	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
+	ShowBeforeCreation bool `json:"show_before_creation"`
+
+	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
+	ShowBeforeUpdate bool `json:"show_before_update"`
+
+	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
+	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
+}
+
+// CreateRequestBody2FieldType Type of custom field
+type CreateRequestBody2FieldType string
+
+// CreateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type CreateRequestBody2Required string
+
+// CreateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
+type CreateRequestBody2RequiredV2 string
+
+// CreateRequestBody3 defines model for CreateRequestBody3.
+type CreateRequestBody3 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CreateRequestBody3FieldType `json:"field_type"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+}
+
+// CreateRequestBody3FieldType Type of custom field
+type CreateRequestBody3FieldType string
+
+// CreateRequestBody4 defines model for CreateRequestBody4.
+type CreateRequestBody4 struct {
+	// IncidentId ID of the incident to add an attachment to
+	IncidentId string `json:"incident_id"`
+	Resource   struct {
+		// ExternalId ID of the resource in the external system
+		ExternalId string `json:"external_id"`
+
+		// ResourceType E.g. PagerDuty: the external system that holds the resource
+		ResourceType CreateRequestBody4ResourceResourceType `json:"resource_type"`
+	} `json:"resource"`
+}
+
+// CreateRequestBody4ResourceResourceType E.g. PagerDuty: the external system that holds the resource
+type CreateRequestBody4ResourceResourceType string
+
+// CreateRequestBody5 defines model for CreateRequestBody5.
+type CreateRequestBody5 struct {
+	IncidentId string `json:"incident_id"`
+	UserId     string `json:"user_id"`
+}
+
+// CreateRequestBody6 defines model for CreateRequestBody6.
+type CreateRequestBody6 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Required DEPRECATED: this will always be false.
+	Required bool `json:"required"`
+
+	// Shortform Short human readable name for Slack
+	Shortform string `json:"shortform"`
+}
+
+// CreateRequestBody7 defines model for CreateRequestBody7.
+type CreateRequestBody7 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Shortform Short human readable name for Slack
+	Shortform string `json:"shortform"`
+}
+
+// CreateRequestBody8 defines model for CreateRequestBody8.
+type CreateRequestBody8 struct {
+	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+	Category CreateRequestBody8Category `json:"category"`
+
+	// Description Rich text description of the incident status
+	Description string `json:"description"`
+
+	// Name Unique name of this status
+	Name string `json:"name"`
+}
+
+// CreateRequestBody8Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+type CreateRequestBody8Category string
+
+// CreateRequestBody9 defines model for CreateRequestBody9.
+type CreateRequestBody9 struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IdempotencyKey Unique string used to de-duplicate incident create requests
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentTypeId Incident type to create this incident as
+	IncidentTypeId *string `json:"incident_type_id,omitempty"`
+
+	// Mode Whether the incident is real or test
+	Mode *CreateRequestBody9Mode `json:"mode,omitempty"`
+
+	// Name Explanation of the incident
+	Name *string `json:"name,omitempty"`
+
+	// SeverityId Severity to create incident as
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+	SlackTeamId *string `json:"slack_team_id,omitempty"`
+
+	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
+	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
+
+	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
+	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
+
+	// Status Current status of the incident
+	Status *CreateRequestBody9Status `json:"status,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
+
+	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+	Visibility CreateRequestBody9Visibility `json:"visibility"`
+}
+
+// CreateRequestBody9Mode Whether the incident is real or test
+type CreateRequestBody9Mode string
+
+// CreateRequestBody9Status Current status of the incident
+type CreateRequestBody9Status string
+
+// CreateRequestBody9Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type CreateRequestBody9Visibility string
+
 // CreateResponseBody defines model for CreateResponseBody.
 type CreateResponseBody struct {
 	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
+}
+
+// CreateResponseBody2 defines model for CreateResponseBody2.
+type CreateResponseBody2 struct {
+	IncidentMembership IncidentMembership `json:"incident_membership"`
 }
 
 // CreateTypeRequestBody defines model for CreateTypeRequestBody.
@@ -859,9 +1146,6 @@ type CreateTypeRequestBody struct {
 
 	// Ranked If this type should be ranked
 	Ranked *bool `json:"ranked,omitempty"`
-
-	// SemanticType Semantic type of this resource
-	SemanticType *string `json:"semantic_type,omitempty"`
 
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
@@ -886,7 +1170,7 @@ type CustomFieldEntryPayloadV1 struct {
 	// CustomFieldId ID of the custom field this entry is linked against
 	CustomFieldId string `json:"custom_field_id"`
 
-	// Values List of values to associate with this entry
+	// Values List of values to associate with this entry. Use an empty array to unset the value of the custom field.
 	Values []CustomFieldValuePayloadV1 `json:"values"`
 }
 
@@ -936,6 +1220,9 @@ type CustomFieldTypeInfoV1FieldType string
 
 // CustomFieldV1 defines model for CustomFieldV1.
 type CustomFieldV1 struct {
+	// CatalogTypeId For catalog fields, the ID of the associated catalog type
+	CatalogTypeId *string `json:"catalog_type_id,omitempty"`
+
 	// CreatedAt When the action was created
 	CreatedAt time.Time `json:"created_at"`
 
@@ -954,10 +1241,13 @@ type CustomFieldV1 struct {
 	// Options What options are available for this custom field, if this field has options
 	Options []CustomFieldOptionV1 `json:"options"`
 
-	// Required When this custom field must be set during the incident lifecycle.
-	Required CustomFieldV1Required `json:"required"`
+	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+	Required *CustomFieldV1Required `json:"required,omitempty"`
 
-	// ShowBeforeClosure Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.
+	// RequiredV2 When this custom field must be set during the incident lifecycle.
+	RequiredV2 *CustomFieldV1RequiredV2 `json:"required_v2,omitempty"`
+
+	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
 	ShowBeforeClosure bool `json:"show_before_closure"`
 
 	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
@@ -976,13 +1266,46 @@ type CustomFieldV1 struct {
 // CustomFieldV1FieldType Type of custom field
 type CustomFieldV1FieldType string
 
-// CustomFieldV1Required When this custom field must be set during the incident lifecycle.
+// CustomFieldV1Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
 type CustomFieldV1Required string
+
+// CustomFieldV1RequiredV2 When this custom field must be set during the incident lifecycle.
+type CustomFieldV1RequiredV2 string
+
+// CustomFieldV2 defines model for CustomFieldV2.
+type CustomFieldV2 struct {
+	// CatalogTypeId For catalog fields, the ID of the associated catalog type
+	CatalogTypeId *string `json:"catalog_type_id,omitempty"`
+
+	// CreatedAt When the action was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CustomFieldV2FieldType `json:"field_type"`
+
+	// Id Unique identifier for the custom field
+	Id string `json:"id"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+
+	// UpdatedAt When the action was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// CustomFieldV2FieldType Type of custom field
+type CustomFieldV2FieldType string
 
 // CustomFieldValuePayloadV1 defines model for CustomFieldValuePayloadV1.
 type CustomFieldValuePayloadV1 struct {
 	// Id Unique identifier for the custom field value
 	Id *string `json:"id,omitempty"`
+
+	// ValueCatalogEntryId ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.
+	ValueCatalogEntryId *string `json:"value_catalog_entry_id,omitempty"`
 
 	// ValueLink If the custom field type is 'link', this will contain the value assigned.
 	ValueLink *string `json:"value_link,omitempty"`
@@ -1002,6 +1325,8 @@ type CustomFieldValuePayloadV1 struct {
 
 // CustomFieldValueV1 defines model for CustomFieldValueV1.
 type CustomFieldValueV1 struct {
+	ValueCatalogEntry *EmbeddedCatalogEntryV1 `json:"value_catalog_entry,omitempty"`
+
 	// ValueLink If the custom field type is 'link', this will contain the value assigned.
 	ValueLink *string `json:"value_link,omitempty"`
 
@@ -1019,6 +1344,76 @@ type EditRequestBody struct {
 
 	// NotifyIncidentChannel Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.
 	NotifyIncidentChannel bool `json:"notify_incident_channel"`
+}
+
+// EmbeddedCatalogEntryV1 defines model for EmbeddedCatalogEntryV1.
+type EmbeddedCatalogEntryV1 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Id ID of this catalog entry
+	Id string `json:"id"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+}
+
+// EngineParamBindingPayloadV2 defines model for EngineParamBindingPayloadV2.
+type EngineParamBindingPayloadV2 struct {
+	// ArrayValue If set, this is the array value of the step parameter
+	ArrayValue *[]EngineParamBindingValuePayloadV2 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValuePayloadV2   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV2 defines model for EngineParamBindingV2.
+type EngineParamBindingV2 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV2 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV2   `json:"value,omitempty"`
+}
+
+// EngineParamBindingValuePayloadV2 defines model for EngineParamBindingValuePayloadV2.
+type EngineParamBindingValuePayloadV2 struct {
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV2 defines model for EngineParamBindingValueV2.
+type EngineParamBindingValueV2 struct {
+	CatalogEntry *CatalogEntryReferenceV2 `json:"catalog_entry,omitempty"`
+
+	// Helptext Gives a description of the option to the user
+	Helptext *string `json:"helptext,omitempty"`
+
+	// ImageUrl If appropriate, URL to an image that can be displayed alongside the option
+	ImageUrl *string `json:"image_url,omitempty"`
+
+	// IsImageSlackIcon If true, the image_url is a Slack icon and should be displayed as such
+	IsImageSlackIcon *bool `json:"is_image_slack_icon,omitempty"`
+
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+
+	// SortKey Gives an indication of how to sort the options when displayed to the user
+	SortKey string `json:"sort_key"`
+
+	// Unavailable Unavailable is true if we've failed to build the value for this binding
+	Unavailable *bool `json:"unavailable,omitempty"`
+
+	// Value Either the reference or the literal: this field is designed purely to make working with react-select easier
+	Value *string `json:"value,omitempty"`
 }
 
 // ExternalIssueReferenceV1 defines model for ExternalIssueReferenceV1.
@@ -1069,6 +1464,55 @@ type ExternalResourceV1 struct {
 // ExternalResourceV1ResourceType E.g. PagerDuty: the external system that holds the resource
 type ExternalResourceV1ResourceType string
 
+// FollowUpPriorityV2 defines model for FollowUpPriorityV2.
+type FollowUpPriorityV2 struct {
+	// Description Description of the follow-up priority option
+	Description *string `json:"description,omitempty"`
+
+	// Id Unique identifier for the follow-up priority option
+	Id string `json:"id"`
+
+	// Name Name of the follow-up priority option
+	Name string `json:"name"`
+
+	// Rank Rank is used to order the follow-up priority options correctly
+	Rank int64 `json:"rank"`
+}
+
+// FollowUpV2 defines model for FollowUpV2.
+type FollowUpV2 struct {
+	Assignee *UserV1 `json:"assignee,omitempty"`
+
+	// CompletedAt When the follow-up was completed
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// CreatedAt When the follow-up was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Description of the follow-up
+	Description            *string                   `json:"description,omitempty"`
+	ExternalIssueReference *ExternalIssueReferenceV2 `json:"external_issue_reference,omitempty"`
+
+	// Id Unique identifier for the follow-up
+	Id string `json:"id"`
+
+	// IncidentId Unique identifier of the incident the follow-up belongs to
+	IncidentId string              `json:"incident_id"`
+	Priority   *FollowUpPriorityV2 `json:"priority,omitempty"`
+
+	// Status Status of the follow-up
+	Status FollowUpV2Status `json:"status"`
+
+	// Title Title of the follow-up
+	Title string `json:"title"`
+
+	// UpdatedAt When the follow-up was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// FollowUpV2Status Status of the follow-up
+type FollowUpV2Status string
+
 // IdentityResponseBody defines model for IdentityResponseBody.
 type IdentityResponseBody struct {
 	Identity IdentityV1 `json:"identity"`
@@ -1076,6 +1520,9 @@ type IdentityResponseBody struct {
 
 // IdentityV1 defines model for IdentityV1.
 type IdentityV1 struct {
+	// DashboardUrl The dashboard URL for this organisation
+	DashboardUrl string `json:"dashboard_url"`
+
 	// Name The name assigned to the current API Key
 	Name string `json:"name"`
 
@@ -1096,10 +1543,36 @@ type IncidentAttachmentV1 struct {
 	Resource   ExternalResourceV1 `json:"resource"`
 }
 
+// IncidentDurationMetricV2 defines model for IncidentDurationMetricV2.
+type IncidentDurationMetricV2 struct {
+	// Id Unique ID of this incident duration metric
+	Id string `json:"id"`
+
+	// Name Unique name of this duration metric
+	Name string `json:"name"`
+}
+
+// IncidentDurationMetricWithValueV2 defines model for IncidentDurationMetricWithValueV2.
+type IncidentDurationMetricWithValueV2 struct {
+	DurationMetric IncidentDurationMetricV2 `json:"duration_metric"`
+
+	// ValueSeconds The calculated durations for this metric
+	ValueSeconds *int64 `json:"value_seconds,omitempty"`
+}
+
 // IncidentEditPayloadV2 defines model for IncidentEditPayloadV2.
 type IncidentEditPayloadV2 struct {
+	// CallUrl The call URL attached to this incident
+	CallUrl *string `json:"call_url,omitempty"`
+
 	// CustomFieldEntries Set the incident's custom fields to these values
 	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV2 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentStatusId Incident status to change incident to (you can only change an incident from one active status to another, any other lifecycle changes must be taken via the app.)
+	IncidentStatusId *string `json:"incident_status_id,omitempty"`
 
 	// IncidentTimestampValues Assign the incident's timestamps to these values
 	IncidentTimestampValues *[]IncidentTimestampValuePayloadV2 `json:"incident_timestamp_values,omitempty"`
@@ -1112,6 +1585,22 @@ type IncidentEditPayloadV2 struct {
 
 	// Summary Detailed description of the incident
 	Summary *string `json:"summary,omitempty"`
+}
+
+// IncidentMembership defines model for IncidentMembership.
+type IncidentMembership struct {
+	// CreatedAt When the membership was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Id Unique identifier of this incident membership
+	Id string `json:"id"`
+
+	// IncidentId Unique identifier of the incident
+	IncidentId string `json:"incident_id"`
+
+	// UpdatedAt When the membership was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+	User      UserV1    `json:"user"`
 }
 
 // IncidentRoleAssignmentPayloadV1 defines model for IncidentRoleAssignmentPayloadV1.
@@ -1153,8 +1642,8 @@ type IncidentRoleV1 struct {
 	// Name Human readable name of the incident role
 	Name string `json:"name"`
 
-	// Required Whether incident require this role to be set
-	Required bool `json:"required"`
+	// Required DEPRECATED: this will always be false.
+	Required *bool `json:"required,omitempty"`
 
 	// RoleType Type of incident role
 	RoleType IncidentRoleV1RoleType `json:"role_type"`
@@ -1169,9 +1658,39 @@ type IncidentRoleV1 struct {
 // IncidentRoleV1RoleType Type of incident role
 type IncidentRoleV1RoleType string
 
+// IncidentRoleV2 defines model for IncidentRoleV2.
+type IncidentRoleV2 struct {
+	// CreatedAt When the action was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Id Unique identifier for the role
+	Id string `json:"id"`
+
+	// Instructions Provided to whoever is nominated for the role
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// RoleType Type of incident role
+	RoleType IncidentRoleV2RoleType `json:"role_type"`
+
+	// Shortform Short human readable name for Slack
+	Shortform string `json:"shortform"`
+
+	// UpdatedAt When the action was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// IncidentRoleV2RoleType Type of incident role
+type IncidentRoleV2RoleType string
+
 // IncidentStatusV1 defines model for IncidentStatusV1.
 type IncidentStatusV1 struct {
-	// Category Whether this status is a live or closed status. If you have enabled auto-create, there will also be 'triage' and 'declined' statuses, which cannot be modified.
+	// Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
 	Category  IncidentStatusV1Category `json:"category"`
 	CreatedAt time.Time                `json:"created_at"`
 
@@ -1189,7 +1708,7 @@ type IncidentStatusV1 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// IncidentStatusV1Category Whether this status is a live or closed status. If you have enabled auto-create, there will also be 'triage' and 'declined' statuses, which cannot be modified.
+// IncidentStatusV1Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
 type IncidentStatusV1Category string
 
 // IncidentTimestampV1 defines model for IncidentTimestampV1.
@@ -1323,7 +1842,7 @@ type IncidentV1 struct {
 	// SlackChannelName Name of the slack channel
 	SlackChannelName *string `json:"slack_channel_name,omitempty"`
 
-	// SlackTeamId ID of the Slack team / workspace
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
 	SlackTeamId string `json:"slack_team_id"`
 
 	// Status Current status of the incident
@@ -1361,8 +1880,11 @@ type IncidentV2 struct {
 	Creator   ActorV2   `json:"creator"`
 
 	// CustomFieldEntries Custom field entries for this incident
-	CustomFieldEntries     []CustomFieldEntryV1      `json:"custom_field_entries"`
-	ExternalIssueReference *ExternalIssueReferenceV2 `json:"external_issue_reference,omitempty"`
+	CustomFieldEntries []CustomFieldEntryV1 `json:"custom_field_entries"`
+
+	// DurationMetrics Incident duration metrics and their measurements for this incident
+	DurationMetrics        *[]IncidentDurationMetricWithValueV2 `json:"duration_metrics,omitempty"`
+	ExternalIssueReference *ExternalIssueReferenceV2            `json:"external_issue_reference,omitempty"`
 
 	// Id Unique identifier for the incident
 	Id string `json:"id"`
@@ -1397,7 +1919,7 @@ type IncidentV2 struct {
 	// SlackChannelName Name of the slack channel
 	SlackChannelName *string `json:"slack_channel_name,omitempty"`
 
-	// SlackTeamId ID of the Slack team / workspace
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
 	SlackTeamId string `json:"slack_team_id"`
 
 	// Summary Detailed description of the incident
@@ -1408,6 +1930,18 @@ type IncidentV2 struct {
 
 	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
 	Visibility IncidentV2Visibility `json:"visibility"`
+
+	// WorkloadMinutesLate Amount of time spent on the incident in late hours
+	WorkloadMinutesLate *float64 `json:"workload_minutes_late,omitempty"`
+
+	// WorkloadMinutesSleeping Amount of time spent on the incident in sleeping hours
+	WorkloadMinutesSleeping *float64 `json:"workload_minutes_sleeping,omitempty"`
+
+	// WorkloadMinutesTotal Amount of time spent on the incident in total
+	WorkloadMinutesTotal *float64 `json:"workload_minutes_total,omitempty"`
+
+	// WorkloadMinutesWorking Amount of time spent on the incident in working hours
+	WorkloadMinutesWorking *float64 `json:"workload_minutes_working,omitempty"`
 }
 
 // IncidentV2Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
@@ -1435,60 +1969,87 @@ type ListResponseBody struct {
 
 // ListResponseBody10 defines model for ListResponseBody10.
 type ListResponseBody10 struct {
-	Incidents      []IncidentV1                   `json:"incidents"`
-	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
 }
 
 // ListResponseBody11 defines model for ListResponseBody11.
 type ListResponseBody11 struct {
-	Incidents      []IncidentV2                   `json:"incidents"`
-	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
 }
 
 // ListResponseBody12 defines model for ListResponseBody12.
 type ListResponseBody12 struct {
+	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
+}
+
+// ListResponseBody13 defines model for ListResponseBody13.
+type ListResponseBody13 struct {
+	IncidentUpdates []IncidentUpdateV2    `json:"incident_updates"`
+	PaginationMeta  *PaginationMetaResult `json:"pagination_meta,omitempty"`
+}
+
+// ListResponseBody14 defines model for ListResponseBody14.
+type ListResponseBody14 struct {
+	Incidents      []IncidentV1                   `json:"incidents"`
+	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+}
+
+// ListResponseBody15 defines model for ListResponseBody15.
+type ListResponseBody15 struct {
+	Incidents      []IncidentV2                   `json:"incidents"`
+	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+}
+
+// ListResponseBody16 defines model for ListResponseBody16.
+type ListResponseBody16 struct {
 	Severities []SeverityV2 `json:"severities"`
+}
+
+// ListResponseBody17 defines model for ListResponseBody17.
+type ListResponseBody17 struct {
+	PaginationMeta PaginationMetaResult `json:"pagination_meta"`
+	Users          []UserWithRolesV2    `json:"users"`
 }
 
 // ListResponseBody2 defines model for ListResponseBody2.
 type ListResponseBody2 struct {
-	CustomFieldOptions []CustomFieldOptionV1 `json:"custom_field_options"`
+	Actions []ActionV2 `json:"actions"`
 }
 
 // ListResponseBody3 defines model for ListResponseBody3.
 type ListResponseBody3 struct {
-	CustomFields []CustomFieldV1 `json:"custom_fields"`
+	CustomFieldOptions []CustomFieldOptionV1 `json:"custom_field_options"`
+	PaginationMeta     PaginationMetaResult  `json:"pagination_meta"`
 }
 
 // ListResponseBody4 defines model for ListResponseBody4.
 type ListResponseBody4 struct {
-	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
+	CustomFields []CustomFieldV1 `json:"custom_fields"`
 }
 
 // ListResponseBody5 defines model for ListResponseBody5.
 type ListResponseBody5 struct {
-	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
+	CustomFields []CustomFieldV2 `json:"custom_fields"`
 }
 
 // ListResponseBody6 defines model for ListResponseBody6.
 type ListResponseBody6 struct {
-	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
+	FollowUps []FollowUpV2 `json:"follow_ups"`
 }
 
 // ListResponseBody7 defines model for ListResponseBody7.
 type ListResponseBody7 struct {
-	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
+	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
 }
 
 // ListResponseBody8 defines model for ListResponseBody8.
 type ListResponseBody8 struct {
-	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
+	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
 }
 
 // ListResponseBody9 defines model for ListResponseBody9.
 type ListResponseBody9 struct {
-	IncidentUpdates []IncidentUpdateV2    `json:"incident_updates"`
-	PaginationMeta  *PaginationMetaResult `json:"pagination_meta,omitempty"`
+	IncidentRoles []IncidentRoleV2 `json:"incident_roles"`
 }
 
 // ListTypesResponseBody defines model for ListTypesResponseBody.
@@ -1515,6 +2076,21 @@ type PaginationMetaResultWithTotal struct {
 
 	// TotalRecordCount How many matching records were there in total, if known
 	TotalRecordCount *int64 `json:"total_record_count,omitempty"`
+}
+
+// RBACRoleV2 defines model for RBACRoleV2.
+type RBACRoleV2 struct {
+	// Description Description of the purpose for the RBAC role
+	Description *string `json:"description,omitempty"`
+
+	// Id Unique identifier of the RBAC role
+	Id string `json:"id"`
+
+	// Name Name of the RBAC role
+	Name string `json:"name"`
+
+	// Slug Unique human-readable slug for the RBAC role
+	Slug string `json:"slug"`
 }
 
 // RetrospectiveIncidentOptionsV2 defines model for RetrospectiveIncidentOptionsV2.
@@ -1557,47 +2133,72 @@ type ShowResponseBody struct {
 
 // ShowResponseBody10 defines model for ShowResponseBody10.
 type ShowResponseBody10 struct {
+	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
+}
+
+// ShowResponseBody11 defines model for ShowResponseBody11.
+type ShowResponseBody11 struct {
+	IncidentType IncidentTypeV1 `json:"incident_type"`
+}
+
+// ShowResponseBody12 defines model for ShowResponseBody12.
+type ShowResponseBody12 struct {
+	Incident IncidentV1 `json:"incident"`
+}
+
+// ShowResponseBody13 defines model for ShowResponseBody13.
+type ShowResponseBody13 struct {
+	Incident IncidentV2 `json:"incident"`
+}
+
+// ShowResponseBody14 defines model for ShowResponseBody14.
+type ShowResponseBody14 struct {
 	Severity SeverityV2 `json:"severity"`
+}
+
+// ShowResponseBody15 defines model for ShowResponseBody15.
+type ShowResponseBody15 struct {
+	User UserWithRolesV2 `json:"user"`
 }
 
 // ShowResponseBody2 defines model for ShowResponseBody2.
 type ShowResponseBody2 struct {
-	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
+	Action ActionV2 `json:"action"`
 }
 
 // ShowResponseBody3 defines model for ShowResponseBody3.
 type ShowResponseBody3 struct {
-	CustomField CustomFieldV1 `json:"custom_field"`
+	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
 }
 
 // ShowResponseBody4 defines model for ShowResponseBody4.
 type ShowResponseBody4 struct {
-	IncidentRole IncidentRoleV1 `json:"incident_role"`
+	CustomField CustomFieldV1 `json:"custom_field"`
 }
 
 // ShowResponseBody5 defines model for ShowResponseBody5.
 type ShowResponseBody5 struct {
-	IncidentStatus IncidentStatusV1 `json:"incident_status"`
+	CustomField CustomFieldV2 `json:"custom_field"`
 }
 
 // ShowResponseBody6 defines model for ShowResponseBody6.
 type ShowResponseBody6 struct {
-	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
+	FollowUp FollowUpV2 `json:"follow_up"`
 }
 
 // ShowResponseBody7 defines model for ShowResponseBody7.
 type ShowResponseBody7 struct {
-	IncidentType IncidentTypeV1 `json:"incident_type"`
+	IncidentRole IncidentRoleV1 `json:"incident_role"`
 }
 
 // ShowResponseBody8 defines model for ShowResponseBody8.
 type ShowResponseBody8 struct {
-	Incident IncidentV1 `json:"incident"`
+	IncidentRole IncidentRoleV2 `json:"incident_role"`
 }
 
 // ShowResponseBody9 defines model for ShowResponseBody9.
 type ShowResponseBody9 struct {
-	Incident IncidentV2 `json:"incident"`
+	IncidentStatus IncidentStatusV1 `json:"incident_status"`
 }
 
 // UpdateEntryRequestBody defines model for UpdateEntryRequestBody.
@@ -1606,7 +2207,7 @@ type UpdateEntryRequestBody struct {
 	Aliases *[]string `json:"aliases,omitempty"`
 
 	// AttributeValues Values of this entry
-	AttributeValues map[string]CatalogAttributeBindingPayloadV2 `json:"attribute_values"`
+	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
 
 	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
 	ExternalId *string `json:"external_id,omitempty"`
@@ -1635,10 +2236,13 @@ type UpdateRequestBody2 struct {
 	// Name Human readable name for the custom field
 	Name string `json:"name"`
 
-	// Required When this custom field must be set during the incident lifecycle.
-	Required UpdateRequestBody2Required `json:"required"`
+	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+	Required *UpdateRequestBody2Required `json:"required,omitempty"`
 
-	// ShowBeforeClosure Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.
+	// RequiredV2 When this custom field must be set during the incident lifecycle.
+	RequiredV2 *UpdateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
+
+	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
 	ShowBeforeClosure bool `json:"show_before_closure"`
 
 	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
@@ -1651,11 +2255,23 @@ type UpdateRequestBody2 struct {
 	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
 }
 
-// UpdateRequestBody2Required When this custom field must be set during the incident lifecycle.
+// UpdateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
 type UpdateRequestBody2Required string
+
+// UpdateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
+type UpdateRequestBody2RequiredV2 string
 
 // UpdateRequestBody3 defines model for UpdateRequestBody3.
 type UpdateRequestBody3 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+}
+
+// UpdateRequestBody4 defines model for UpdateRequestBody4.
+type UpdateRequestBody4 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -1665,15 +2281,30 @@ type UpdateRequestBody3 struct {
 	// Name Human readable name of the incident role
 	Name string `json:"name"`
 
-	// Required Whether incident require this role to be set
-	Required bool `json:"required"`
+	// Required DEPRECATED: this will always be false.
+	Required *bool `json:"required,omitempty"`
 
 	// Shortform Short human readable name for Slack
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody4 defines model for UpdateRequestBody4.
-type UpdateRequestBody4 struct {
+// UpdateRequestBody5 defines model for UpdateRequestBody5.
+type UpdateRequestBody5 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Shortform Short human readable name for Slack
+	Shortform string `json:"shortform"`
+}
+
+// UpdateRequestBody6 defines model for UpdateRequestBody6.
+type UpdateRequestBody6 struct {
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
 
@@ -1700,9 +2331,6 @@ type UpdateTypeRequestBody struct {
 
 	// Ranked If this type should be ranked
 	Ranked *bool `json:"ranked,omitempty"`
-
-	// SemanticType Semantic type of this resource
-	SemanticType *string `json:"semantic_type,omitempty"`
 
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
@@ -1753,6 +2381,30 @@ type UserV1 struct {
 // UserV1Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
 type UserV1Role string
 
+// UserWithRolesV2 defines model for UserWithRolesV2.
+type UserWithRolesV2 struct {
+	BaseRole    RBACRoleV2   `json:"base_role"`
+	CustomRoles []RBACRoleV2 `json:"custom_roles"`
+
+	// Email Email address of the user.
+	Email *string `json:"email,omitempty"`
+
+	// Id Unique identifier of the user
+	Id string `json:"id"`
+
+	// Name Name of the user
+	Name string `json:"name"`
+
+	// Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
+	Role UserWithRolesV2Role `json:"role"`
+
+	// SlackUserId Slack ID of the user
+	SlackUserId *string `json:"slack_user_id,omitempty"`
+}
+
+// UserWithRolesV2Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
+type UserWithRolesV2Role string
+
 // ActionsV1ListParams defines parameters for ActionsV1List.
 type ActionsV1ListParams struct {
 	// IncidentId Find actions related to this incident
@@ -1798,7 +2450,7 @@ type IncidentAttachmentsV1ListParamsResourceType string
 // IncidentsV1ListParams defines parameters for IncidentsV1List.
 type IncidentsV1ListParams struct {
 	// PageSize Integer number of records to return
-	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
 
 	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
@@ -1807,17 +2459,47 @@ type IncidentsV1ListParams struct {
 	Status *[]string `form:"status,omitempty" json:"status,omitempty"`
 }
 
+// ActionsV2ListParams defines parameters for ActionsV2List.
+type ActionsV2ListParams struct {
+	// IncidentId Find actions related to this incident
+	IncidentId *string `form:"incident_id,omitempty" json:"incident_id,omitempty"`
+
+	// IncidentMode Filter to actions from incidents of the given mode. If not set, only actions from `standard` and `retrospective` incidents are returned
+	IncidentMode *ActionsV2ListParamsIncidentMode `form:"incident_mode,omitempty" json:"incident_mode,omitempty"`
+}
+
+// ActionsV2ListParamsIncidentMode defines parameters for ActionsV2List.
+type ActionsV2ListParamsIncidentMode string
+
+// AlertEventsV2CreateHTTPParams defines parameters for AlertEventsV2CreateHTTP.
+type AlertEventsV2CreateHTTPParams struct {
+	// Token Token used to authenticate the request, generated when configuring the alert source. Will be consumed via a URL query string parameter
+	Token *string `form:"token,omitempty" json:"token,omitempty"`
+}
+
 // CatalogV2ListEntriesParams defines parameters for CatalogV2ListEntries.
 type CatalogV2ListEntriesParams struct {
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `form:"catalog_type_id" json:"catalog_type_id"`
 
 	// PageSize Integer number of records to return
-	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
 
 	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
 }
+
+// FollowUpsV2ListParams defines parameters for FollowUpsV2List.
+type FollowUpsV2ListParams struct {
+	// IncidentId Find follow-ups related to this incident
+	IncidentId *string `form:"incident_id,omitempty" json:"incident_id,omitempty"`
+
+	// IncidentMode Filter to follow-ups from incidents of the given mode. If not set, only follow-ups from `standard` and `retrospective` incidents are returned
+	IncidentMode *FollowUpsV2ListParamsIncidentMode `form:"incident_mode,omitempty" json:"incident_mode,omitempty"`
+}
+
+// FollowUpsV2ListParamsIncidentMode defines parameters for FollowUpsV2List.
+type FollowUpsV2ListParamsIncidentMode string
 
 // IncidentUpdatesV2ListParams defines parameters for IncidentUpdatesV2List.
 type IncidentUpdatesV2ListParams struct {
@@ -1825,7 +2507,7 @@ type IncidentUpdatesV2ListParams struct {
 	IncidentId *string `form:"incident_id,omitempty" json:"incident_id,omitempty"`
 
 	// PageSize Integer number of records to return
-	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
 
 	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
@@ -1842,10 +2524,13 @@ type IncidentsV2ListParams struct {
 	// Status Filter on incident status. The accepted operators are 'one_of', or 'not_in'.
 	Status *map[string][]string `form:"status,omitempty" json:"status,omitempty"`
 
+	// StatusCategory Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{"one_of": ["triage", "active", "post-incident", "closed"] }`, meaning that canceled, declined and merged incidents are not included.
+	StatusCategory *map[string][]string `form:"status_category,omitempty" json:"status_category,omitempty"`
+
 	// Severity Filter on incident severity. The accepted operators are 'one_of', 'not_in', 'gte', 'lte'.
 	Severity *map[string][]string `form:"severity,omitempty" json:"severity,omitempty"`
 
-	// IncidentType Filter on incident type. The accepted operator is 'one_of'.
+	// IncidentType Filter on incident type. The accepted operators are 'one_of, or 'not_in'.
 	IncidentType *map[string][]string `form:"incident_type,omitempty" json:"incident_type,omitempty"`
 
 	// IncidentRole Filter on an incident role. Role ID should be sent, followed by the operator and values. The accepted operators are 'one_of', 'is_blank'.
@@ -1853,6 +2538,18 @@ type IncidentsV2ListParams struct {
 
 	// CustomField Filter on an incident custom field. Custom field ID should be sent, followed by the operator and values. Accepted operator will depend on the custom field type.
 	CustomField *map[string]map[string][]string `form:"custom_field,omitempty" json:"custom_field,omitempty"`
+
+	// Mode Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{"one_of": ["standard", "retrospective"] }`, meaning that test and tutorial incidents are not included.
+	Mode *map[string][]string `form:"mode,omitempty" json:"mode,omitempty"`
+}
+
+// UsersV2ListParams defines parameters for UsersV2List.
+type UsersV2ListParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
 }
 
 // CustomFieldOptionsV1CreateJSONRequestBody defines body for CustomFieldOptionsV1Create for application/json ContentType.
@@ -1868,28 +2565,37 @@ type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody2
 type CustomFieldsV1UpdateJSONRequestBody = UpdateRequestBody2
 
 // IncidentAttachmentsV1CreateJSONRequestBody defines body for IncidentAttachmentsV1Create for application/json ContentType.
-type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody3
+type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody4
+
+// IncidentMembershipsV1CreateJSONRequestBody defines body for IncidentMembershipsV1Create for application/json ContentType.
+type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody5
+
+// IncidentMembershipsV1RevokeJSONRequestBody defines body for IncidentMembershipsV1Revoke for application/json ContentType.
+type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody5
 
 // IncidentRolesV1CreateJSONRequestBody defines body for IncidentRolesV1Create for application/json ContentType.
-type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody4
+type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody6
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
-type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody3
+type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody4
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
-type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody5
+type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody8
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
-type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody4
+type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody6
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
-type IncidentsV1CreateJSONRequestBody = CreateRequestBody6
+type IncidentsV1CreateJSONRequestBody = CreateRequestBody9
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody8
+type SeveritiesV1CreateJSONRequestBody = CreateRequestBody11
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody8
+type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody11
+
+// AlertEventsV2CreateHTTPJSONRequestBody defines body for AlertEventsV2CreateHTTP for application/json ContentType.
+type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
 
 // CatalogV2CreateEntryJSONRequestBody defines body for CatalogV2CreateEntry for application/json ContentType.
 type CatalogV2CreateEntryJSONRequestBody = CreateEntryRequestBody
@@ -1906,8 +2612,20 @@ type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
 // CatalogV2UpdateTypeSchemaJSONRequestBody defines body for CatalogV2UpdateTypeSchema for application/json ContentType.
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
 
+// CustomFieldsV2CreateJSONRequestBody defines body for CustomFieldsV2Create for application/json ContentType.
+type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody3
+
+// CustomFieldsV2UpdateJSONRequestBody defines body for CustomFieldsV2Update for application/json ContentType.
+type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody3
+
+// IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
+type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody7
+
+// IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
+type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody5
+
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
-type IncidentsV2CreateJSONRequestBody = CreateRequestBody7
+type IncidentsV2CreateJSONRequestBody = CreateRequestBody10
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
 type IncidentsV2EditJSONRequestBody = EditRequestBody
@@ -2043,6 +2761,16 @@ type ClientInterface interface {
 	// IncidentAttachmentsV1Delete request
 	IncidentAttachmentsV1Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// IncidentMembershipsV1Create request with any body
+	IncidentMembershipsV1CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IncidentMembershipsV1Create(ctx context.Context, body IncidentMembershipsV1CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentMembershipsV1Revoke request with any body
+	IncidentMembershipsV1RevokeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IncidentMembershipsV1Revoke(ctx context.Context, body IncidentMembershipsV1RevokeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// IncidentRolesV1List request
 	IncidentRolesV1List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2101,6 +2829,9 @@ type ClientInterface interface {
 	// UtilitiesV1OpenAPI request
 	UtilitiesV1OpenAPI(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UtilitiesV1OpenAPIV3 request
+	UtilitiesV1OpenAPIV3(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// SeveritiesV1List request
 	SeveritiesV1List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2119,6 +2850,17 @@ type ClientInterface interface {
 	SeveritiesV1UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SeveritiesV1Update(ctx context.Context, id string, body SeveritiesV1UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ActionsV2List request
+	ActionsV2List(ctx context.Context, params *ActionsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ActionsV2Show request
+	ActionsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertEventsV2CreateHTTP request with any body
+	AlertEventsV2CreateHTTPWithBody(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AlertEventsV2CreateHTTP(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CatalogV2ListEntries request
 	CatalogV2ListEntries(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2166,6 +2908,50 @@ type ClientInterface interface {
 
 	CatalogV2UpdateTypeSchema(ctx context.Context, id string, body CatalogV2UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CustomFieldsV2List request
+	CustomFieldsV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CustomFieldsV2Create request with any body
+	CustomFieldsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CustomFieldsV2Create(ctx context.Context, body CustomFieldsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CustomFieldsV2Delete request
+	CustomFieldsV2Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CustomFieldsV2Show request
+	CustomFieldsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CustomFieldsV2Update request with any body
+	CustomFieldsV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CustomFieldsV2Update(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// FollowUpsV2List request
+	FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// FollowUpsV2Show request
+	FollowUpsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentRolesV2List request
+	IncidentRolesV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentRolesV2Create request with any body
+	IncidentRolesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IncidentRolesV2Create(ctx context.Context, body IncidentRolesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentRolesV2Delete request
+	IncidentRolesV2Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentRolesV2Show request
+	IncidentRolesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentRolesV2Update request with any body
+	IncidentRolesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IncidentRolesV2Update(ctx context.Context, id string, body IncidentRolesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// IncidentTimestampsV2List request
 	IncidentTimestampsV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2190,6 +2976,12 @@ type ClientInterface interface {
 	IncidentsV2EditWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UsersV2List request
+	UsersV2List(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UsersV2Show request
+	UsersV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ActionsV1List(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2434,6 +3226,54 @@ func (c *Client) IncidentAttachmentsV1Create(ctx context.Context, body IncidentA
 
 func (c *Client) IncidentAttachmentsV1Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentAttachmentsV1DeleteRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentMembershipsV1CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentMembershipsV1CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentMembershipsV1Create(ctx context.Context, body IncidentMembershipsV1CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentMembershipsV1CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentMembershipsV1RevokeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentMembershipsV1RevokeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentMembershipsV1Revoke(ctx context.Context, body IncidentMembershipsV1RevokeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentMembershipsV1RevokeRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2696,6 +3536,18 @@ func (c *Client) UtilitiesV1OpenAPI(ctx context.Context, reqEditors ...RequestEd
 	return c.Client.Do(req)
 }
 
+func (c *Client) UtilitiesV1OpenAPIV3(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUtilitiesV1OpenAPIV3Request(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) SeveritiesV1List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSeveritiesV1ListRequest(c.Server)
 	if err != nil {
@@ -2770,6 +3622,54 @@ func (c *Client) SeveritiesV1UpdateWithBody(ctx context.Context, id string, cont
 
 func (c *Client) SeveritiesV1Update(ctx context.Context, id string, body SeveritiesV1UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSeveritiesV1UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ActionsV2List(ctx context.Context, params *ActionsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewActionsV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ActionsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewActionsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertEventsV2CreateHTTPWithBody(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertEventsV2CreateHTTPRequestWithBody(c.Server, alertSourceConfigId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertEventsV2CreateHTTP(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertEventsV2CreateHTTPRequest(c.Server, alertSourceConfigId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2984,6 +3884,198 @@ func (c *Client) CatalogV2UpdateTypeSchema(ctx context.Context, id string, body 
 	return c.Client.Do(req)
 }
 
+func (c *Client) CustomFieldsV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2ListRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2Create(ctx context.Context, body CustomFieldsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2DeleteRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2UpdateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CustomFieldsV2Update(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCustomFieldsV2UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFollowUpsV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FollowUpsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFollowUpsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2ListRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2Create(ctx context.Context, body IncidentRolesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2Delete(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2DeleteRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2UpdateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentRolesV2Update(ctx context.Context, id string, body IncidentRolesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentRolesV2UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) IncidentTimestampsV2List(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentTimestampsV2ListRequest(c.Server)
 	if err != nil {
@@ -3082,6 +4174,30 @@ func (c *Client) IncidentsV2EditWithBody(ctx context.Context, id string, content
 
 func (c *Client) IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentsV2EditRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsersV2List(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsersV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsersV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsersV2ShowRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -3797,6 +4913,86 @@ func NewIncidentAttachmentsV1DeleteRequest(server string, id string) (*http.Requ
 	return req, nil
 }
 
+// NewIncidentMembershipsV1CreateRequest calls the generic IncidentMembershipsV1Create builder with application/json body
+func NewIncidentMembershipsV1CreateRequest(server string, body IncidentMembershipsV1CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIncidentMembershipsV1CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewIncidentMembershipsV1CreateRequestWithBody generates requests for IncidentMembershipsV1Create with any type of body
+func NewIncidentMembershipsV1CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/incident_memberships")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewIncidentMembershipsV1RevokeRequest calls the generic IncidentMembershipsV1Revoke builder with application/json body
+func NewIncidentMembershipsV1RevokeRequest(server string, body IncidentMembershipsV1RevokeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIncidentMembershipsV1RevokeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewIncidentMembershipsV1RevokeRequestWithBody generates requests for IncidentMembershipsV1Revoke with any type of body
+func NewIncidentMembershipsV1RevokeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/incident_memberships/actions/revoke")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewIncidentRolesV1ListRequest generates requests for IncidentRolesV1List
 func NewIncidentRolesV1ListRequest(server string) (*http.Request, error) {
 	var err error
@@ -4402,6 +5598,33 @@ func NewUtilitiesV1OpenAPIRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewUtilitiesV1OpenAPIV3Request generates requests for UtilitiesV1OpenAPIV3
+func NewUtilitiesV1OpenAPIV3Request(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/openapiV3.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewSeveritiesV1ListRequest generates requests for SeveritiesV1List
 func NewSeveritiesV1ListRequest(server string) (*http.Request, error) {
 	var err error
@@ -4575,6 +5798,170 @@ func NewSeveritiesV1UpdateRequestWithBody(server string, id string, contentType 
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewActionsV2ListRequest generates requests for ActionsV2List
+func NewActionsV2ListRequest(server string, params *ActionsV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/actions")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.IncidentId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "incident_id", runtime.ParamLocationQuery, *params.IncidentId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.IncidentMode != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "incident_mode", runtime.ParamLocationQuery, *params.IncidentMode); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewActionsV2ShowRequest generates requests for ActionsV2Show
+func NewActionsV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/actions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAlertEventsV2CreateHTTPRequest calls the generic AlertEventsV2CreateHTTP builder with application/json body
+func NewAlertEventsV2CreateHTTPRequest(server string, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAlertEventsV2CreateHTTPRequestWithBody(server, alertSourceConfigId, params, "application/json", bodyReader)
+}
+
+// NewAlertEventsV2CreateHTTPRequestWithBody generates requests for AlertEventsV2CreateHTTP with any type of body
+func NewAlertEventsV2CreateHTTPRequestWithBody(server string, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "alert_source_config_id", runtime.ParamLocationPath, alertSourceConfigId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_events/http/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Token != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "token", runtime.ParamLocationQuery, *params.Token); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -4882,7 +6269,7 @@ func NewCatalogV2CreateTypeRequest(server string, body CatalogV2CreateTypeJSONRe
 // NewCatalogV2CreateTypeRequestWithBody generates requests for CatalogV2CreateType with any type of body
 func NewCatalogV2CreateTypeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
-	
+
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return nil, err
@@ -5061,6 +6448,467 @@ func NewCatalogV2UpdateTypeSchemaRequestWithBody(server string, id string, conte
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCustomFieldsV2ListRequest generates requests for CustomFieldsV2List
+func NewCustomFieldsV2ListRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/custom_fields")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCustomFieldsV2CreateRequest calls the generic CustomFieldsV2Create builder with application/json body
+func NewCustomFieldsV2CreateRequest(server string, body CustomFieldsV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCustomFieldsV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCustomFieldsV2CreateRequestWithBody generates requests for CustomFieldsV2Create with any type of body
+func NewCustomFieldsV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/custom_fields")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCustomFieldsV2DeleteRequest generates requests for CustomFieldsV2Delete
+func NewCustomFieldsV2DeleteRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/custom_fields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCustomFieldsV2ShowRequest generates requests for CustomFieldsV2Show
+func NewCustomFieldsV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/custom_fields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCustomFieldsV2UpdateRequest calls the generic CustomFieldsV2Update builder with application/json body
+func NewCustomFieldsV2UpdateRequest(server string, id string, body CustomFieldsV2UpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCustomFieldsV2UpdateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewCustomFieldsV2UpdateRequestWithBody generates requests for CustomFieldsV2Update with any type of body
+func NewCustomFieldsV2UpdateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/custom_fields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewFollowUpsV2ListRequest generates requests for FollowUpsV2List
+func NewFollowUpsV2ListRequest(server string, params *FollowUpsV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/follow_ups")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.IncidentId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "incident_id", runtime.ParamLocationQuery, *params.IncidentId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.IncidentMode != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "incident_mode", runtime.ParamLocationQuery, *params.IncidentMode); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewFollowUpsV2ShowRequest generates requests for FollowUpsV2Show
+func NewFollowUpsV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/follow_ups/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewIncidentRolesV2ListRequest generates requests for IncidentRolesV2List
+func NewIncidentRolesV2ListRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incident_roles")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewIncidentRolesV2CreateRequest calls the generic IncidentRolesV2Create builder with application/json body
+func NewIncidentRolesV2CreateRequest(server string, body IncidentRolesV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIncidentRolesV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewIncidentRolesV2CreateRequestWithBody generates requests for IncidentRolesV2Create with any type of body
+func NewIncidentRolesV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incident_roles")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewIncidentRolesV2DeleteRequest generates requests for IncidentRolesV2Delete
+func NewIncidentRolesV2DeleteRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incident_roles/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewIncidentRolesV2ShowRequest generates requests for IncidentRolesV2Show
+func NewIncidentRolesV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incident_roles/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewIncidentRolesV2UpdateRequest calls the generic IncidentRolesV2Update builder with application/json body
+func NewIncidentRolesV2UpdateRequest(server string, id string, body IncidentRolesV2UpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIncidentRolesV2UpdateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewIncidentRolesV2UpdateRequestWithBody generates requests for IncidentRolesV2Update with any type of body
+func NewIncidentRolesV2UpdateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incident_roles/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -5279,6 +7127,22 @@ func NewIncidentsV2ListRequest(server string, params *IncidentsV2ListParams) (*h
 
 	}
 
+	if params.StatusCategory != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status_category", runtime.ParamLocationQuery, *params.StatusCategory); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	if params.Severity != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "severity", runtime.ParamLocationQuery, *params.Severity); err != nil {
@@ -5330,6 +7194,22 @@ func NewIncidentsV2ListRequest(server string, params *IncidentsV2ListParams) (*h
 	if params.CustomField != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "custom_field", runtime.ParamLocationQuery, *params.CustomField); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Mode != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mode", runtime.ParamLocationQuery, *params.Mode); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -5474,6 +7354,103 @@ func NewIncidentsV2EditRequestWithBody(server string, id string, contentType str
 	return req, nil
 }
 
+// NewUsersV2ListRequest generates requests for UsersV2List
+func NewUsersV2ListRequest(server string, params *UsersV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/users")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageSize != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.After != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUsersV2ShowRequest generates requests for UsersV2Show
+func NewUsersV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/users/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -5575,6 +7552,16 @@ type ClientWithResponsesInterface interface {
 	// IncidentAttachmentsV1Delete request
 	IncidentAttachmentsV1DeleteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentAttachmentsV1DeleteResponse, error)
 
+	// IncidentMembershipsV1Create request with any body
+	IncidentMembershipsV1CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1CreateResponse, error)
+
+	IncidentMembershipsV1CreateWithResponse(ctx context.Context, body IncidentMembershipsV1CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1CreateResponse, error)
+
+	// IncidentMembershipsV1Revoke request with any body
+	IncidentMembershipsV1RevokeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1RevokeResponse, error)
+
+	IncidentMembershipsV1RevokeWithResponse(ctx context.Context, body IncidentMembershipsV1RevokeJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1RevokeResponse, error)
+
 	// IncidentRolesV1List request
 	IncidentRolesV1ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentRolesV1ListResponse, error)
 
@@ -5633,6 +7620,9 @@ type ClientWithResponsesInterface interface {
 	// UtilitiesV1OpenAPI request
 	UtilitiesV1OpenAPIWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UtilitiesV1OpenAPIResponse, error)
 
+	// UtilitiesV1OpenAPIV3 request
+	UtilitiesV1OpenAPIV3WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UtilitiesV1OpenAPIV3Response, error)
+
 	// SeveritiesV1List request
 	SeveritiesV1ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SeveritiesV1ListResponse, error)
 
@@ -5651,6 +7641,17 @@ type ClientWithResponsesInterface interface {
 	SeveritiesV1UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SeveritiesV1UpdateResponse, error)
 
 	SeveritiesV1UpdateWithResponse(ctx context.Context, id string, body SeveritiesV1UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SeveritiesV1UpdateResponse, error)
+
+	// ActionsV2List request
+	ActionsV2ListWithResponse(ctx context.Context, params *ActionsV2ListParams, reqEditors ...RequestEditorFn) (*ActionsV2ListResponse, error)
+
+	// ActionsV2Show request
+	ActionsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ActionsV2ShowResponse, error)
+
+	// AlertEventsV2CreateHTTP request with any body
+	AlertEventsV2CreateHTTPWithBodyWithResponse(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertEventsV2CreateHTTPResponse, error)
+
+	AlertEventsV2CreateHTTPWithResponse(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertEventsV2CreateHTTPResponse, error)
 
 	// CatalogV2ListEntries request
 	CatalogV2ListEntriesWithResponse(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV2ListEntriesResponse, error)
@@ -5698,6 +7699,50 @@ type ClientWithResponsesInterface interface {
 
 	CatalogV2UpdateTypeSchemaWithResponse(ctx context.Context, id string, body CatalogV2UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV2UpdateTypeSchemaResponse, error)
 
+	// CustomFieldsV2List request
+	CustomFieldsV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CustomFieldsV2ListResponse, error)
+
+	// CustomFieldsV2Create request with any body
+	CustomFieldsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CustomFieldsV2CreateResponse, error)
+
+	CustomFieldsV2CreateWithResponse(ctx context.Context, body CustomFieldsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*CustomFieldsV2CreateResponse, error)
+
+	// CustomFieldsV2Delete request
+	CustomFieldsV2DeleteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CustomFieldsV2DeleteResponse, error)
+
+	// CustomFieldsV2Show request
+	CustomFieldsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CustomFieldsV2ShowResponse, error)
+
+	// CustomFieldsV2Update request with any body
+	CustomFieldsV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CustomFieldsV2UpdateResponse, error)
+
+	CustomFieldsV2UpdateWithResponse(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*CustomFieldsV2UpdateResponse, error)
+
+	// FollowUpsV2List request
+	FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error)
+
+	// FollowUpsV2Show request
+	FollowUpsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*FollowUpsV2ShowResponse, error)
+
+	// IncidentRolesV2List request
+	IncidentRolesV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentRolesV2ListResponse, error)
+
+	// IncidentRolesV2Create request with any body
+	IncidentRolesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentRolesV2CreateResponse, error)
+
+	IncidentRolesV2CreateWithResponse(ctx context.Context, body IncidentRolesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentRolesV2CreateResponse, error)
+
+	// IncidentRolesV2Delete request
+	IncidentRolesV2DeleteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentRolesV2DeleteResponse, error)
+
+	// IncidentRolesV2Show request
+	IncidentRolesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentRolesV2ShowResponse, error)
+
+	// IncidentRolesV2Update request with any body
+	IncidentRolesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentRolesV2UpdateResponse, error)
+
+	IncidentRolesV2UpdateWithResponse(ctx context.Context, id string, body IncidentRolesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentRolesV2UpdateResponse, error)
+
 	// IncidentTimestampsV2List request
 	IncidentTimestampsV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentTimestampsV2ListResponse, error)
 
@@ -5722,6 +7767,12 @@ type ClientWithResponsesInterface interface {
 	IncidentsV2EditWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
 
 	IncidentsV2EditWithResponse(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
+
+	// UsersV2List request
+	UsersV2ListWithResponse(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*UsersV2ListResponse, error)
+
+	// UsersV2Show request
+	UsersV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*UsersV2ShowResponse, error)
 }
 
 type ActionsV1ListResponse struct {
@@ -5771,7 +7822,7 @@ func (r ActionsV1ShowResponse) StatusCode() int {
 type CustomFieldOptionsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody2
+	JSON200      *ListResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -5793,7 +7844,7 @@ func (r CustomFieldOptionsV1ListResponse) StatusCode() int {
 type CustomFieldOptionsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody2
+	JSON201      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -5836,7 +7887,7 @@ func (r CustomFieldOptionsV1DeleteResponse) StatusCode() int {
 type CustomFieldOptionsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -5858,7 +7909,7 @@ func (r CustomFieldOptionsV1ShowResponse) StatusCode() int {
 type CustomFieldOptionsV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -5880,7 +7931,7 @@ func (r CustomFieldOptionsV1UpdateResponse) StatusCode() int {
 type CustomFieldsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody3
+	JSON200      *ListResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -5902,7 +7953,7 @@ func (r CustomFieldsV1ListResponse) StatusCode() int {
 type CustomFieldsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody3
+	JSON201      *ShowResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -5945,7 +7996,7 @@ func (r CustomFieldsV1DeleteResponse) StatusCode() int {
 type CustomFieldsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *ShowResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -5967,7 +8018,7 @@ func (r CustomFieldsV1ShowResponse) StatusCode() int {
 type CustomFieldsV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *ShowResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -6011,7 +8062,7 @@ func (r UtilitiesV1IdentityResponse) StatusCode() int {
 type IncidentAttachmentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody4
+	JSON200      *ListResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -6073,10 +8124,53 @@ func (r IncidentAttachmentsV1DeleteResponse) StatusCode() int {
 	return 0
 }
 
+type IncidentMembershipsV1CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CreateResponseBody2
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentMembershipsV1CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentMembershipsV1CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentMembershipsV1RevokeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentMembershipsV1RevokeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentMembershipsV1RevokeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type IncidentRolesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody5
+	JSON200      *ListResponseBody8
 }
 
 // Status returns HTTPResponse.Status
@@ -6098,7 +8192,7 @@ func (r IncidentRolesV1ListResponse) StatusCode() int {
 type IncidentRolesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody4
+	JSON201      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -6141,7 +8235,7 @@ func (r IncidentRolesV1DeleteResponse) StatusCode() int {
 type IncidentRolesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody4
+	JSON200      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -6163,7 +8257,7 @@ func (r IncidentRolesV1ShowResponse) StatusCode() int {
 type IncidentRolesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody4
+	JSON200      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -6185,7 +8279,7 @@ func (r IncidentRolesV1UpdateResponse) StatusCode() int {
 type IncidentStatusesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody6
+	JSON200      *ListResponseBody10
 }
 
 // Status returns HTTPResponse.Status
@@ -6207,7 +8301,7 @@ func (r IncidentStatusesV1ListResponse) StatusCode() int {
 type IncidentStatusesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody5
+	JSON201      *ShowResponseBody9
 }
 
 // Status returns HTTPResponse.Status
@@ -6250,7 +8344,7 @@ func (r IncidentStatusesV1DeleteResponse) StatusCode() int {
 type IncidentStatusesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody5
+	JSON200      *ShowResponseBody9
 }
 
 // Status returns HTTPResponse.Status
@@ -6272,7 +8366,7 @@ func (r IncidentStatusesV1ShowResponse) StatusCode() int {
 type IncidentStatusesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody5
+	JSON200      *ShowResponseBody9
 }
 
 // Status returns HTTPResponse.Status
@@ -6294,7 +8388,7 @@ func (r IncidentStatusesV1UpdateResponse) StatusCode() int {
 type IncidentTypesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody8
+	JSON200      *ListResponseBody12
 }
 
 // Status returns HTTPResponse.Status
@@ -6316,7 +8410,7 @@ func (r IncidentTypesV1ListResponse) StatusCode() int {
 type IncidentTypesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody7
+	JSON200      *ShowResponseBody11
 }
 
 // Status returns HTTPResponse.Status
@@ -6338,7 +8432,7 @@ func (r IncidentTypesV1ShowResponse) StatusCode() int {
 type IncidentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody10
+	JSON200      *ListResponseBody14
 }
 
 // Status returns HTTPResponse.Status
@@ -6360,7 +8454,7 @@ func (r IncidentsV1ListResponse) StatusCode() int {
 type IncidentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody8
+	JSON200      *ShowResponseBody12
 }
 
 // Status returns HTTPResponse.Status
@@ -6382,7 +8476,7 @@ func (r IncidentsV1CreateResponse) StatusCode() int {
 type IncidentsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody8
+	JSON200      *ShowResponseBody12
 }
 
 // Status returns HTTPResponse.Status
@@ -6423,10 +8517,32 @@ func (r UtilitiesV1OpenAPIResponse) StatusCode() int {
 	return 0
 }
 
+type UtilitiesV1OpenAPIV3Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *openapi_types.File
+}
+
+// Status returns HTTPResponse.Status
+func (r UtilitiesV1OpenAPIV3Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UtilitiesV1OpenAPIV3Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type SeveritiesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody12
+	JSON200      *ListResponseBody16
 }
 
 // Status returns HTTPResponse.Status
@@ -6448,7 +8564,7 @@ func (r SeveritiesV1ListResponse) StatusCode() int {
 type SeveritiesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody10
+	JSON201      *ShowResponseBody14
 }
 
 // Status returns HTTPResponse.Status
@@ -6491,7 +8607,7 @@ func (r SeveritiesV1DeleteResponse) StatusCode() int {
 type SeveritiesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody10
+	JSON200      *ShowResponseBody14
 }
 
 // Status returns HTTPResponse.Status
@@ -6513,7 +8629,7 @@ func (r SeveritiesV1ShowResponse) StatusCode() int {
 type SeveritiesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody10
+	JSON200      *ShowResponseBody14
 }
 
 // Status returns HTTPResponse.Status
@@ -6526,6 +8642,72 @@ func (r SeveritiesV1UpdateResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r SeveritiesV1UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ActionsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody2
+}
+
+// Status returns HTTPResponse.Status
+func (r ActionsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ActionsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ActionsV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody2
+}
+
+// Status returns HTTPResponse.Status
+func (r ActionsV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ActionsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertEventsV2CreateHTTPResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *CreateHTTPResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertEventsV2CreateHTTPResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertEventsV2CreateHTTPResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6794,10 +8976,272 @@ func (r CatalogV2UpdateTypeSchemaResponse) StatusCode() int {
 	return 0
 }
 
+type CustomFieldsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody5
+}
+
+// Status returns HTTPResponse.Status
+func (r CustomFieldsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CustomFieldsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CustomFieldsV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ShowResponseBody5
+}
+
+// Status returns HTTPResponse.Status
+func (r CustomFieldsV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CustomFieldsV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CustomFieldsV2DeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r CustomFieldsV2DeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CustomFieldsV2DeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CustomFieldsV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody5
+}
+
+// Status returns HTTPResponse.Status
+func (r CustomFieldsV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CustomFieldsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CustomFieldsV2UpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody5
+}
+
+// Status returns HTTPResponse.Status
+func (r CustomFieldsV2UpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CustomFieldsV2UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type FollowUpsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody6
+}
+
+// Status returns HTTPResponse.Status
+func (r FollowUpsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FollowUpsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type FollowUpsV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody6
+}
+
+// Status returns HTTPResponse.Status
+func (r FollowUpsV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FollowUpsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentRolesV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody9
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentRolesV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentRolesV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentRolesV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ShowResponseBody8
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentRolesV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentRolesV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentRolesV2DeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentRolesV2DeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentRolesV2DeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentRolesV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody8
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentRolesV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentRolesV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IncidentRolesV2UpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody8
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentRolesV2UpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentRolesV2UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type IncidentTimestampsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody7
+	JSON200      *ListResponseBody11
 }
 
 // Status returns HTTPResponse.Status
@@ -6819,7 +9263,7 @@ func (r IncidentTimestampsV2ListResponse) StatusCode() int {
 type IncidentTimestampsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody6
+	JSON200      *ShowResponseBody10
 }
 
 // Status returns HTTPResponse.Status
@@ -6841,7 +9285,7 @@ func (r IncidentTimestampsV2ShowResponse) StatusCode() int {
 type IncidentUpdatesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody9
+	JSON200      *ListResponseBody13
 }
 
 // Status returns HTTPResponse.Status
@@ -6863,7 +9307,7 @@ func (r IncidentUpdatesV2ListResponse) StatusCode() int {
 type IncidentsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody11
+	JSON200      *ListResponseBody15
 }
 
 // Status returns HTTPResponse.Status
@@ -6885,7 +9329,7 @@ func (r IncidentsV2ListResponse) StatusCode() int {
 type IncidentsV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody9
+	JSON200      *ShowResponseBody13
 }
 
 // Status returns HTTPResponse.Status
@@ -6907,7 +9351,7 @@ func (r IncidentsV2CreateResponse) StatusCode() int {
 type IncidentsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody9
+	JSON200      *ShowResponseBody13
 }
 
 // Status returns HTTPResponse.Status
@@ -6929,7 +9373,7 @@ func (r IncidentsV2ShowResponse) StatusCode() int {
 type IncidentsV2EditResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody9
+	JSON200      *ShowResponseBody13
 }
 
 // Status returns HTTPResponse.Status
@@ -6942,6 +9386,50 @@ func (r IncidentsV2EditResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r IncidentsV2EditResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsersV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody17
+}
+
+// Status returns HTTPResponse.Status
+func (r UsersV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UsersV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsersV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody15
+}
+
+// Status returns HTTPResponse.Status
+func (r UsersV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UsersV2ShowResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -7132,6 +9620,40 @@ func (c *ClientWithResponses) IncidentAttachmentsV1DeleteWithResponse(ctx contex
 	return ParseIncidentAttachmentsV1DeleteResponse(rsp)
 }
 
+// IncidentMembershipsV1CreateWithBodyWithResponse request with arbitrary body returning *IncidentMembershipsV1CreateResponse
+func (c *ClientWithResponses) IncidentMembershipsV1CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1CreateResponse, error) {
+	rsp, err := c.IncidentMembershipsV1CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentMembershipsV1CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) IncidentMembershipsV1CreateWithResponse(ctx context.Context, body IncidentMembershipsV1CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1CreateResponse, error) {
+	rsp, err := c.IncidentMembershipsV1Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentMembershipsV1CreateResponse(rsp)
+}
+
+// IncidentMembershipsV1RevokeWithBodyWithResponse request with arbitrary body returning *IncidentMembershipsV1RevokeResponse
+func (c *ClientWithResponses) IncidentMembershipsV1RevokeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1RevokeResponse, error) {
+	rsp, err := c.IncidentMembershipsV1RevokeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentMembershipsV1RevokeResponse(rsp)
+}
+
+func (c *ClientWithResponses) IncidentMembershipsV1RevokeWithResponse(ctx context.Context, body IncidentMembershipsV1RevokeJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentMembershipsV1RevokeResponse, error) {
+	rsp, err := c.IncidentMembershipsV1Revoke(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentMembershipsV1RevokeResponse(rsp)
+}
+
 // IncidentRolesV1ListWithResponse request returning *IncidentRolesV1ListResponse
 func (c *ClientWithResponses) IncidentRolesV1ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentRolesV1ListResponse, error) {
 	rsp, err := c.IncidentRolesV1List(ctx, reqEditors...)
@@ -7316,6 +9838,15 @@ func (c *ClientWithResponses) UtilitiesV1OpenAPIWithResponse(ctx context.Context
 	return ParseUtilitiesV1OpenAPIResponse(rsp)
 }
 
+// UtilitiesV1OpenAPIV3WithResponse request returning *UtilitiesV1OpenAPIV3Response
+func (c *ClientWithResponses) UtilitiesV1OpenAPIV3WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UtilitiesV1OpenAPIV3Response, error) {
+	rsp, err := c.UtilitiesV1OpenAPIV3(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUtilitiesV1OpenAPIV3Response(rsp)
+}
+
 // SeveritiesV1ListWithResponse request returning *SeveritiesV1ListResponse
 func (c *ClientWithResponses) SeveritiesV1ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SeveritiesV1ListResponse, error) {
 	rsp, err := c.SeveritiesV1List(ctx, reqEditors...)
@@ -7375,6 +9906,41 @@ func (c *ClientWithResponses) SeveritiesV1UpdateWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseSeveritiesV1UpdateResponse(rsp)
+}
+
+// ActionsV2ListWithResponse request returning *ActionsV2ListResponse
+func (c *ClientWithResponses) ActionsV2ListWithResponse(ctx context.Context, params *ActionsV2ListParams, reqEditors ...RequestEditorFn) (*ActionsV2ListResponse, error) {
+	rsp, err := c.ActionsV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseActionsV2ListResponse(rsp)
+}
+
+// ActionsV2ShowWithResponse request returning *ActionsV2ShowResponse
+func (c *ClientWithResponses) ActionsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ActionsV2ShowResponse, error) {
+	rsp, err := c.ActionsV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseActionsV2ShowResponse(rsp)
+}
+
+// AlertEventsV2CreateHTTPWithBodyWithResponse request with arbitrary body returning *AlertEventsV2CreateHTTPResponse
+func (c *ClientWithResponses) AlertEventsV2CreateHTTPWithBodyWithResponse(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertEventsV2CreateHTTPResponse, error) {
+	rsp, err := c.AlertEventsV2CreateHTTPWithBody(ctx, alertSourceConfigId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertEventsV2CreateHTTPResponse(rsp)
+}
+
+func (c *ClientWithResponses) AlertEventsV2CreateHTTPWithResponse(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertEventsV2CreateHTTPResponse, error) {
+	rsp, err := c.AlertEventsV2CreateHTTP(ctx, alertSourceConfigId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertEventsV2CreateHTTPResponse(rsp)
 }
 
 // CatalogV2ListEntriesWithResponse request returning *CatalogV2ListEntriesResponse
@@ -7525,6 +10091,146 @@ func (c *ClientWithResponses) CatalogV2UpdateTypeSchemaWithResponse(ctx context.
 	return ParseCatalogV2UpdateTypeSchemaResponse(rsp)
 }
 
+// CustomFieldsV2ListWithResponse request returning *CustomFieldsV2ListResponse
+func (c *ClientWithResponses) CustomFieldsV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CustomFieldsV2ListResponse, error) {
+	rsp, err := c.CustomFieldsV2List(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2ListResponse(rsp)
+}
+
+// CustomFieldsV2CreateWithBodyWithResponse request with arbitrary body returning *CustomFieldsV2CreateResponse
+func (c *ClientWithResponses) CustomFieldsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CustomFieldsV2CreateResponse, error) {
+	rsp, err := c.CustomFieldsV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) CustomFieldsV2CreateWithResponse(ctx context.Context, body CustomFieldsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*CustomFieldsV2CreateResponse, error) {
+	rsp, err := c.CustomFieldsV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2CreateResponse(rsp)
+}
+
+// CustomFieldsV2DeleteWithResponse request returning *CustomFieldsV2DeleteResponse
+func (c *ClientWithResponses) CustomFieldsV2DeleteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CustomFieldsV2DeleteResponse, error) {
+	rsp, err := c.CustomFieldsV2Delete(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2DeleteResponse(rsp)
+}
+
+// CustomFieldsV2ShowWithResponse request returning *CustomFieldsV2ShowResponse
+func (c *ClientWithResponses) CustomFieldsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CustomFieldsV2ShowResponse, error) {
+	rsp, err := c.CustomFieldsV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2ShowResponse(rsp)
+}
+
+// CustomFieldsV2UpdateWithBodyWithResponse request with arbitrary body returning *CustomFieldsV2UpdateResponse
+func (c *ClientWithResponses) CustomFieldsV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CustomFieldsV2UpdateResponse, error) {
+	rsp, err := c.CustomFieldsV2UpdateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2UpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) CustomFieldsV2UpdateWithResponse(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*CustomFieldsV2UpdateResponse, error) {
+	rsp, err := c.CustomFieldsV2Update(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCustomFieldsV2UpdateResponse(rsp)
+}
+
+// FollowUpsV2ListWithResponse request returning *FollowUpsV2ListResponse
+func (c *ClientWithResponses) FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error) {
+	rsp, err := c.FollowUpsV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFollowUpsV2ListResponse(rsp)
+}
+
+// FollowUpsV2ShowWithResponse request returning *FollowUpsV2ShowResponse
+func (c *ClientWithResponses) FollowUpsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*FollowUpsV2ShowResponse, error) {
+	rsp, err := c.FollowUpsV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFollowUpsV2ShowResponse(rsp)
+}
+
+// IncidentRolesV2ListWithResponse request returning *IncidentRolesV2ListResponse
+func (c *ClientWithResponses) IncidentRolesV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentRolesV2ListResponse, error) {
+	rsp, err := c.IncidentRolesV2List(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2ListResponse(rsp)
+}
+
+// IncidentRolesV2CreateWithBodyWithResponse request with arbitrary body returning *IncidentRolesV2CreateResponse
+func (c *ClientWithResponses) IncidentRolesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentRolesV2CreateResponse, error) {
+	rsp, err := c.IncidentRolesV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) IncidentRolesV2CreateWithResponse(ctx context.Context, body IncidentRolesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentRolesV2CreateResponse, error) {
+	rsp, err := c.IncidentRolesV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2CreateResponse(rsp)
+}
+
+// IncidentRolesV2DeleteWithResponse request returning *IncidentRolesV2DeleteResponse
+func (c *ClientWithResponses) IncidentRolesV2DeleteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentRolesV2DeleteResponse, error) {
+	rsp, err := c.IncidentRolesV2Delete(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2DeleteResponse(rsp)
+}
+
+// IncidentRolesV2ShowWithResponse request returning *IncidentRolesV2ShowResponse
+func (c *ClientWithResponses) IncidentRolesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentRolesV2ShowResponse, error) {
+	rsp, err := c.IncidentRolesV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2ShowResponse(rsp)
+}
+
+// IncidentRolesV2UpdateWithBodyWithResponse request with arbitrary body returning *IncidentRolesV2UpdateResponse
+func (c *ClientWithResponses) IncidentRolesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentRolesV2UpdateResponse, error) {
+	rsp, err := c.IncidentRolesV2UpdateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2UpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) IncidentRolesV2UpdateWithResponse(ctx context.Context, id string, body IncidentRolesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentRolesV2UpdateResponse, error) {
+	rsp, err := c.IncidentRolesV2Update(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentRolesV2UpdateResponse(rsp)
+}
+
 // IncidentTimestampsV2ListWithResponse request returning *IncidentTimestampsV2ListResponse
 func (c *ClientWithResponses) IncidentTimestampsV2ListWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*IncidentTimestampsV2ListResponse, error) {
 	rsp, err := c.IncidentTimestampsV2List(ctx, reqEditors...)
@@ -7604,6 +10310,24 @@ func (c *ClientWithResponses) IncidentsV2EditWithResponse(ctx context.Context, i
 	return ParseIncidentsV2EditResponse(rsp)
 }
 
+// UsersV2ListWithResponse request returning *UsersV2ListResponse
+func (c *ClientWithResponses) UsersV2ListWithResponse(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*UsersV2ListResponse, error) {
+	rsp, err := c.UsersV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsersV2ListResponse(rsp)
+}
+
+// UsersV2ShowWithResponse request returning *UsersV2ShowResponse
+func (c *ClientWithResponses) UsersV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*UsersV2ShowResponse, error) {
+	rsp, err := c.UsersV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsersV2ShowResponse(rsp)
+}
+
 // ParseActionsV1ListResponse parses an HTTP response from a ActionsV1ListWithResponse call
 func ParseActionsV1ListResponse(rsp *http.Response) (*ActionsV1ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -7671,7 +10395,7 @@ func ParseCustomFieldOptionsV1ListResponse(rsp *http.Response) (*CustomFieldOpti
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody2
+		var dest ListResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7697,7 +10421,7 @@ func ParseCustomFieldOptionsV1CreateResponse(rsp *http.Response) (*CustomFieldOp
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody2
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7739,7 +10463,7 @@ func ParseCustomFieldOptionsV1ShowResponse(rsp *http.Response) (*CustomFieldOpti
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7765,7 +10489,7 @@ func ParseCustomFieldOptionsV1UpdateResponse(rsp *http.Response) (*CustomFieldOp
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7791,7 +10515,7 @@ func ParseCustomFieldsV1ListResponse(rsp *http.Response) (*CustomFieldsV1ListRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody3
+		var dest ListResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7817,7 +10541,7 @@ func ParseCustomFieldsV1CreateResponse(rsp *http.Response) (*CustomFieldsV1Creat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody3
+		var dest ShowResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7859,7 +10583,7 @@ func ParseCustomFieldsV1ShowResponse(rsp *http.Response) (*CustomFieldsV1ShowRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest ShowResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7885,7 +10609,7 @@ func ParseCustomFieldsV1UpdateResponse(rsp *http.Response) (*CustomFieldsV1Updat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest ShowResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7937,7 +10661,7 @@ func ParseIncidentAttachmentsV1ListResponse(rsp *http.Response) (*IncidentAttach
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody4
+		var dest ListResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -7990,6 +10714,48 @@ func ParseIncidentAttachmentsV1DeleteResponse(rsp *http.Response) (*IncidentAtta
 	return response, nil
 }
 
+// ParseIncidentMembershipsV1CreateResponse parses an HTTP response from a IncidentMembershipsV1CreateWithResponse call
+func ParseIncidentMembershipsV1CreateResponse(rsp *http.Response) (*IncidentMembershipsV1CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentMembershipsV1CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CreateResponseBody2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentMembershipsV1RevokeResponse parses an HTTP response from a IncidentMembershipsV1RevokeWithResponse call
+func ParseIncidentMembershipsV1RevokeResponse(rsp *http.Response) (*IncidentMembershipsV1RevokeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentMembershipsV1RevokeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
 // ParseIncidentRolesV1ListResponse parses an HTTP response from a IncidentRolesV1ListWithResponse call
 func ParseIncidentRolesV1ListResponse(rsp *http.Response) (*IncidentRolesV1ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -8005,7 +10771,7 @@ func ParseIncidentRolesV1ListResponse(rsp *http.Response) (*IncidentRolesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody5
+		var dest ListResponseBody8
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8031,7 +10797,7 @@ func ParseIncidentRolesV1CreateResponse(rsp *http.Response) (*IncidentRolesV1Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8073,7 +10839,7 @@ func ParseIncidentRolesV1ShowResponse(rsp *http.Response) (*IncidentRolesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8099,7 +10865,7 @@ func ParseIncidentRolesV1UpdateResponse(rsp *http.Response) (*IncidentRolesV1Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8125,7 +10891,7 @@ func ParseIncidentStatusesV1ListResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody6
+		var dest ListResponseBody10
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8151,7 +10917,7 @@ func ParseIncidentStatusesV1CreateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody9
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8193,7 +10959,7 @@ func ParseIncidentStatusesV1ShowResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody9
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8219,7 +10985,7 @@ func ParseIncidentStatusesV1UpdateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody9
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8245,7 +11011,7 @@ func ParseIncidentTypesV1ListResponse(rsp *http.Response) (*IncidentTypesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody8
+		var dest ListResponseBody12
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8271,7 +11037,7 @@ func ParseIncidentTypesV1ShowResponse(rsp *http.Response) (*IncidentTypesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody7
+		var dest ShowResponseBody11
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8297,7 +11063,7 @@ func ParseIncidentsV1ListResponse(rsp *http.Response) (*IncidentsV1ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody10
+		var dest ListResponseBody14
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8323,7 +11089,7 @@ func ParseIncidentsV1CreateResponse(rsp *http.Response) (*IncidentsV1CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody8
+		var dest ShowResponseBody12
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8349,7 +11115,7 @@ func ParseIncidentsV1ShowResponse(rsp *http.Response) (*IncidentsV1ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody8
+		var dest ShowResponseBody12
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8386,6 +11152,32 @@ func ParseUtilitiesV1OpenAPIResponse(rsp *http.Response) (*UtilitiesV1OpenAPIRes
 	return response, nil
 }
 
+// ParseUtilitiesV1OpenAPIV3Response parses an HTTP response from a UtilitiesV1OpenAPIV3WithResponse call
+func ParseUtilitiesV1OpenAPIV3Response(rsp *http.Response) (*UtilitiesV1OpenAPIV3Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UtilitiesV1OpenAPIV3Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest openapi_types.File
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseSeveritiesV1ListResponse parses an HTTP response from a SeveritiesV1ListWithResponse call
 func ParseSeveritiesV1ListResponse(rsp *http.Response) (*SeveritiesV1ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -8401,7 +11193,7 @@ func ParseSeveritiesV1ListResponse(rsp *http.Response) (*SeveritiesV1ListRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody12
+		var dest ListResponseBody16
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8427,7 +11219,7 @@ func ParseSeveritiesV1CreateResponse(rsp *http.Response) (*SeveritiesV1CreateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody14
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8469,7 +11261,7 @@ func ParseSeveritiesV1ShowResponse(rsp *http.Response) (*SeveritiesV1ShowRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody14
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8495,11 +11287,89 @@ func ParseSeveritiesV1UpdateResponse(rsp *http.Response) (*SeveritiesV1UpdateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody14
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseActionsV2ListResponse parses an HTTP response from a ActionsV2ListWithResponse call
+func ParseActionsV2ListResponse(rsp *http.Response) (*ActionsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ActionsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseActionsV2ShowResponse parses an HTTP response from a ActionsV2ShowWithResponse call
+func ParseActionsV2ShowResponse(rsp *http.Response) (*ActionsV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ActionsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAlertEventsV2CreateHTTPResponse parses an HTTP response from a AlertEventsV2CreateHTTPWithResponse call
+func ParseAlertEventsV2CreateHTTPResponse(rsp *http.Response) (*AlertEventsV2CreateHTTPResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertEventsV2CreateHTTPResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest CreateHTTPResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
 
 	}
 
@@ -8798,6 +11668,298 @@ func ParseCatalogV2UpdateTypeSchemaResponse(rsp *http.Response) (*CatalogV2Updat
 	return response, nil
 }
 
+// ParseCustomFieldsV2ListResponse parses an HTTP response from a CustomFieldsV2ListWithResponse call
+func ParseCustomFieldsV2ListResponse(rsp *http.Response) (*CustomFieldsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CustomFieldsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody5
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCustomFieldsV2CreateResponse parses an HTTP response from a CustomFieldsV2CreateWithResponse call
+func ParseCustomFieldsV2CreateResponse(rsp *http.Response) (*CustomFieldsV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CustomFieldsV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ShowResponseBody5
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCustomFieldsV2DeleteResponse parses an HTTP response from a CustomFieldsV2DeleteWithResponse call
+func ParseCustomFieldsV2DeleteResponse(rsp *http.Response) (*CustomFieldsV2DeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CustomFieldsV2DeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseCustomFieldsV2ShowResponse parses an HTTP response from a CustomFieldsV2ShowWithResponse call
+func ParseCustomFieldsV2ShowResponse(rsp *http.Response) (*CustomFieldsV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CustomFieldsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody5
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCustomFieldsV2UpdateResponse parses an HTTP response from a CustomFieldsV2UpdateWithResponse call
+func ParseCustomFieldsV2UpdateResponse(rsp *http.Response) (*CustomFieldsV2UpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CustomFieldsV2UpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody5
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFollowUpsV2ListResponse parses an HTTP response from a FollowUpsV2ListWithResponse call
+func ParseFollowUpsV2ListResponse(rsp *http.Response) (*FollowUpsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FollowUpsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody6
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFollowUpsV2ShowResponse parses an HTTP response from a FollowUpsV2ShowWithResponse call
+func ParseFollowUpsV2ShowResponse(rsp *http.Response) (*FollowUpsV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FollowUpsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody6
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentRolesV2ListResponse parses an HTTP response from a IncidentRolesV2ListWithResponse call
+func ParseIncidentRolesV2ListResponse(rsp *http.Response) (*IncidentRolesV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentRolesV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody9
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentRolesV2CreateResponse parses an HTTP response from a IncidentRolesV2CreateWithResponse call
+func ParseIncidentRolesV2CreateResponse(rsp *http.Response) (*IncidentRolesV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentRolesV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ShowResponseBody8
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentRolesV2DeleteResponse parses an HTTP response from a IncidentRolesV2DeleteWithResponse call
+func ParseIncidentRolesV2DeleteResponse(rsp *http.Response) (*IncidentRolesV2DeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentRolesV2DeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseIncidentRolesV2ShowResponse parses an HTTP response from a IncidentRolesV2ShowWithResponse call
+func ParseIncidentRolesV2ShowResponse(rsp *http.Response) (*IncidentRolesV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentRolesV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody8
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentRolesV2UpdateResponse parses an HTTP response from a IncidentRolesV2UpdateWithResponse call
+func ParseIncidentRolesV2UpdateResponse(rsp *http.Response) (*IncidentRolesV2UpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentRolesV2UpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody8
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseIncidentTimestampsV2ListResponse parses an HTTP response from a IncidentTimestampsV2ListWithResponse call
 func ParseIncidentTimestampsV2ListResponse(rsp *http.Response) (*IncidentTimestampsV2ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -8813,7 +11975,7 @@ func ParseIncidentTimestampsV2ListResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody7
+		var dest ListResponseBody11
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8839,7 +12001,7 @@ func ParseIncidentTimestampsV2ShowResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody6
+		var dest ShowResponseBody10
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8865,7 +12027,7 @@ func ParseIncidentUpdatesV2ListResponse(rsp *http.Response) (*IncidentUpdatesV2L
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody9
+		var dest ListResponseBody13
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8891,7 +12053,7 @@ func ParseIncidentsV2ListResponse(rsp *http.Response) (*IncidentsV2ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody11
+		var dest ListResponseBody15
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8917,7 +12079,7 @@ func ParseIncidentsV2CreateResponse(rsp *http.Response) (*IncidentsV2CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody9
+		var dest ShowResponseBody13
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8943,7 +12105,7 @@ func ParseIncidentsV2ShowResponse(rsp *http.Response) (*IncidentsV2ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody9
+		var dest ShowResponseBody13
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -8969,7 +12131,59 @@ func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody9
+		var dest ShowResponseBody13
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUsersV2ListResponse parses an HTTP response from a UsersV2ListWithResponse call
+func ParseUsersV2ListResponse(rsp *http.Response) (*UsersV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UsersV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody17
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUsersV2ShowResponse parses an HTTP response from a UsersV2ShowWithResponse call
+func ParseUsersV2ShowResponse(rsp *http.Response) (*UsersV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UsersV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody15
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/client/openapi3.json
+++ b/client/openapi3.json
@@ -13,68 +13,60 @@
   "paths": {
     "/v1/actions": {
       "get": {
-        "tags": [
-          "Actions V1"
-        ],
-        "summary": "List Actions V1",
         "description": "List all actions for an organisation.",
         "operationId": "Actions V1#List",
         "parameters": [
           {
-            "name": "incident_id",
-            "in": "query",
+            "allowEmptyValue": true,
             "description": "Find actions related to this incident",
-            "allowEmptyValue": true,
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "query",
+            "name": "incident_id",
             "schema": {
-              "type": "string",
               "description": "Find actions related to this incident",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           },
           {
-            "name": "is_follow_up",
-            "in": "query",
+            "allowEmptyValue": true,
             "description": "Filter to actions marked as being follow up actions",
-            "allowEmptyValue": true,
+            "example": true,
+            "in": "query",
+            "name": "is_follow_up",
             "schema": {
-              "type": "boolean",
               "description": "Filter to actions marked as being follow up actions",
-              "example": true
-            },
-            "example": true
+              "example": true,
+              "type": "boolean"
+            }
           },
           {
-            "name": "incident_mode",
-            "in": "query",
-            "description": "Filter to actions from incidents of the given mode. If not set, only actions from `real` incidents are returned",
             "allowEmptyValue": true,
-            "schema": {
-              "type": "string",
-              "description": "Filter to actions from incidents of the given mode. If not set, only actions from `real` incidents are returned",
-              "example": "real",
-              "enum": [
-                "real",
-                "test",
-                "tutorial"
-              ]
-            },
+            "description": "Filter to actions from incidents of the given mode. If not set, only actions from `real` incidents are returned",
             "examples": {
               "default": {
                 "summary": "default",
                 "value": "real"
               }
+            },
+            "in": "query",
+            "name": "incident_mode",
+            "schema": {
+              "description": "Filter to actions from incidents of the given mode. If not set, only actions from `real` incidents are returned",
+              "enum": [
+                "real",
+                "test",
+                "tutorial"
+              ],
+              "example": "real",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody"
-                },
                 "example": {
                   "actions": [
                     {
@@ -100,43 +92,44 @@
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
                   ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
+        },
+        "summary": "List Actions V1",
+        "tags": [
+          "Actions V1"
+        ],
+        "deprecated": true
       }
     },
     "/v1/actions/{id}": {
       "get": {
-        "tags": [
-          "Actions V1"
-        ],
-        "summary": "Show Actions V1",
         "description": "Get a single incident action.",
         "operationId": "Actions V1#Show",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the action",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the action",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
-                },
                 "example": {
                   "action": {
                     "assignee": {
@@ -160,11 +153,20 @@
                     "status": "outstanding",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
+        },
+        "summary": "Show Actions V1",
+        "tags": [
+          "Actions V1"
+        ],
+        "deprecated": true
       }
     },
     "/v1/custom_field_options": {
@@ -222,7 +224,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody2"
+                  "$ref": "#/components/schemas/ListResponseBody3"
                 },
                 "example": {
                   "custom_field_options": [
@@ -232,7 +234,11 @@
                       "sort_key": 10,
                       "value": "Product"
                     }
-                  ]
+                  ],
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  }
                 }
               }
             }
@@ -267,7 +273,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 },
                 "example": {
                   "custom_field_option": {
@@ -338,7 +344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 },
                 "example": {
                   "custom_field_option": {
@@ -394,7 +400,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 },
                 "example": {
                   "custom_field_option": {
@@ -412,23 +418,16 @@
     },
     "/v1/custom_fields": {
       "get": {
-        "tags": [
-          "Custom Fields V1"
-        ],
-        "summary": "List Custom Fields V1",
         "description": "List all custom fields for an organisation.",
         "operationId": "Custom Fields V1#List",
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody3"
-                },
                 "example": {
                   "custom_fields": [
                     {
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Which team is impacted by this issue",
                       "field_type": "single_select",
@@ -443,6 +442,7 @@
                         }
                       ],
                       "required": "never",
+                      "required_v2": "never",
                       "show_before_closure": true,
                       "show_before_creation": true,
                       "show_before_update": true,
@@ -450,49 +450,52 @@
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
                   ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody4"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
-      },
-      "post": {
+        },
+        "summary": "List Custom Fields V1",
         "tags": [
           "Custom Fields V1"
         ],
-        "summary": "Create Custom Fields V1",
+        "deprecated": true
+      },
+      "post": {
         "description": "Create a new custom field",
         "operationId": "Custom Fields V1#Create",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
-              },
               "example": {
                 "description": "Which team is impacted by this issue",
                 "field_type": "single_select",
                 "name": "Affected Team",
                 "required": "never",
+                "required_v2": "never",
                 "show_before_closure": true,
                 "show_before_creation": true,
                 "show_before_update": true,
                 "show_in_announcement_post": true
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody2"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
-            "description": "Created response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
-                },
                 "example": {
                   "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
@@ -507,78 +510,82 @@
                       }
                     ],
                     "required": "never",
+                    "required_v2": "never",
                     "show_before_closure": true,
                     "show_before_creation": true,
                     "show_before_update": true,
                     "show_in_announcement_post": true,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody4"
                 }
               }
-            }
+            },
+            "description": "Created response."
           }
-        }
+        },
+        "summary": "Create Custom Fields V1",
+        "tags": [
+          "Custom Fields V1"
+        ],
+        "deprecated": true
       }
     },
     "/v1/custom_fields/{id}": {
       "delete": {
-        "tags": [
-          "Custom Fields V1"
-        ],
-        "summary": "Delete Custom Fields V1",
         "description": "Delete a custom field",
         "operationId": "Custom Fields V1#Delete",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the custom field",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "No Content response."
           }
-        }
-      },
-      "get": {
+        },
+        "summary": "Delete Custom Fields V1",
         "tags": [
           "Custom Fields V1"
         ],
-        "summary": "Show Custom Fields V1",
+        "deprecated": true
+      },
+      "get": {
         "description": "Get a single custom field.",
         "operationId": "Custom Fields V1#Show",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the custom field",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
-                },
                 "example": {
                   "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
@@ -593,68 +600,72 @@
                       }
                     ],
                     "required": "never",
+                    "required_v2": "never",
                     "show_before_closure": true,
                     "show_before_creation": true,
                     "show_before_update": true,
                     "show_in_announcement_post": true,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody4"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
-      },
-      "put": {
+        },
+        "summary": "Show Custom Fields V1",
         "tags": [
           "Custom Fields V1"
         ],
-        "summary": "Update Custom Fields V1",
+        "deprecated": true
+      },
+      "put": {
         "description": "Update the details of a custom field",
         "operationId": "Custom Fields V1#Update",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the custom field",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
-              },
               "example": {
                 "description": "Which team is impacted by this issue",
                 "name": "Affected Team",
                 "required": "never",
+                "required_v2": "never",
                 "show_before_closure": true,
                 "show_before_creation": true,
                 "show_before_update": true,
                 "show_in_announcement_post": true
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody2"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
-                },
                 "example": {
                   "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
@@ -669,17 +680,27 @@
                       }
                     ],
                     "required": "never",
+                    "required_v2": "never",
                     "show_before_closure": true,
                     "show_before_creation": true,
                     "show_before_update": true,
                     "show_in_announcement_post": true,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody4"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
+        },
+        "summary": "Update Custom Fields V1",
+        "tags": [
+          "Custom Fields V1"
+        ],
+        "deprecated": true
       }
     },
     "/v1/identity": {
@@ -700,6 +721,7 @@
                 },
                 "example": {
                   "identity": {
+                    "dashboard_url": "https://app.incident.io/my-org",
                     "name": "Alertmanager token",
                     "roles": [
                       "incident_creator"
@@ -759,9 +781,12 @@
                 "opsgenie_alert",
                 "datadog_monitor_alert",
                 "github_pull_request",
+                "gitlab_merge_request",
                 "sentry_issue",
                 "atlassian_statuspage_incident",
                 "zendesk_ticket",
+                "google_calendar_event",
+                "scrubbed",
                 "statuspage_incident"
               ]
             },
@@ -779,7 +804,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody4"
+                  "$ref": "#/components/schemas/ListResponseBody7"
                 },
                 "example": {
                   "incident_attachments": [
@@ -812,7 +837,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               },
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
@@ -879,62 +904,24 @@
         }
       }
     },
-    "/v1/incident_roles": {
-      "get": {
-        "tags": [
-          "Incident Roles V1"
-        ],
-        "summary": "List Incident Roles V1",
-        "description": "List all incident roles for an organisation.",
-        "operationId": "Incident Roles V1#List",
-        "responses": {
-          "200": {
-            "description": "OK response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody5"
-                },
-                "example": {
-                  "incident_roles": [
-                    {
-                      "created_at": "2021-08-17T13:28:57.801578Z",
-                      "description": "The person currently coordinating the incident",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                      "name": "Incident Lead",
-                      "required": true,
-                      "role_type": "lead",
-                      "shortform": "lead",
-                      "updated_at": "2021-08-17T13:28:57.801578Z"
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
+    "/v1/incident_memberships": {
       "post": {
         "tags": [
-          "Incident Roles V1"
+          "Incident Memberships V1"
         ],
-        "summary": "Create Incident Roles V1",
-        "description": "Create a new incident role",
-        "operationId": "Incident Roles V1#Create",
+        "summary": "Create Incident Memberships V1",
+        "description": "Makes a user a member of a private incident",
+        "operationId": "Incident Memberships V1#Create",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
-                "description": "The person currently coordinating the incident",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "required": true,
-                "shortform": "lead"
+                "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
+                "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
               }
             }
           }
@@ -945,19 +932,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
+                  "$ref": "#/components/schemas/CreateResponseBody2"
                 },
                 "example": {
-                  "incident_role": {
+                  "incident_membership": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
-                    "description": "The person currently coordinating the incident",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                    "name": "Incident Lead",
-                    "required": true,
-                    "role_type": "lead",
-                    "shortform": "lead",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "user": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
                   }
                 }
               }
@@ -966,63 +955,174 @@
         }
       }
     },
-    "/v1/incident_roles/{id}": {
-      "delete": {
+    "/v1/incident_memberships/actions/revoke": {
+      "post": {
+        "tags": [
+          "Incident Memberships V1"
+        ],
+        "summary": "Revoke Incident Memberships V1",
+        "description": "Revoke a user's membership of a private incident",
+        "operationId": "Incident Memberships V1#Revoke",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody5"
+              },
+              "example": {
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      }
+    },
+    "/v1/incident_roles": {
+      "get": {
+        "description": "List all incident roles for an organisation.",
+        "operationId": "Incident Roles V1#List",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "incident_roles": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "The person currently coordinating the incident",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                      "name": "Incident Lead",
+                      "required": false,
+                      "role_type": "lead",
+                      "shortform": "lead",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody8"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "List Incident Roles V1",
         "tags": [
           "Incident Roles V1"
         ],
-        "summary": "Delete Incident Roles V1",
+        "deprecated": true
+      },
+      "post": {
+        "description": "Create a new incident role",
+        "operationId": "Incident Roles V1#Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "description": "The person currently coordinating the incident",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "required": false,
+                "shortform": "lead"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody6"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "incident_role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody7"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "Create Incident Roles V1",
+        "tags": [
+          "Incident Roles V1"
+        ],
+        "deprecated": true
+      }
+    },
+    "/v1/incident_roles/{id}": {
+      "delete": {
         "description": "Removes an existing role",
         "operationId": "Incident Roles V1#Delete",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the role",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "No Content response."
           }
-        }
-      },
-      "get": {
+        },
+        "summary": "Delete Incident Roles V1",
         "tags": [
           "Incident Roles V1"
         ],
-        "summary": "Show Incident Roles V1",
+        "deprecated": true
+      },
+      "get": {
         "description": "Get a single incident role.",
         "operationId": "Incident Roles V1#Show",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the role",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
-                },
                 "example": {
                   "incident_role": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -1030,63 +1130,64 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                     "name": "Incident Lead",
-                    "required": true,
+                    "required": false,
                     "role_type": "lead",
                     "shortform": "lead",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody7"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
-      },
-      "put": {
+        },
+        "summary": "Show Incident Roles V1",
         "tags": [
           "Incident Roles V1"
         ],
-        "summary": "Update Incident Roles V1",
+        "deprecated": true
+      },
+      "put": {
         "description": "Update an existing incident role",
         "operationId": "Incident Roles V1#Update",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "string",
               "description": "Unique identifier for the role",
-              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
-              },
               "example": {
                 "description": "The person currently coordinating the incident",
                 "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                 "name": "Incident Lead",
-                "required": true,
+                "required": false,
                 "shortform": "lead"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody4"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "OK response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
-                },
                 "example": {
                   "incident_role": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -1094,33 +1195,42 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                     "name": "Incident Lead",
-                    "required": true,
+                    "required": false,
                     "role_type": "lead",
                     "shortform": "lead",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody7"
                 }
               }
-            }
+            },
+            "description": "OK response."
           }
-        }
+        },
+        "summary": "Update Incident Roles V1",
+        "tags": [
+          "Incident Roles V1"
+        ],
+        "deprecated": true
       }
     },
     "/v1/incident_statuses": {
       "get": {
         "tags": [
-          "IncidentStatuses V1"
+          "Incident Statuses V1"
         ],
-        "summary": "List IncidentStatuses V1",
+        "summary": "List Incident Statuses V1",
         "description": "List all incident statuses for an organisation.",
-        "operationId": "IncidentStatuses V1#List",
+        "operationId": "Incident Statuses V1#List",
         "responses": {
           "200": {
             "description": "OK response.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody6"
+                  "$ref": "#/components/schemas/ListResponseBody10"
                 },
                 "example": {
                   "incident_statuses": [
@@ -1142,17 +1252,17 @@
       },
       "post": {
         "tags": [
-          "IncidentStatuses V1"
+          "Incident Statuses V1"
         ],
-        "summary": "Create IncidentStatuses V1",
+        "summary": "Create Incident Statuses V1",
         "description": "Create a new incident status",
-        "operationId": "IncidentStatuses V1#Create",
+        "operationId": "Incident Statuses V1#Create",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody8"
               },
               "example": {
                 "category": "live",
@@ -1168,7 +1278,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody9"
                 },
                 "example": {
                   "incident_status": {
@@ -1190,11 +1300,11 @@
     "/v1/incident_statuses/{id}": {
       "delete": {
         "tags": [
-          "IncidentStatuses V1"
+          "Incident Statuses V1"
         ],
-        "summary": "Delete IncidentStatuses V1",
+        "summary": "Delete Incident Statuses V1",
         "description": "Delete an incident status",
-        "operationId": "IncidentStatuses V1#Delete",
+        "operationId": "Incident Statuses V1#Delete",
         "parameters": [
           {
             "name": "id",
@@ -1217,11 +1327,11 @@
       },
       "get": {
         "tags": [
-          "IncidentStatuses V1"
+          "Incident Statuses V1"
         ],
-        "summary": "Show IncidentStatuses V1",
+        "summary": "Show Incident Statuses V1",
         "description": "Get a single incident status.",
-        "operationId": "IncidentStatuses V1#Show",
+        "operationId": "Incident Statuses V1#Show",
         "parameters": [
           {
             "name": "id",
@@ -1242,7 +1352,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody9"
                 },
                 "example": {
                   "incident_status": {
@@ -1262,11 +1372,11 @@
       },
       "put": {
         "tags": [
-          "IncidentStatuses V1"
+          "Incident Statuses V1"
         ],
-        "summary": "Update IncidentStatuses V1",
+        "summary": "Update Incident Statuses V1",
         "description": "Update an existing incident status",
-        "operationId": "IncidentStatuses V1#Update",
+        "operationId": "Incident Statuses V1#Update",
         "parameters": [
           {
             "name": "id",
@@ -1286,7 +1396,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody4"
+                "$ref": "#/components/schemas/UpdateRequestBody6"
               },
               "example": {
                 "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
@@ -1301,7 +1411,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody9"
                 },
                 "example": {
                   "incident_status": {
@@ -1334,7 +1444,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody8"
+                  "$ref": "#/components/schemas/ListResponseBody12"
                 },
                 "example": {
                   "incident_types": [
@@ -1384,7 +1494,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody7"
+                  "$ref": "#/components/schemas/ShowResponseBody11"
                 },
                 "example": {
                   "incident_type": {
@@ -1419,6 +1529,7 @@
               "default": 25,
               "description": "Integer number of records to return",
               "example": 25,
+              "format": "int64",
               "maximum": 500,
               "type": "integer"
             }
@@ -1501,6 +1612,15 @@
                           },
                           "values": [
                             {
+                              "value_catalog_entry": {
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
+                                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "name": "Primary On-call"
+                              },
                               "value_link": "https://google.com/",
                               "value_numeric": "123.456",
                               "value_option": {
@@ -1530,7 +1650,7 @@
                             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                             "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                             "name": "Incident Lead",
-                            "required": true,
+                            "required": false,
                             "role_type": "lead",
                             "shortform": "lead",
                             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -1582,7 +1702,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody10"
+                  "$ref": "#/components/schemas/ListResponseBody14"
                 }
               }
             },
@@ -1608,6 +1728,7 @@
                     "values": [
                       {
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "value_link": "https://google.com/",
                         "value_numeric": "123.456",
                         "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -1640,7 +1761,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody9"
               }
             }
           },
@@ -1685,6 +1806,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -1714,7 +1844,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -1760,7 +1890,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/ShowResponseBody12"
                 }
               }
             },
@@ -1831,6 +1961,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -1860,7 +1999,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -1906,7 +2045,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/ShowResponseBody12"
                 }
               }
             },
@@ -1945,6 +2084,31 @@
         }
       }
     },
+    "/v1/openapiV3.json": {
+      "get": {
+        "tags": [
+          "Utilities V1"
+        ],
+        "summary": "OpenAPIV3 Utilities V1",
+        "description": "Get the OpenAPI (v3) definition.",
+        "operationId": "Utilities V1#OpenAPIV3",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "example": "{}",
+                  "format": "binary"
+                },
+                "example": "{}"
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/severities": {
       "get": {
         "tags": [
@@ -1959,7 +2123,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody12"
+                  "$ref": "#/components/schemas/ListResponseBody16"
                 },
                 "example": {
                   "severities": [
@@ -1990,7 +2154,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody11"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2006,7 +2170,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody14"
                 },
                 "example": {
                   "severity": {
@@ -2079,7 +2243,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody14"
                 },
                 "example": {
                   "severity": {
@@ -2122,7 +2286,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody11"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2138,7 +2302,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody14"
                 },
                 "example": {
                   "severity": {
@@ -2149,6 +2313,215 @@
                     "rank": 1,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/actions": {
+      "get": {
+        "tags": [
+          "Actions V2"
+        ],
+        "summary": "List Actions V2",
+        "description": "List all actions for an organisation.",
+        "operationId": "Actions V2#List",
+        "parameters": [
+          {
+            "name": "incident_id",
+            "in": "query",
+            "description": "Find actions related to this incident",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "Find actions related to this incident",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          {
+            "name": "incident_mode",
+            "in": "query",
+            "description": "Filter to actions from incidents of the given mode. If not set, only actions from `standard` and `retrospective` incidents are returned",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter to actions from incidents of the given mode. If not set, only actions from `standard` and `retrospective` incidents are returned",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "retrospective",
+                "test",
+                "tutorial"
+              ]
+            },
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "standard"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody2"
+                },
+                "example": {
+                  "actions": [
+                    {
+                      "assignee": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "completed_at": "2021-08-17T13:28:57.801578Z",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Call the fire brigade",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "status": "outstanding",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/actions/{id}": {
+      "get": {
+        "tags": [
+          "Actions V2"
+        ],
+        "summary": "Show Actions V2",
+        "description": "Get a single incident action.",
+        "operationId": "Actions V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the action",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the action",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody2"
+                },
+                "example": {
+                  "action": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Call the fire brigade",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "status": "outstanding",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/alert_events/http/{alert_source_config_id}": {
+      "post": {
+        "tags": [
+          "Alert Events V2"
+        ],
+        "summary": "CreateHTTP Alert Events V2",
+        "description": "Create an alert event using an HTTP source.",
+        "operationId": "Alert Events V2#CreateHTTP",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "description": "Token used to authenticate the request, generated when configuring the alert source. Will be consumed via a URL query string parameter",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "Token used to authenticate the request, generated when configuring the alert source. Will be consumed via a URL query string parameter",
+              "example": "some-random-string"
+            },
+            "example": "some-random-string"
+          },
+          {
+            "name": "alert_source_config_id",
+            "in": "path",
+            "description": "Which alert source config produced this alert",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Which alert source config produced this alert",
+              "example": "01GW2G3V0S59R238FAHPDS1R66"
+            },
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHTTPRequestBody"
+              },
+              "example": {
+                "deduplication_key": "4293868629",
+                "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
+                "metadata": {
+                  "service": "hello.world.com",
+                  "team": [
+                    "my-team"
+                  ]
+                },
+                "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                "status": "firing",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateHTTPResponseBody"
+                },
+                "example": {
+                  "deduplication_key": "unique-key",
+                  "message": "Event accepted for processing",
+                  "status": "success"
                 }
               }
             }
@@ -2188,7 +2561,8 @@
               "description": "Integer number of records to return",
               "default": 25,
               "example": 25,
-              "maximum": 500
+              "format": "int64",
+              "maximum": 250
             },
             "example": 25
           },
@@ -2220,33 +2594,44 @@
                         "lawrence@incident.io",
                         "lawrence"
                       ],
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
                       "attribute_values": {
                         "abc123": {
                           "array_value": [
                             {
                               "catalog_entry": {
+                                "archived_at": "2021-08-17T14:28:57.801578Z",
                                 "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "catalog_entry_name": "Primary escalation",
                                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                               },
+                              "helptext": "Collection of standalone automations like auto-closing incidents.",
                               "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                               "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "sort_key": "000020"
+                              "reference": "incident.severity",
+                              "sort_key": "000020",
+                              "unavailable": false,
+                              "value": "abc123"
                             }
                           ],
                           "value": {
                             "catalog_entry": {
+                              "archived_at": "2021-08-17T14:28:57.801578Z",
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
+                            "helptext": "Collection of standalone automations like auto-closing incidents.",
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "sort_key": "000020"
+                            "reference": "incident.severity",
+                            "sort_key": "000020",
+                            "unavailable": false,
+                            "value": "abc123"
                           }
                         }
                       },
@@ -2263,16 +2648,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -2280,7 +2667,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -2288,6 +2677,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   },
@@ -2306,7 +2696,7 @@
           "Catalog V2"
         ],
         "summary": "CreateEntry Catalog V2",
-        "description": "Create an entry for a type in the catalog.",
+        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.",
         "operationId": "Catalog V2#CreateEntry",
         "requestBody": {
           "required": true,
@@ -2324,11 +2714,13 @@
                   "abc123": {
                     "array_value": [
                       {
-                        "literal": "SEV123"
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "literal": "SEV123"
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
                     }
                   }
                 },
@@ -2354,33 +2746,44 @@
                       "lawrence@incident.io",
                       "lawrence"
                     ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
+                              "archived_at": "2021-08-17T14:28:57.801578Z",
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
+                            "helptext": "Collection of standalone automations like auto-closing incidents.",
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "sort_key": "000020"
+                            "reference": "incident.severity",
+                            "sort_key": "000020",
+                            "unavailable": false,
+                            "value": "abc123"
                           }
                         ],
                         "value": {
                           "catalog_entry": {
+                            "archived_at": "2021-08-17T14:28:57.801578Z",
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
+                          "helptext": "Collection of standalone automations like auto-closing incidents.",
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "sort_key": "000020"
+                          "reference": "incident.severity",
+                          "sort_key": "000020",
+                          "unavailable": false,
+                          "value": "abc123"
                         }
                       }
                     },
@@ -2411,11 +2814,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog entry",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog entry",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2438,11 +2841,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog entry",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog entry",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2462,33 +2865,44 @@
                       "lawrence@incident.io",
                       "lawrence"
                     ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
+                              "archived_at": "2021-08-17T14:28:57.801578Z",
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
+                            "helptext": "Collection of standalone automations like auto-closing incidents.",
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "sort_key": "000020"
+                            "reference": "incident.severity",
+                            "sort_key": "000020",
+                            "unavailable": false,
+                            "value": "abc123"
                           }
                         ],
                         "value": {
                           "catalog_entry": {
+                            "archived_at": "2021-08-17T14:28:57.801578Z",
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
+                          "helptext": "Collection of standalone automations like auto-closing incidents.",
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "sort_key": "000020"
+                          "reference": "incident.severity",
+                          "sort_key": "000020",
+                          "unavailable": false,
+                          "value": "abc123"
                         }
                       }
                     },
@@ -2504,16 +2918,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -2521,7 +2937,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -2529,6 +2947,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -2549,11 +2968,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog entry",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog entry",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2575,11 +2994,13 @@
                   "abc123": {
                     "array_value": [
                       {
-                        "literal": "SEV123"
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "literal": "SEV123"
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
                     }
                   }
                 },
@@ -2604,33 +3025,44 @@
                       "lawrence@incident.io",
                       "lawrence"
                     ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
+                              "archived_at": "2021-08-17T14:28:57.801578Z",
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
+                            "helptext": "Collection of standalone automations like auto-closing incidents.",
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "sort_key": "000020"
+                            "reference": "incident.severity",
+                            "sort_key": "000020",
+                            "unavailable": false,
+                            "value": "abc123"
                           }
                         ],
                         "value": {
                           "catalog_entry": {
+                            "archived_at": "2021-08-17T14:28:57.801578Z",
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
+                          "helptext": "Collection of standalone automations like auto-closing incidents.",
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "sort_key": "000020"
+                          "reference": "incident.severity",
+                          "sort_key": "000020",
+                          "unavailable": false,
+                          "value": "abc123"
                         }
                       }
                     },
@@ -2646,16 +3078,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -2663,7 +3097,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -2671,6 +3107,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -2687,7 +3124,7 @@
           "Catalog V2"
         ],
         "summary": "ListResources Catalog V2",
-        "description": "List available engine resources for the catalog",
+        "description": "List available engine resources for the catalog.\n\nA resource represents a type of data that can be held within the catalog, so this\nendpoint can be used to see what attribute types can be used when updating the\nschema of a catalog type.\n",
         "operationId": "Catalog V2#ListResources",
         "responses": {
           "200": {
@@ -2736,16 +3173,18 @@
                       "annotations": {
                         "incident.io/catalog-importer/id": "id-of-config"
                       },
-                      "color": "slate",
+                      "color": "yellow",
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                      "dynamic_resource_parameter": "abc123",
                       "estimated_count": 7,
-                      "external_type": "PagerDutyService",
                       "icon": "bolt",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_editable": false,
+                      "last_synced_at": "2021-08-17T13:28:57.801578Z",
                       "name": "Kubernetes Cluster",
                       "ranked": true,
+                      "registry_type": "PagerDutyService",
                       "required_integrations": [
                         "pager_duty"
                       ],
@@ -2753,7 +3192,9 @@
                         "attributes": [
                           {
                             "array": false,
+                            "backlink_attribute": "abc123",
                             "id": "01GW2G3V0S59R238FAHPDS1R66",
+                            "mode": "manual",
                             "name": "tier",
                             "type": "Custom[\"Service\"]"
                           }
@@ -2761,6 +3202,7 @@
                         "version": 1
                       },
                       "semantic_type": "custom",
+                      "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                       "type_name": "Custom[\"BackstageGroup\"]",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
@@ -2776,7 +3218,7 @@
           "Catalog V2"
         ],
         "summary": "CreateType Catalog V2",
-        "description": "Create a catalog type.",
+        "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
         "operationId": "Catalog V2#CreateType",
         "requestBody": {
           "required": true,
@@ -2789,12 +3231,12 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
-                "color": "slate",
+                "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "bolt",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
-                "semantic_type": "custom",
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "type_name": "Custom[\"BackstageGroup\"]"
               }
             }
@@ -2813,16 +3255,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -2830,7 +3274,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -2838,6 +3284,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -2860,11 +3307,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog type",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog type",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2887,11 +3334,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog type",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog type",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2910,16 +3357,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -2927,7 +3376,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -2935,6 +3386,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -2949,17 +3401,17 @@
           "Catalog V2"
         ],
         "summary": "UpdateType Catalog V2",
-        "description": "Updates an existing catalog type.",
+        "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
         "operationId": "Catalog V2#UpdateType",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog type",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog type",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -2976,12 +3428,12 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
-                "color": "slate",
+                "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "bolt",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
-                "semantic_type": "custom"
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog"
               }
             }
           }
@@ -2999,16 +3451,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -3016,7 +3470,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -3024,6 +3480,7 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -3040,17 +3497,17 @@
           "Catalog V2"
         ],
         "summary": "UpdateTypeSchema Catalog V2",
-        "description": "Update an existing catalog types schema, adding or removing attributes.",
+        "description": "Update an existing catalog types schema, adding or removing attributes.\n\nUpdating the schema is handled separately from creating and updating types, so that you don't\nhave to worry about dependencies between types. For example, if type A has an attribute that\nrelies on type B, you would have to create type B first.\n\nBy allowing the creation of types without a schema, they can be created in any order, but it\nmeans that you need to make a separate call to this endpoint to update the schema.",
         "operationId": "Catalog V2#UpdateTypeSchema",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "ID of this resource",
+            "description": "ID of this catalog type",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "ID of this resource",
+              "description": "ID of this catalog type",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -3067,7 +3524,9 @@
                 "attributes": [
                   {
                     "array": false,
+                    "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "mode": "manual",
                     "name": "tier",
                     "type": "Custom[\"Service\"]"
                   }
@@ -3090,16 +3549,18 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
-                    "color": "slate",
+                    "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "external_type": "PagerDutyService",
                     "icon": "bolt",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
                     "ranked": true,
+                    "registry_type": "PagerDutyService",
                     "required_integrations": [
                       "pager_duty"
                     ],
@@ -3107,7 +3568,9 @@
                       "attributes": [
                         {
                           "array": false,
+                          "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "manual",
                           "name": "tier",
                           "type": "Custom[\"Service\"]"
                         }
@@ -3115,7 +3578,595 @@
                       "version": 1
                     },
                     "semantic_type": "custom",
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/custom_fields": {
+      "get": {
+        "tags": [
+          "Custom Fields V2"
+        ],
+        "summary": "List Custom Fields V2",
+        "description": "List all custom fields for an organisation.",
+        "operationId": "Custom Fields V2#List",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody5"
+                },
+                "example": {
+                  "custom_fields": [
+                    {
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Which team is impacted by this issue",
+                      "field_type": "single_select",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Affected Team",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Custom Fields V2"
+        ],
+        "summary": "Create Custom Fields V2",
+        "description": "Create a new custom field",
+        "operationId": "Custom Fields V2#Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody3"
+              },
+              "example": {
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "name": "Affected Team"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody5"
+                },
+                "example": {
+                  "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/custom_fields/{id}": {
+      "delete": {
+        "tags": [
+          "Custom Fields V2"
+        ],
+        "summary": "Delete Custom Fields V2",
+        "description": "Delete a custom field",
+        "operationId": "Custom Fields V2#Delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the custom field",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the custom field",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Custom Fields V2"
+        ],
+        "summary": "Show Custom Fields V2",
+        "description": "Get a single custom field.",
+        "operationId": "Custom Fields V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the custom field",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the custom field",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody5"
+                },
+                "example": {
+                  "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Custom Fields V2"
+        ],
+        "summary": "Update Custom Fields V2",
+        "description": "Update the details of a custom field",
+        "operationId": "Custom Fields V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the custom field",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the custom field",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody3"
+              },
+              "example": {
+                "description": "Which team is impacted by this issue",
+                "name": "Affected Team"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody5"
+                },
+                "example": {
+                  "custom_field": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/follow_ups": {
+      "get": {
+        "tags": [
+          "Follow-ups V2"
+        ],
+        "summary": "List Follow-ups V2",
+        "description": "List all follow-ups for an organisation.",
+        "operationId": "Follow-ups V2#List",
+        "parameters": [
+          {
+            "name": "incident_id",
+            "in": "query",
+            "description": "Find follow-ups related to this incident",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "Find follow-ups related to this incident",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          {
+            "name": "incident_mode",
+            "in": "query",
+            "description": "Filter to follow-ups from incidents of the given mode. If not set, only follow-ups from `standard` and `retrospective` incidents are returned",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter to follow-ups from incidents of the given mode. If not set, only follow-ups from `standard` and `retrospective` incidents are returned",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "retrospective",
+                "test",
+                "tutorial"
+              ]
+            },
+            "example": "standard"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody6"
+                },
+                "example": {
+                  "follow_ups": [
+                    {
+                      "assignee": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "completed_at": "2021-08-17T13:28:57.801578Z",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Call the fire brigade",
+                      "external_issue_reference": {
+                        "issue_name": "INC-123",
+                        "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                        "provider": "asana"
+                      },
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "priority": {
+                        "description": "A follow-up that requires immediate attention.",
+                        "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                        "name": "Urgent",
+                        "rank": 10
+                      },
+                      "status": "outstanding",
+                      "title": "Cat is stuck in the tree",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/follow_ups/{id}": {
+      "get": {
+        "tags": [
+          "Follow-ups V2"
+        ],
+        "summary": "Show Follow-ups V2",
+        "description": "Get a single incident follow-up.",
+        "operationId": "Follow-ups V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the follow-up",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the follow-up",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody6"
+                },
+                "example": {
+                  "follow_up": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "priority": {
+                      "description": "A follow-up that requires immediate attention.",
+                      "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                      "name": "Urgent",
+                      "rank": 10
+                    },
+                    "status": "outstanding",
+                    "title": "Cat is stuck in the tree",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/incident_roles": {
+      "get": {
+        "tags": [
+          "Incident Roles V2"
+        ],
+        "summary": "List Incident Roles V2",
+        "description": "List all incident roles for an organisation.",
+        "operationId": "Incident Roles V2#List",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody9"
+                },
+                "example": {
+                  "incident_roles": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "The person currently coordinating the incident",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                      "name": "Incident Lead",
+                      "role_type": "lead",
+                      "shortform": "lead",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Incident Roles V2"
+        ],
+        "summary": "Create Incident Roles V2",
+        "description": "Create a new incident role",
+        "operationId": "Incident Roles V2#Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody7"
+              },
+              "example": {
+                "description": "The person currently coordinating the incident",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "shortform": "lead"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody8"
+                },
+                "example": {
+                  "incident_role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/incident_roles/{id}": {
+      "delete": {
+        "tags": [
+          "Incident Roles V2"
+        ],
+        "summary": "Delete Incident Roles V2",
+        "description": "Removes an existing role",
+        "operationId": "Incident Roles V2#Delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the role",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the role",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Incident Roles V2"
+        ],
+        "summary": "Show Incident Roles V2",
+        "description": "Get a single incident role.",
+        "operationId": "Incident Roles V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the role",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the role",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody8"
+                },
+                "example": {
+                  "incident_role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Incident Roles V2"
+        ],
+        "summary": "Update Incident Roles V2",
+        "description": "Update an existing incident role",
+        "operationId": "Incident Roles V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the role",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the role",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody5"
+              },
+              "example": {
+                "description": "The person currently coordinating the incident",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "shortform": "lead"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody8"
+                },
+                "example": {
+                  "incident_role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "role_type": "lead",
+                    "shortform": "lead",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -3139,7 +4190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody7"
+                  "$ref": "#/components/schemas/ListResponseBody11"
                 },
                 "example": {
                   "incident_timestamps": [
@@ -3184,7 +4235,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/ShowResponseBody10"
                 },
                 "example": {
                   "incident_timestamp": {
@@ -3230,6 +4281,7 @@
               "description": "Integer number of records to return",
               "default": 25,
               "example": 25,
+              "format": "int64",
               "maximum": 500
             },
             "example": 25
@@ -3253,7 +4305,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody9"
+                  "$ref": "#/components/schemas/ListResponseBody13"
                 },
                 "example": {
                   "incident_updates": [
@@ -3261,7 +4313,7 @@
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "message": "The cat is getting irritable, best rescue it soon",
+                      "message": "We're working on a fix, hoping to ship in the next 30 minutes",
                       "new_incident_status": {
                         "category": "triage",
                         "created_at": "2021-08-17T13:28:57.801578Z",
@@ -3311,7 +4363,7 @@
           "Incidents V2"
         ],
         "summary": "List Incidents V2",
-        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
+        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard&mode[one_of]=retrospective&mode[one_of]=test&mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
         "operationId": "Incidents V2#List",
         "parameters": [
           {
@@ -3357,16 +4409,46 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "example": "value"
+                  "example": "some_value"
                 },
                 "example": [
-                  "value"
+                  "some_value"
                 ]
               }
             },
             "example": {
               "one_of": [
                 "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            }
+          },
+          {
+            "name": "status_category",
+            "in": "query",
+            "description": "Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{\"one_of\": [\"triage\", \"active\", \"post-incident\", \"closed\"] }`, meaning that canceled, declined and merged incidents are not included.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "object",
+              "description": "Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{\"one_of\": [\"triage\", \"active\", \"post-incident\", \"closed\"] }`, meaning that canceled, declined and merged incidents are not included.",
+              "example": {
+                "one_of": [
+                  "active"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "some_value"
+                },
+                "example": [
+                  "some_value"
+                ]
+              }
+            },
+            "example": {
+              "one_of": [
+                "active"
               ]
             }
           },
@@ -3387,10 +4469,10 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "example": "value"
+                  "example": "some_value"
                 },
                 "example": [
-                  "value"
+                  "some_value"
                 ]
               }
             },
@@ -3403,11 +4485,11 @@
           {
             "name": "incident_type",
             "in": "query",
-            "description": "Filter on incident type. The accepted operator is 'one_of'.",
+            "description": "Filter on incident type. The accepted operators are 'one_of, or 'not_in'.",
             "allowEmptyValue": true,
             "schema": {
               "type": "object",
-              "description": "Filter on incident type. The accepted operator is 'one_of'.",
+              "description": "Filter on incident type. The accepted operators are 'one_of, or 'not_in'.",
               "example": {
                 "one_of": [
                   "01GBSQF3FHF7FWZQNWGHAVQ804"
@@ -3417,10 +4499,10 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "example": "value"
+                  "example": "some_value"
                 },
                 "example": [
-                  "value"
+                  "some_value"
                 ]
               }
             },
@@ -3449,7 +4531,7 @@
               "additionalProperties": {
                 "type": "object",
                 "example": {
-                  "key": [
+                  "abc123": [
                     "value"
                   ]
                 },
@@ -3493,7 +4575,7 @@
               "additionalProperties": {
                 "type": "object",
                 "example": {
-                  "key": [
+                  "abc123": [
                     "value"
                   ]
                 },
@@ -3517,6 +4599,36 @@
                 ]
               }
             }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "description": "Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{\"one_of\": [\"standard\", \"retrospective\"] }`, meaning that test and tutorial incidents are not included.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "object",
+              "description": "Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{\"one_of\": [\"standard\", \"retrospective\"] }`, meaning that test and tutorial incidents are not included.",
+              "example": {
+                "one_of": [
+                  "retrospective"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "some_value"
+                },
+                "example": [
+                  "some_value"
+                ]
+              }
+            },
+            "example": {
+              "one_of": [
+                "retrospective"
+              ]
+            }
           }
         ],
         "responses": {
@@ -3525,7 +4637,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody11"
+                  "$ref": "#/components/schemas/ListResponseBody15"
                 },
                 "example": {
                   "incidents": [
@@ -3563,6 +4675,15 @@
                           },
                           "values": [
                             {
+                              "value_catalog_entry": {
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
+                                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "name": "Primary On-call"
+                              },
                               "value_link": "https://google.com/",
                               "value_numeric": "123.456",
                               "value_option": {
@@ -3574,6 +4695,15 @@
                               "value_text": "This is my text field, I hope you like it"
                             }
                           ]
+                        }
+                      ],
+                      "duration_metrics": [
+                        {
+                          "duration_metric": {
+                            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                            "name": "Lasted"
+                          },
+                          "value_seconds": 1
                         }
                       ],
                       "external_issue_reference": {
@@ -3597,7 +4727,7 @@
                             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                             "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                             "name": "Incident Lead",
-                            "required": true,
+                            "required": false,
                             "role_type": "lead",
                             "shortform": "lead",
                             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -3653,7 +4783,11 @@
                       "slack_team_id": "T02A1FSLE8J",
                       "summary": "Our database is really really sad, and we don't know why yet.",
                       "updated_at": "2021-08-17T13:28:57.801578Z",
-                      "visibility": "public"
+                      "visibility": "public",
+                      "workload_minutes_late": 40.7,
+                      "workload_minutes_sleeping": 0,
+                      "workload_minutes_total": 60.7,
+                      "workload_minutes_working": 20
                     }
                   ],
                   "pagination_meta": {
@@ -3679,7 +4813,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               },
               "example": {
                 "custom_field_entries": [
@@ -3688,6 +4822,7 @@
                     "values": [
                       {
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "value_link": "https://google.com/",
                         "value_numeric": "123.456",
                         "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -3723,6 +4858,7 @@
                   "slack_channel_id": "abc123"
                 },
                 "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+                "slack_channel_name_override": "inc-123-database-down",
                 "slack_team_id": "T02A1FSLE8J",
                 "summary": "Our database is really really sad, and we don't know why yet.",
                 "visibility": "public"
@@ -3736,7 +4872,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody9"
+                  "$ref": "#/components/schemas/ShowResponseBody13"
                 },
                 "example": {
                   "incident": {
@@ -3773,6 +4909,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -3784,6 +4929,15 @@
                             "value_text": "This is my text field, I hope you like it"
                           }
                         ]
+                      }
+                    ],
+                    "duration_metrics": [
+                      {
+                        "duration_metric": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Lasted"
+                        },
+                        "value_seconds": 1
                       }
                     ],
                     "external_issue_reference": {
@@ -3807,7 +4961,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -3863,7 +5017,11 @@
                     "slack_team_id": "T02A1FSLE8J",
                     "summary": "Our database is really really sad, and we don't know why yet.",
                     "updated_at": "2021-08-17T13:28:57.801578Z",
-                    "visibility": "public"
+                    "visibility": "public",
+                    "workload_minutes_late": 40.7,
+                    "workload_minutes_sleeping": 0,
+                    "workload_minutes_total": 60.7,
+                    "workload_minutes_working": 20
                   }
                 }
               }
@@ -3878,7 +5036,7 @@
           "Incidents V2"
         ],
         "summary": "Show Incidents V2",
-        "description": "Get a single incident.",
+        "description": "Get a single incident.\n\nThe ID supplied can be either the incident's full ID, or the numeric part of its\nreference. For example, to get INC-123, you could use either its full ID or:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents/123\n",
         "operationId": "Incidents V2#Show",
         "parameters": [
           {
@@ -3900,7 +5058,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody9"
+                  "$ref": "#/components/schemas/ShowResponseBody13"
                 },
                 "example": {
                   "incident": {
@@ -3937,6 +5095,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -3948,6 +5115,15 @@
                             "value_text": "This is my text field, I hope you like it"
                           }
                         ]
+                      }
+                    ],
+                    "duration_metrics": [
+                      {
+                        "duration_metric": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Lasted"
+                        },
+                        "value_seconds": 1
                       }
                     ],
                     "external_issue_reference": {
@@ -3971,7 +5147,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -4027,7 +5203,11 @@
                     "slack_team_id": "T02A1FSLE8J",
                     "summary": "Our database is really really sad, and we don't know why yet.",
                     "updated_at": "2021-08-17T13:28:57.801578Z",
-                    "visibility": "public"
+                    "visibility": "public",
+                    "workload_minutes_late": 40.7,
+                    "workload_minutes_sleeping": 0,
+                    "workload_minutes_total": 60.7,
+                    "workload_minutes_working": 20
                   }
                 }
               }
@@ -4042,7 +5222,7 @@
           "Incidents V2"
         ],
         "summary": "Edit Incidents V2",
-        "description": "Edit an existing incident.\n\nThis endpoint allows you to edit the properties of an existing incident: e.g. set the severity or update custom fields.\n\nWhen using this endpoint, only fields that are provided will be edited (omitted fields \nwill be ignored).\n",
+        "description": "Edit an existing incident.\n\nThis endpoint allows you to edit the properties of an existing incident: e.g. set the severity or update custom fields.\n\nWhen using this endpoint, only fields that are provided will be edited (omitted fields\nwill be ignored).\n",
         "operationId": "Incidents V2#Edit",
         "parameters": [
           {
@@ -4067,12 +5247,14 @@
               },
               "example": {
                 "incident": {
+                  "call_url": "https://zoom.us/foo",
                   "custom_field_entries": [
                     {
                       "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "values": [
                         {
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "value_link": "https://google.com/",
                           "value_numeric": "123.456",
                           "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -4082,6 +5264,17 @@
                       ]
                     }
                   ],
+                  "incident_role_assignments": [
+                    {
+                      "assignee": {
+                        "email": "bob@example.com",
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "slack_user_id": "USER123"
+                      },
+                      "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+                    }
+                  ],
+                  "incident_status_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
                   "incident_timestamp_values": [
                     {
                       "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -4103,7 +5296,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody9"
+                  "$ref": "#/components/schemas/ShowResponseBody13"
                 },
                 "example": {
                   "incident": {
@@ -4140,6 +5333,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -4151,6 +5353,15 @@
                             "value_text": "This is my text field, I hope you like it"
                           }
                         ]
+                      }
+                    ],
+                    "duration_metrics": [
+                      {
+                        "duration_metric": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Lasted"
+                        },
+                        "value_seconds": 1
                       }
                     ],
                     "external_issue_reference": {
@@ -4174,7 +5385,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -4230,7 +5441,150 @@
                     "slack_team_id": "T02A1FSLE8J",
                     "summary": "Our database is really really sad, and we don't know why yet.",
                     "updated_at": "2021-08-17T13:28:57.801578Z",
-                    "visibility": "public"
+                    "visibility": "public",
+                    "workload_minutes_late": 40.7,
+                    "workload_minutes_sleeping": 0,
+                    "workload_minutes_total": 60.7,
+                    "workload_minutes_working": 20
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users": {
+      "get": {
+        "tags": [
+          "Users V2"
+        ],
+        "summary": "List Users V2",
+        "description": "List users for an organisation.",
+        "operationId": "Users V2#List",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Integer number of records to return",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "integer",
+              "description": "Integer number of records to return",
+              "default": 25,
+              "example": 25,
+              "format": "int64",
+              "maximum": 500
+            },
+            "example": 25
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+            },
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody17"
+                },
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  },
+                  "users": [
+                    {
+                      "base_role": {
+                        "description": "Elevated permissions for the customer success team.",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Customer Success",
+                        "slug": "customer-success"
+                      },
+                      "custom_roles": [
+                        {
+                          "description": "Elevated permissions for the customer success team.",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Customer Success",
+                          "slug": "customer-success"
+                        }
+                      ],
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/{id}": {
+      "get": {
+        "tags": [
+          "Users V2"
+        ],
+        "summary": "Show Users V2",
+        "description": "Get a single user.",
+        "operationId": "Users V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier of the user",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier of the user",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody15"
+                },
+                "example": {
+                  "user": {
+                    "base_role": {
+                      "description": "Elevated permissions for the customer success team.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Customer Success",
+                      "slug": "customer-success"
+                    },
+                    "custom_roles": [
+                      {
+                        "description": "Elevated permissions for the customer success team.",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Customer Success",
+                        "slug": "customer-success"
+                      }
+                    ],
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
                   }
                 }
               }
@@ -4242,6 +5596,81 @@
   },
   "components": {
     "schemas": {
+      "APIKeyCreatedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "The type of log entry that this is",
+            "example": "api_key.created"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "type": "string",
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Development API Key",
+                "type": "api_key"
+              }
+            ]
+          },
+          "version": {
+            "type": "integer",
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "action": "api_key.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Development API Key",
+              "type": "api_key"
+            }
+          ],
+          "version": 1
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ]
+      },
       "APIKeyV2": {
         "type": "object",
         "properties": {
@@ -4357,6 +5786,82 @@
           "updated_at"
         ]
       },
+      "ActionV2": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "$ref": "#/components/schemas/UserV1"
+          },
+          "completed_at": {
+            "type": "string",
+            "description": "When the action was completed",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the action",
+            "example": "Call the fire brigade"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the action",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "Unique identifier of the incident the action belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the action",
+            "example": "outstanding",
+            "enum": [
+              "outstanding",
+              "completed",
+              "deleted",
+              "not_doing"
+            ]
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "assignee": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          },
+          "completed_at": "2021-08-17T13:28:57.801578Z",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Call the fire brigade",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "status": "outstanding",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "incident_id",
+          "description",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "ActorV2": {
         "type": "object",
         "properties": {
@@ -4393,11 +5898,24 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.follow_up_created_v1": {
             "$ref": "#/components/schemas/WebhookPrivateResourceV2"
@@ -4411,6 +5929,18 @@
           "private_incident.incident_updated_v2": {
             "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
           "public_incident.follow_up_created_v1": {
             "$ref": "#/components/schemas/ActionV1"
           },
@@ -4419,6 +5949,9 @@
           },
           "public_incident.incident_created_v2": {
             "$ref": "#/components/schemas/IncidentV2"
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
           },
           "public_incident.incident_updated_v2": {
             "$ref": "#/components/schemas/IncidentV2"
@@ -4426,6 +5959,12 @@
         },
         "example": {
           "event_type": "public_incident.incident_created_v2",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          },
           "private_incident.follow_up_created_v1": {
             "id": "abc123"
           },
@@ -4437,6 +5976,60 @@
           },
           "private_incident.incident_updated_v2": {
             "id": "abc123"
+          },
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
           },
           "public_incident.follow_up_created_v1": {
             "assignee": {
@@ -4516,6 +6109,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -4527,6 +6129,15 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ],
             "external_issue_reference": {
@@ -4550,7 +6161,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -4606,7 +6217,179 @@
             "slack_team_id": "T02A1FSLE8J",
             "summary": "Our database is really really sad, and we don't know why yet.",
             "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          },
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
           },
           "public_incident.incident_updated_v2": {
             "call_url": "https://zoom.us/foo",
@@ -4642,6 +6425,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -4653,6 +6445,15 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ],
             "external_issue_reference": {
@@ -4676,7 +6477,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -4732,86 +6533,15 @@
             "slack_team_id": "T02A1FSLE8J",
             "summary": "Our database is really really sad, and we don't know why yet.",
             "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
           }
         },
         "required": [
           "event_type"
-        ]
-      },
-      "AnnouncementRuleCreatedV1ResponseBody": {
-        "type": "object",
-        "properties": {
-          "action": {
-            "type": "string",
-            "description": "The type of log entry that this is",
-            "example": "announcement_rule.created"
-          },
-          "actor": {
-            "$ref": "#/components/schemas/AuditLogActorV2"
-          },
-          "context": {
-            "$ref": "#/components/schemas/AuditLogEntryContextV2"
-          },
-          "occurred_at": {
-            "type": "string",
-            "description": "When the entry occurred",
-            "example": "2021-08-17T13:28:57.801578Z",
-            "format": "date-time"
-          },
-          "targets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AuditLogTargetV2"
-            },
-            "description": "The custom field that was created",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "#engineering",
-                "type": "announcement_rule"
-              }
-            ]
-          },
-          "version": {
-            "type": "integer",
-            "description": "Which version the event is",
-            "example": 1,
-            "format": "int64"
-          }
-        },
-        "example": {
-          "action": "announcement_rule.created",
-          "actor": {
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "metadata": {
-              "user_base_role_slug": "admin",
-              "user_custom_role_slugs": "engineering,security"
-            },
-            "name": "John Doe",
-            "type": "user"
-          },
-          "context": {
-            "location": "1.2.3.4",
-            "user_agent": "Chrome/91.0.4472.114"
-          },
-          "occurred_at": "2021-08-17T13:28:57.801578Z",
-          "targets": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "#engineering",
-              "type": "announcement_rule"
-            }
-          ],
-          "version": 1
-        },
-        "required": [
-          "action",
-          "occurred_at",
-          "version",
-          "actor",
-          "targets",
-          "context"
         ]
       },
       "AuditLogActorMetadataV2": {
@@ -4951,9 +6681,15 @@
             "description": "The type of target",
             "example": "user",
             "enum": [
-              "announcement_rule",
               "api_key",
+              "alert_route",
+              "alert_schema",
+              "alert_source",
+              "announcement_rule",
+              "catalog_type",
               "custom_field",
+              "debrief_invite_rule",
+              "escalation_path",
               "follow_up_priority",
               "incident",
               "incident_duration_metric",
@@ -4962,12 +6698,17 @@
               "incident_timestamp",
               "incident_type",
               "integration",
+              "internal_status_page",
+              "nudge",
               "policy",
               "private_incident_membership",
               "rbac_role",
+              "schedule",
               "scim_group",
               "severity",
               "status_page",
+              "status_page_sub_page",
+              "status_page_template",
               "user",
               "workflow"
             ]
@@ -5051,158 +6792,15 @@
           "before_custom_role_slugs": "engineering,security"
         }
       },
-      "CatalogAttributeBindingPayloadV2": {
-        "type": "object",
-        "properties": {
-          "array_value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CatalogAttributeValuePayloadV2"
-            },
-            "description": "If set, this is the array value of the attribute",
-            "example": [
-              {
-                "literal": "SEV123"
-              }
-            ]
-          },
-          "value": {
-            "$ref": "#/components/schemas/CatalogAttributeValuePayloadV2"
-          }
-        },
-        "example": {
-          "array_value": [
-            {
-              "literal": "SEV123"
-            }
-          ],
-          "value": {
-            "literal": "SEV123"
-          }
-        }
-      },
-      "CatalogAttributeBindingV2": {
-        "type": "object",
-        "properties": {
-          "array_value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CatalogAttributeValueV2"
-            },
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "catalog_entry": {
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "sort_key": "000020"
-              }
-            ]
-          },
-          "value": {
-            "$ref": "#/components/schemas/CatalogAttributeValueV2"
-          }
-        },
-        "example": {
-          "array_value": [
-            {
-              "catalog_entry": {
-                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "catalog_entry_name": "Primary escalation",
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-              "is_image_slack_icon": false,
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "sort_key": "000020"
-            }
-          ],
-          "value": {
-            "catalog_entry": {
-              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "catalog_entry_name": "Primary escalation",
-              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-            "is_image_slack_icon": false,
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "sort_key": "000020"
-          }
-        }
-      },
-      "CatalogAttributeValuePayloadV2": {
-        "type": "object",
-        "properties": {
-          "literal": {
-            "type": "string",
-            "description": "The literal value of this attribute",
-            "example": "SEV123"
-          }
-        },
-        "example": {
-          "literal": "SEV123"
-        }
-      },
-      "CatalogAttributeValueV2": {
-        "type": "object",
-        "properties": {
-          "catalog_entry": {
-            "$ref": "#/components/schemas/CatalogEntryReferenceV2"
-          },
-          "image_url": {
-            "type": "string",
-            "description": "If appropriate, URL to an image that can be displayed alongside the option",
-            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
-          },
-          "is_image_slack_icon": {
-            "type": "boolean",
-            "description": "If true, the image_url is a Slack icon and should be displayed as such",
-            "example": false
-          },
-          "label": {
-            "type": "string",
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones"
-          },
-          "literal": {
-            "type": "string",
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123"
-          },
-          "sort_key": {
-            "type": "string",
-            "description": "Gives an indication of how to sort the options when displayed to the user",
-            "example": "000020"
-          }
-        },
-        "example": {
-          "catalog_entry": {
-            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "catalog_entry_name": "Primary escalation",
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-          },
-          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-          "is_image_slack_icon": false,
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "sort_key": "000020"
-        },
-        "required": [
-          "label",
-          "sort_key"
-        ]
-      },
       "CatalogEntryReferenceV2": {
         "type": "object",
         "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
           "catalog_entry_id": {
             "type": "string",
             "description": "ID of this catalog entry",
@@ -5220,6 +6818,7 @@
           }
         },
         "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
           "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "catalog_entry_name": "Primary escalation",
           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
@@ -5245,6 +6844,12 @@
               "lawrence"
             ]
           },
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
           "attribute_values": {
             "type": "object",
             "description": "Values of this entry",
@@ -5253,33 +6858,43 @@
                 "array_value": [
                   {
                     "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "sort_key": "000020"
+                    "reference": "incident.severity",
+                    "sort_key": "000020",
+                    "unavailable": false,
+                    "value": "abc123"
                   }
                 ],
                 "value": {
                   "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "sort_key": "000020"
+                  "reference": "incident.severity",
+                  "sort_key": "000020",
+                  "unavailable": false,
+                  "value": "abc123"
                 }
               }
             },
             "additionalProperties": {
-              "$ref": "#/components/schemas/CatalogAttributeBindingV2"
+              "$ref": "#/components/schemas/EngineParamBindingV2"
             }
           },
           "catalog_type_id": {
@@ -5300,7 +6915,7 @@
           },
           "id": {
             "type": "string",
-            "description": "ID of this resource",
+            "description": "ID of this catalog entry",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "name": {
@@ -5326,33 +6941,44 @@
             "lawrence@incident.io",
             "lawrence"
           ],
+          "archived_at": "2021-08-17T14:28:57.801578Z",
           "attribute_values": {
             "abc123": {
               "array_value": [
                 {
                   "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "sort_key": "000020"
+                  "reference": "incident.severity",
+                  "sort_key": "000020",
+                  "unavailable": false,
+                  "value": "abc123"
                 }
               ],
               "value": {
                 "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "sort_key": "000020"
+                "reference": "incident.severity",
+                "sort_key": "000020",
+                "unavailable": false,
+                "value": "abc123"
               }
             }
           },
@@ -5422,7 +7048,8 @@
           "description",
           "value_docstring",
           "category",
-          "config"
+          "config",
+          "is_user_link"
         ]
       },
       "CatalogTypeAttributePayloadV2": {
@@ -5433,10 +7060,28 @@
             "description": "Whether this attribute is an array",
             "example": false
           },
+          "backlink_attribute": {
+            "type": "string",
+            "description": "The attribute to use (if this is a backlink)",
+            "example": "abc123"
+          },
           "id": {
             "type": "string",
             "description": "The ID of this attribute",
             "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Controls how this attribute is modified",
+            "example": "manual",
+            "enum": [
+              "",
+              "manual",
+              "external",
+              "internal",
+              "dynamic",
+              "backlink"
+            ]
           },
           "name": {
             "type": "string",
@@ -5451,7 +7096,9 @@
         },
         "example": {
           "array": false,
+          "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "mode": "manual",
           "name": "tier",
           "type": "Custom[\"Service\"]"
         },
@@ -5469,10 +7116,28 @@
             "description": "Whether this attribute is an array",
             "example": false
           },
+          "backlink_attribute": {
+            "type": "string",
+            "description": "The attribute to use (if this is a backlink)",
+            "example": "abc123"
+          },
           "id": {
             "type": "string",
             "description": "The ID of this attribute",
             "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Controls how this attribute is modified",
+            "example": "manual",
+            "enum": [
+              "",
+              "manual",
+              "external",
+              "internal",
+              "dynamic",
+              "backlink"
+            ]
           },
           "name": {
             "type": "string",
@@ -5487,12 +7152,15 @@
         },
         "example": {
           "array": false,
+          "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "mode": "manual",
           "name": "tier",
           "type": "Custom[\"Service\"]"
         },
         "required": [
           "id",
+          "mode",
           "name",
           "type",
           "array"
@@ -5510,7 +7178,9 @@
             "example": [
               {
                 "array": false,
+                "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "manual",
                 "name": "tier",
                 "type": "Custom[\"Service\"]"
               }
@@ -5527,7 +7197,9 @@
           "attributes": [
             {
               "array": false,
+              "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "mode": "manual",
               "name": "tier",
               "type": "Custom[\"Service\"]"
             }
@@ -5556,14 +7228,15 @@
           "color": {
             "type": "string",
             "description": "Sets the display color of this type in the dashboard",
-            "example": "slate",
+            "example": "yellow",
             "enum": [
-              "slate",
-              "red",
               "yellow",
               "green",
               "blue",
-              "violet"
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
             ]
           },
           "created_at": {
@@ -5577,16 +7250,16 @@
             "description": "Human readble description of this type",
             "example": "Represents Kubernetes clusters that we run inside of GKE."
           },
+          "dynamic_resource_parameter": {
+            "type": "string",
+            "description": "If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.",
+            "example": "abc123"
+          },
           "estimated_count": {
             "type": "integer",
             "description": "If populated, gives an estimated count of entries for this type",
             "example": 7,
             "format": "int64"
-          },
-          "external_type": {
-            "type": "string",
-            "description": "The external resource this type is synced from, if any",
-            "example": "PagerDutyService"
           },
           "icon": {
             "type": "string",
@@ -5598,13 +7271,21 @@
               "briefcase",
               "browser",
               "bulb",
+              "calendar",
               "clock",
               "cog",
+              "components",
               "database",
               "doc",
               "email",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
               "server",
               "severity",
+              "store",
               "star",
               "tag",
               "user",
@@ -5613,13 +7294,19 @@
           },
           "id": {
             "type": "string",
-            "description": "ID of this resource",
+            "description": "ID of this catalog type",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "is_editable": {
             "type": "boolean",
             "description": "Catalog types that are synced with external resources can't be edited",
             "example": false
+          },
+          "last_synced_at": {
+            "type": "string",
+            "description": "When this type was last synced (if it's ever been sync'd)",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
           },
           "name": {
             "type": "string",
@@ -5630,6 +7317,11 @@
             "type": "boolean",
             "description": "If this type should be ranked",
             "example": true
+          },
+          "registry_type": {
+            "type": "string",
+            "description": "The registry resource this type is synced from, if any",
+            "example": "PagerDutyService"
           },
           "required_integrations": {
             "type": "array",
@@ -5647,8 +7339,13 @@
           },
           "semantic_type": {
             "type": "string",
-            "description": "Semantic type of this resource",
+            "description": "Semantic type of this resource (unused)",
             "example": "custom"
+          },
+          "source_repo_url": {
+            "type": "string",
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog"
           },
           "type_name": {
             "type": "string",
@@ -5660,27 +7357,24 @@
             "description": "When this type was last updated",
             "example": "2021-08-17T13:28:57.801578Z",
             "format": "date-time"
-          },
-          "source_repo_url": {
-            "type": "string",
-            "description": "The url of the external repository where this type is managed",
-            "example": "https://github.com/incident-io/catalog-importer"
           }
         },
         "example": {
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
-          "color": "slate",
+          "color": "yellow",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "external_type": "PagerDutyService",
           "icon": "bolt",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
+          "last_synced_at": "2021-08-17T13:28:57.801578Z",
           "name": "Kubernetes Cluster",
           "ranked": true,
+          "registry_type": "PagerDutyService",
           "required_integrations": [
             "pager_duty"
           ],
@@ -5688,7 +7382,9 @@
             "attributes": [
               {
                 "array": false,
+                "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "manual",
                 "name": "tier",
                 "type": "Custom[\"Service\"]"
               }
@@ -5696,9 +7392,9 @@
             "version": 1
           },
           "semantic_type": "custom",
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
           "type_name": "Custom[\"BackstageGroup\"]",
-          "updated_at": "2021-08-17T13:28:57.801578Z",
-          "source_repo_url": "https://github.com/incident-io/catalog-importer"
+          "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
           "id",
@@ -5713,7 +7409,8 @@
           "is_editable",
           "annotations",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "mode"
         ]
       },
       "CreateEntryRequestBody": {
@@ -5738,16 +7435,18 @@
               "abc123": {
                 "array_value": [
                   {
-                    "literal": "SEV123"
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
                   }
                 ],
                 "value": {
-                  "literal": "SEV123"
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
                 }
               }
             },
             "additionalProperties": {
-              "$ref": "#/components/schemas/CatalogAttributeBindingPayloadV2"
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
             }
           },
           "catalog_type_id": {
@@ -5781,11 +7480,13 @@
             "abc123": {
               "array_value": [
                 {
-                  "literal": "SEV123"
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
                 }
               ],
               "value": {
-                "literal": "SEV123"
+                "literal": "SEV123",
+                "reference": "incident.severity"
               }
             }
           },
@@ -5813,33 +7514,44 @@
               "lawrence@incident.io",
               "lawrence"
             ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
             "attribute_values": {
               "abc123": {
                 "array_value": [
                   {
                     "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "sort_key": "000020"
+                    "reference": "incident.severity",
+                    "sort_key": "000020",
+                    "unavailable": false,
+                    "value": "abc123"
                   }
                 ],
                 "value": {
                   "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "sort_key": "000020"
+                  "reference": "incident.severity",
+                  "sort_key": "000020",
+                  "unavailable": false,
+                  "value": "abc123"
                 }
               }
             },
@@ -5854,6 +7566,107 @@
         },
         "required": [
           "catalog_entry"
+        ]
+      },
+      "CreateHTTPRequestBody": {
+        "type": "object",
+        "properties": {
+          "deduplication_key": {
+            "type": "string",
+            "description": "A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.",
+            "example": "4293868629"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description that optionally adds more detail to title ",
+            "example": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix..."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Any additional metadata that you've configured your alert source to parse",
+            "example": {
+              "service": "hello.world.com",
+              "team": [
+                "my-team"
+              ]
+            },
+            "additionalProperties": true
+          },
+          "source_url": {
+            "type": "string",
+            "description": "If applicable, a link to the alert in the upstream system",
+            "example": "https://www.my-alerting-platform.com/alerts/my-alert-123"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of this alert",
+            "example": "firing",
+            "enum": [
+              "firing",
+              "resolved"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Alert title which is used when summarising the alert",
+            "example": "*errors.withMessage: PG::Error failed to connect"
+          }
+        },
+        "example": {
+          "deduplication_key": "4293868629",
+          "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
+          "metadata": {
+            "service": "hello.world.com",
+            "team": [
+              "my-team"
+            ]
+          },
+          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+          "status": "firing",
+          "title": "*errors.withMessage: PG::Error failed to connect"
+        },
+        "required": [
+          "title",
+          "status"
+        ]
+      },
+      "CreateHTTPResponseBody": {
+        "type": "object",
+        "properties": {
+          "deduplication_key": {
+            "type": "string",
+            "description": "The deduplication key that the event has been processed with",
+            "example": "unique-key",
+            "enum": [
+              "unique-key"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Human readable message giving detail about the event",
+            "example": "Event accepted for processing",
+            "enum": [
+              "Event accepted for processing"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the event",
+            "example": "success",
+            "enum": [
+              "success"
+            ]
+          }
+        },
+        "example": {
+          "deduplication_key": "unique-key",
+          "message": "Event accepted for processing",
+          "status": "success"
+        },
+        "required": [
+          "status",
+          "message",
+          "deduplication_key"
         ]
       },
       "CreateRequestBody": {
@@ -5887,238 +7700,7 @@
           "value"
         ]
       },
-      "CreateRequestBody2": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Description of the custom field",
-            "example": "Which team is impacted by this issue"
-          },
-          "field_type": {
-            "type": "string",
-            "description": "Type of custom field",
-            "example": "single_select",
-            "enum": [
-              "single_select",
-              "multi_select",
-              "text",
-              "link",
-              "numeric"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Human readable name for the custom field",
-            "example": "Affected Team",
-            "maxLength": 50
-          },
-          "required": {
-            "type": "string",
-            "description": "When this custom field must be set during the incident lifecycle.",
-            "example": "never",
-            "enum": [
-              "never",
-              "before_closure",
-              "always"
-            ]
-          },
-          "show_before_closure": {
-            "type": "boolean",
-            "description": "Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.",
-            "example": true
-          },
-          "show_before_creation": {
-            "type": "boolean",
-            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
-            "example": true
-          },
-          "show_before_update": {
-            "type": "boolean",
-            "description": "Whether a custom field should be shown in the incident update modal.",
-            "example": true
-          },
-          "show_in_announcement_post": {
-            "type": "boolean",
-            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
-            "example": true
-          }
-        },
-        "example": {
-          "description": "Which team is impacted by this issue",
-          "field_type": "single_select",
-          "name": "Affected Team",
-          "required": "never",
-          "show_before_closure": true,
-          "show_before_creation": true,
-          "show_before_update": true,
-          "show_in_announcement_post": true
-        },
-        "required": [
-          "id",
-          "name",
-          "description",
-          "field_type",
-          "required",
-          "show_before_creation",
-          "show_before_closure",
-          "show_before_update",
-          "options",
-          "created_at",
-          "updated_at"
-        ]
-      },
-      "CreateRequestBody3": {
-        "type": "object",
-        "properties": {
-          "incident_id": {
-            "type": "string",
-            "description": "ID of the incident to add an attachment to",
-            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
-          },
-          "resource": {
-            "type": "object",
-            "properties": {
-              "external_id": {
-                "type": "string",
-                "description": "ID of the resource in the external system",
-                "example": "123"
-              },
-              "resource_type": {
-                "type": "string",
-                "description": "E.g. PagerDuty: the external system that holds the resource",
-                "example": "pager_duty_incident",
-                "enum": [
-                  "pager_duty_incident",
-                  "opsgenie_alert",
-                  "datadog_monitor_alert",
-                  "github_pull_request",
-                  "sentry_issue",
-                  "atlassian_statuspage_incident",
-                  "zendesk_ticket",
-                  "statuspage_incident"
-                ]
-              }
-            },
-            "example": {
-              "external_id": "123",
-              "resource_type": "pager_duty_incident"
-            },
-            "required": [
-              "id",
-              "permalink",
-              "external_id",
-              "title",
-              "resource_type",
-              "resource_type_label",
-              "created_at",
-              "updated_at"
-            ]
-          }
-        },
-        "example": {
-          "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
-          "resource": {
-            "external_id": "123",
-            "resource_type": "pager_duty_incident"
-          }
-        },
-        "required": [
-          "incident_id",
-          "resource"
-        ]
-      },
-      "CreateRequestBody4": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Describes the purpose of the role",
-            "example": "The person currently coordinating the incident",
-            "minLength": 1
-          },
-          "instructions": {
-            "type": "string",
-            "description": "Provided to whoever is nominated for the role",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities"
-          },
-          "name": {
-            "type": "string",
-            "description": "Human readable name of the incident role",
-            "example": "Incident Lead",
-            "minLength": 1
-          },
-          "required": {
-            "type": "boolean",
-            "description": "Whether incident require this role to be set",
-            "example": true
-          },
-          "shortform": {
-            "type": "string",
-            "description": "Short human readable name for Slack",
-            "example": "lead",
-            "minLength": 1
-          }
-        },
-        "example": {
-          "description": "The person currently coordinating the incident",
-          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-          "name": "Incident Lead",
-          "required": true,
-          "shortform": "lead"
-        },
-        "required": [
-          "name",
-          "shortform",
-          "description",
-          "instructions",
-          "required",
-          "conditions",
-          "id",
-          "role_type",
-          "created_at",
-          "updated_at"
-        ]
-      },
-      "CreateRequestBody5": {
-        "type": "object",
-        "properties": {
-          "category": {
-            "type": "string",
-            "description": "Whether the status should be considered 'live' or 'closed'. The triage and declined statuses cannot be created or modified.",
-            "example": "live",
-            "enum": [
-              "live",
-              "closed"
-            ]
-          },
-          "description": {
-            "type": "string",
-            "description": "Rich text description of the incident status",
-            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
-          },
-          "name": {
-            "type": "string",
-            "description": "Unique name of this status",
-            "example": "Closed"
-          }
-        },
-        "example": {
-          "category": "live",
-          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-          "name": "Closed"
-        },
-        "required": [
-          "name",
-          "description",
-          "category",
-          "id",
-          "rank",
-          "created_at",
-          "updated_at"
-        ]
-      },
-      "CreateRequestBody6": {
+      "CreateRequestBody10": {
         "type": "object",
         "properties": {
           "custom_field_entries": {
@@ -6133,163 +7715,7 @@
                 "values": [
                   {
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real or test",
-            "example": "real",
-            "enum": [
-              "real",
-              "test"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "ID of the Slack team / workspace",
-            "example": "T02A1FSLE8J"
-          },
-          "source_message_channel_id": {
-            "type": "string",
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5"
-          },
-          "source_message_timestamp": {
-            "type": "string",
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509"
-          },
-          "status": {
-            "type": "string",
-            "description": "Current status of the incident",
-            "example": "triage",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ]
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
-        },
-        "required": [
-          "idempotency_key",
-          "visibility"
-        ]
-      },
-      "CreateRequestBody7": {
-        "type": "object",
-        "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -6374,6 +7800,11 @@
             "description": "Severity to create incident as",
             "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
           },
+          "slack_channel_name_override": {
+            "type": "string",
+            "description": "Name of the Slack channel to create for this incident",
+            "example": "inc-123-database-down"
+          },
           "slack_team_id": {
             "type": "string",
             "description": "Slack Team to create the incident in",
@@ -6401,6 +7832,7 @@
               "values": [
                 {
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "value_link": "https://google.com/",
                   "value_numeric": "123.456",
                   "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -6436,6 +7868,7 @@
             "slack_channel_id": "abc123"
           },
           "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_channel_name_override": "inc-123-database-down",
           "slack_team_id": "T02A1FSLE8J",
           "summary": "Our database is really really sad, and we don't know why yet.",
           "visibility": "public"
@@ -6445,7 +7878,7 @@
           "visibility"
         ]
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody11": {
         "type": "object",
         "properties": {
           "description": {
@@ -6476,6 +7909,518 @@
           "description"
         ]
       },
+      "CreateRequestBody2": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of custom field",
+            "example": "single_select",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          },
+          "required": {
+            "type": "string",
+            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
+            "example": "never",
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ]
+          },
+          "required_v2": {
+            "type": "string",
+            "description": "When this custom field must be set during the incident lifecycle.",
+            "example": "never",
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
+          },
+          "show_before_closure": {
+            "type": "boolean",
+            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
+            "example": true
+          },
+          "show_before_creation": {
+            "type": "boolean",
+            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
+            "example": true
+          },
+          "show_before_update": {
+            "type": "boolean",
+            "description": "Whether a custom field should be shown in the incident update modal.",
+            "example": true
+          },
+          "show_in_announcement_post": {
+            "type": "boolean",
+            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
+            "example": true
+          }
+        },
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "name": "Affected Team",
+          "required": "never",
+          "required_v2": "never",
+          "show_before_closure": true,
+          "show_before_creation": true,
+          "show_before_update": true,
+          "show_in_announcement_post": true
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "field_type",
+          "show_before_creation",
+          "show_before_closure",
+          "show_before_update",
+          "options",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateRequestBody3": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of custom field",
+            "example": "single_select",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          }
+        },
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "name": "Affected Team"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "field_type",
+          "cannot_be_unset",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateRequestBody4": {
+        "type": "object",
+        "properties": {
+          "incident_id": {
+            "type": "string",
+            "description": "ID of the incident to add an attachment to",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          "resource": {
+            "type": "object",
+            "properties": {
+              "external_id": {
+                "type": "string",
+                "description": "ID of the resource in the external system",
+                "example": "123"
+              },
+              "resource_type": {
+                "type": "string",
+                "description": "E.g. PagerDuty: the external system that holds the resource",
+                "example": "pager_duty_incident",
+                "enum": [
+                  "pager_duty_incident",
+                  "opsgenie_alert",
+                  "datadog_monitor_alert",
+                  "github_pull_request",
+                  "gitlab_merge_request",
+                  "sentry_issue",
+                  "atlassian_statuspage_incident",
+                  "zendesk_ticket",
+                  "google_calendar_event",
+                  "scrubbed",
+                  "statuspage_incident"
+                ]
+              }
+            },
+            "example": {
+              "external_id": "123",
+              "resource_type": "pager_duty_incident"
+            },
+            "required": [
+              "id",
+              "permalink",
+              "external_id",
+              "title",
+              "resource_type",
+              "resource_type_label",
+              "created_at",
+              "updated_at"
+            ]
+          }
+        },
+        "example": {
+          "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "resource": {
+            "external_id": "123",
+            "resource_type": "pager_duty_incident"
+          }
+        },
+        "required": [
+          "incident_id",
+          "resource"
+        ]
+      },
+      "CreateRequestBody5": {
+        "type": "object",
+        "properties": {
+          "incident_id": {
+            "type": "string",
+            "example": "01ET65M7ZADYFCKD4K1AE2QNMC"
+          },
+          "user_id": {
+            "type": "string",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
+          "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "user_id",
+          "incident_id"
+        ]
+      },
+      "CreateRequestBody6": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean",
+            "description": "DEPRECATED: this will always be false.",
+            "example": false
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack",
+            "example": "lead",
+            "minLength": 1
+          }
+        },
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "required": false,
+          "shortform": "lead"
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "required",
+          "conditions",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateRequestBody7": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack",
+            "example": "lead",
+            "minLength": 1
+          }
+        },
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "shortform": "lead"
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "conditions",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateRequestBody8": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.",
+            "example": "live",
+            "enum": [
+              "live",
+              "learning",
+              "closed"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this status",
+            "example": "Closed"
+          }
+        },
+        "example": {
+          "category": "live",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "name": "Closed"
+        },
+        "required": [
+          "name",
+          "description",
+          "category",
+          "id",
+          "rank",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateRequestBody9": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real or test",
+            "example": "real",
+            "enum": [
+              "real",
+              "test"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J"
+          },
+          "source_message_channel_id": {
+            "type": "string",
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5"
+          },
+          "source_message_timestamp": {
+            "type": "string",
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the incident",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
+      },
       "CreateResponseBody": {
         "type": "object",
         "properties": {
@@ -6499,6 +8444,32 @@
           "incident_attachment"
         ]
       },
+      "CreateResponseBody2": {
+        "type": "object",
+        "properties": {
+          "incident_membership": {
+            "$ref": "#/components/schemas/IncidentMembership"
+          }
+        },
+        "example": {
+          "incident_membership": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        },
+        "required": [
+          "incident_membership"
+        ]
+      },
       "CreateTypeRequestBody": {
         "type": "object",
         "properties": {
@@ -6516,14 +8487,15 @@
           "color": {
             "type": "string",
             "description": "Sets the display color of this type in the dashboard",
-            "example": "slate",
+            "example": "yellow",
             "enum": [
-              "slate",
-              "red",
               "yellow",
               "green",
               "blue",
-              "violet"
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
             ]
           },
           "description": {
@@ -6541,13 +8513,21 @@
               "briefcase",
               "browser",
               "bulb",
+              "calendar",
               "clock",
               "cog",
+              "components",
               "database",
               "doc",
               "email",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
               "server",
               "severity",
+              "store",
               "star",
               "tag",
               "user",
@@ -6564,34 +8544,28 @@
             "description": "If this type should be ranked",
             "example": true
           },
-          "semantic_type": {
+          "source_repo_url": {
             "type": "string",
-            "description": "Semantic type of this resource",
-            "example": "custom"
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog"
           },
           "type_name": {
             "type": "string",
             "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
             "example": "Custom[\"BackstageGroup\"]"
-          },
-          "source_repo_url": {
-            "type": "string",
-            "description": "The url of the external repository where this type is managed",
-            "example": "https://github.com/incident-io/catalog-importer"
           }
         },
         "example": {
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
-          "color": "slate",
+          "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "bolt",
           "name": "Kubernetes Cluster",
           "ranked": true,
-          "semantic_type": "custom",
-          "type_name": "Custom[\"BackstageGroup\"]",
-          "source_repo_url": "https://github.com/incident-io/catalog-importer"
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]"
         },
         "required": [
           "name",
@@ -6610,16 +8584,18 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
-            "color": "slate",
+            "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "external_type": "PagerDutyService",
             "icon": "bolt",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
             "ranked": true,
+            "registry_type": "PagerDutyService",
             "required_integrations": [
               "pager_duty"
             ],
@@ -6627,7 +8603,9 @@
               "attributes": [
                 {
                   "array": false,
+                  "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
                   "name": "tier",
                   "type": "Custom[\"Service\"]"
                 }
@@ -6635,6 +8613,7 @@
               "version": 1
             },
             "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -6656,10 +8635,11 @@
             "items": {
               "$ref": "#/components/schemas/CustomFieldValuePayloadV1"
             },
-            "description": "List of values to associate with this entry",
+            "description": "List of values to associate with this entry. Use an empty array to unset the value of the custom field.",
             "example": [
               {
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "value_link": "https://google.com/",
                 "value_numeric": "123.456",
                 "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -6674,6 +8654,7 @@
           "values": [
             {
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "value_link": "https://google.com/",
               "value_numeric": "123.456",
               "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -6701,6 +8682,15 @@
             "description": "List of custom field values set on this entry",
             "example": [
               {
+                "value_catalog_entry": {
+                  "aliases": [
+                    "lawrence@incident.io",
+                    "lawrence"
+                  ],
+                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Primary On-call"
+                },
                 "value_link": "https://google.com/",
                 "value_numeric": "123.456",
                 "value_option": {
@@ -6731,6 +8721,15 @@
           },
           "values": [
             {
+              "value_catalog_entry": {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Primary On-call"
+              },
               "value_link": "https://google.com/",
               "value_numeric": "123.456",
               "value_option": {
@@ -6856,13 +8855,11 @@
           "dynamic_options",
           "rank",
           "field_type",
-          "required",
-          "show_before_creation",
-          "show_before_closure",
-          "show_before_update",
+          "cannot_be_unset",
           "options",
           "is_usable",
           "conditions",
+          "field_mode",
           "created_at",
           "updated_at"
         ]
@@ -6870,6 +8867,11 @@
       "CustomFieldV1": {
         "type": "object",
         "properties": {
+          "catalog_type_id": {
+            "type": "string",
+            "description": "For catalog fields, the ID of the associated catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
           "created_at": {
             "type": "string",
             "description": "When the action was created",
@@ -6921,7 +8923,7 @@
           },
           "required": {
             "type": "string",
-            "description": "When this custom field must be set during the incident lifecycle.",
+            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
             "example": "never",
             "enum": [
               "never",
@@ -6929,9 +8931,19 @@
               "always"
             ]
           },
+          "required_v2": {
+            "type": "string",
+            "description": "When this custom field must be set during the incident lifecycle.",
+            "example": "never",
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
+          },
           "show_before_closure": {
             "type": "boolean",
-            "description": "Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.",
+            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
             "example": true
           },
           "show_before_creation": {
@@ -6957,6 +8969,7 @@
           }
         },
         "example": {
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Which team is impacted by this issue",
           "field_type": "single_select",
@@ -6971,6 +8984,7 @@
             }
           ],
           "required": "never",
+          "required_v2": "never",
           "show_before_closure": true,
           "show_before_creation": true,
           "show_before_update": true,
@@ -6982,11 +8996,78 @@
           "name",
           "description",
           "field_type",
-          "required",
           "show_before_creation",
           "show_before_closure",
           "show_before_update",
           "options",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CustomFieldV2": {
+        "type": "object",
+        "properties": {
+          "catalog_type_id": {
+            "type": "string",
+            "description": "For catalog fields, the ID of the associated catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of custom field",
+            "example": "single_select",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Affected Team",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "field_type",
+          "cannot_be_unset",
           "created_at",
           "updated_at"
         ]
@@ -6997,6 +9078,11 @@
           "id": {
             "type": "string",
             "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "value_link": {
@@ -7027,6 +9113,7 @@
         },
         "example": {
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "value_link": "https://google.com/",
           "value_numeric": "123.456",
           "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -7037,6 +9124,9 @@
       "CustomFieldValueV1": {
         "type": "object",
         "properties": {
+          "value_catalog_entry": {
+            "$ref": "#/components/schemas/EmbeddedCatalogEntryV1"
+          },
           "value_link": {
             "type": "string",
             "description": "If the custom field type is 'link', this will contain the value assigned.",
@@ -7057,6 +9147,15 @@
           }
         },
         "example": {
+          "value_catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call"
+          },
           "value_link": "https://google.com/",
           "value_numeric": "123.456",
           "value_option": {
@@ -7082,12 +9181,14 @@
         },
         "example": {
           "incident": {
+            "call_url": "https://zoom.us/foo",
             "custom_field_entries": [
               {
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "values": [
                   {
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -7097,6 +9198,17 @@
                 ]
               }
             ],
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ],
+            "incident_status_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
             "incident_timestamp_values": [
               {
                 "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -7112,6 +9224,250 @@
         "required": [
           "incident",
           "notify_incident_channel"
+        ]
+      },
+      "EmbeddedCatalogEntryV1": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call"
+          }
+        },
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call"
+        },
+        "required": [
+          "id",
+          "name",
+          "catalog_type_id"
+        ]
+      },
+      "EngineParamBindingPayloadV2": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValuePayloadV2"
+            },
+            "description": "If set, this is the array value of the step parameter",
+            "example": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValuePayloadV2"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV2": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV2"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity",
+                "sort_key": "000020",
+                "unavailable": false,
+                "value": "abc123"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV2"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "catalog_entry": {
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "helptext": "Collection of standalone automations like auto-closing incidents.",
+              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "is_image_slack_icon": false,
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity",
+              "sort_key": "000020",
+              "unavailable": false,
+              "value": "abc123"
+            }
+          ],
+          "value": {
+            "catalog_entry": {
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "helptext": "Collection of standalone automations like auto-closing incidents.",
+            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "is_image_slack_icon": false,
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity",
+            "sort_key": "000020",
+            "unavailable": false,
+            "value": "abc123"
+          }
+        }
+      },
+      "EngineParamBindingValuePayloadV2": {
+        "type": "object",
+        "properties": {
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        }
+      },
+      "EngineParamBindingValueV2": {
+        "type": "object",
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryReferenceV2"
+          },
+          "helptext": {
+            "type": "string",
+            "description": "Gives a description of the option to the user",
+            "example": "Collection of standalone automations like auto-closing incidents."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "If appropriate, URL to an image that can be displayed alongside the option",
+            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+          },
+          "is_image_slack_icon": {
+            "type": "boolean",
+            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "example": false
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          },
+          "sort_key": {
+            "type": "string",
+            "description": "Gives an indication of how to sort the options when displayed to the user",
+            "example": "000020"
+          },
+          "unavailable": {
+            "type": "boolean",
+            "description": "Unavailable is true if we've failed to build the value for this binding",
+            "example": false
+          },
+          "value": {
+            "type": "string",
+            "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "catalog_entry": {
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "helptext": "Collection of standalone automations like auto-closing incidents.",
+          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "is_image_slack_icon": false,
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity",
+          "sort_key": "000020",
+          "unavailable": false,
+          "value": "abc123"
+        },
+        "required": [
+          "label",
+          "sort_key"
         ]
       },
       "ExternalIssueReferenceV1": {
@@ -7133,10 +9489,12 @@
             "example": "asana",
             "enum": [
               "asana",
+              "click_up",
               "linear",
               "jira",
               "jira_server",
               "github",
+              "gitlab",
               "shortcut"
             ]
           }
@@ -7166,10 +9524,12 @@
             "example": "asana",
             "enum": [
               "asana",
+              "click_up",
               "linear",
               "jira",
               "jira_server",
               "github",
+              "gitlab",
               "shortcut"
             ]
           }
@@ -7181,6 +9541,7 @@
         },
         "required": [
           "provider",
+          "provider_instance_id",
           "issue_name",
           "issue_permalink",
           "issue_id"
@@ -7208,9 +9569,12 @@
               "opsgenie_alert",
               "datadog_monitor_alert",
               "github_pull_request",
+              "gitlab_merge_request",
               "sentry_issue",
               "atlassian_statuspage_incident",
               "zendesk_ticket",
+              "google_calendar_event",
+              "scrubbed",
               "statuspage_incident"
             ]
           },
@@ -7237,6 +9601,142 @@
           "updated_at"
         ]
       },
+      "FollowUpPriorityV2": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the follow-up priority option",
+            "example": "A follow-up that requires immediate attention."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the follow-up priority option",
+            "example": "01GNW4BAQ7XRMFF6FHKNXDFPRW"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the follow-up priority option",
+            "example": "Urgent"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank is used to order the follow-up priority options correctly",
+            "example": 10,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "description": "A follow-up that requires immediate attention.",
+          "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+          "name": "Urgent",
+          "rank": 10
+        },
+        "required": [
+          "id",
+          "name",
+          "rank"
+        ]
+      },
+      "FollowUpV2": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "$ref": "#/components/schemas/UserV1"
+          },
+          "completed_at": {
+            "type": "string",
+            "description": "When the follow-up was completed",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When the follow-up was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the follow-up",
+            "example": "Call the fire brigade"
+          },
+          "external_issue_reference": {
+            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the follow-up",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "Unique identifier of the incident the follow-up belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/FollowUpPriorityV2"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the follow-up",
+            "example": "outstanding",
+            "enum": [
+              "outstanding",
+              "completed",
+              "deleted",
+              "not_doing"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the follow-up",
+            "example": "Cat is stuck in the tree"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the follow-up was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "assignee": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          },
+          "completed_at": "2021-08-17T13:28:57.801578Z",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Call the fire brigade",
+          "external_issue_reference": {
+            "issue_name": "INC-123",
+            "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+            "provider": "asana"
+          },
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "priority": {
+            "description": "A follow-up that requires immediate attention.",
+            "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+            "name": "Urgent",
+            "rank": 10
+          },
+          "status": "outstanding",
+          "title": "Cat is stuck in the tree",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "incident_id",
+          "title",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "IdentityResponseBody": {
         "type": "object",
         "properties": {
@@ -7246,6 +9746,7 @@
         },
         "example": {
           "identity": {
+            "dashboard_url": "https://app.incident.io/my-org",
             "name": "Alertmanager token",
             "roles": [
               "incident_creator"
@@ -7259,6 +9760,11 @@
       "IdentityV1": {
         "type": "object",
         "properties": {
+          "dashboard_url": {
+            "type": "string",
+            "description": "The dashboard URL for this organisation",
+            "example": "https://app.incident.io/my-org"
+          },
           "name": {
             "type": "string",
             "description": "The name assigned to the current API Key",
@@ -7276,7 +9782,8 @@
                 "manage_settings",
                 "global_access",
                 "catalog_viewer",
-                "catalog_editor"
+                "catalog_editor",
+                "incident_memberships_editor"
               ]
             },
             "description": "Which roles have been enabled for this key",
@@ -7286,6 +9793,7 @@
           }
         },
         "example": {
+          "dashboard_url": "https://app.incident.io/my-org",
           "name": "Alertmanager token",
           "roles": [
             "incident_creator"
@@ -7293,7 +9801,8 @@
         },
         "required": [
           "name",
-          "roles"
+          "roles",
+          "dashboard_url"
         ]
       },
       "IncidentAttachmentV1": {
@@ -7332,9 +9841,69 @@
           "created_at"
         ]
       },
+      "IncidentDurationMetricV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique ID of this incident duration metric",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this duration metric",
+            "example": "Lasted"
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Lasted"
+        },
+        "required": [
+          "id",
+          "name",
+          "rank",
+          "from_timestamp_id",
+          "to_timestamp_id",
+          "metric_type",
+          "calculation_mode",
+          "created_at",
+          "updated_at",
+          "validate"
+        ]
+      },
+      "IncidentDurationMetricWithValueV2": {
+        "type": "object",
+        "properties": {
+          "duration_metric": {
+            "$ref": "#/components/schemas/IncidentDurationMetricV2"
+          },
+          "value_seconds": {
+            "type": "integer",
+            "description": "The calculated durations for this metric",
+            "example": 1,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "duration_metric": {
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Lasted"
+          },
+          "value_seconds": 1
+        },
+        "required": [
+          "duration_metric"
+        ]
+      },
       "IncidentEditPayloadV2": {
         "type": "object",
         "properties": {
+          "call_url": {
+            "type": "string",
+            "description": "The call URL attached to this incident",
+            "example": "https://zoom.us/foo"
+          },
           "custom_field_entries": {
             "type": "array",
             "items": {
@@ -7347,6 +9916,7 @@
                 "values": [
                   {
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -7356,6 +9926,28 @@
                 ]
               }
             ]
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV2"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_status_id": {
+            "type": "string",
+            "description": "Incident status to change incident to (you can only change an incident from one active status to another, any other lifecycle changes must be taken via the app.)",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
           },
           "incident_timestamp_values": {
             "type": "array",
@@ -7387,12 +9979,14 @@
           }
         },
         "example": {
+          "call_url": "https://zoom.us/foo",
           "custom_field_entries": [
             {
               "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "values": [
                 {
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "value_link": "https://google.com/",
                   "value_numeric": "123.456",
                   "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -7402,6 +9996,17 @@
               ]
             }
           ],
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_status_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
           "incident_timestamp_values": [
             {
               "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -7412,6 +10017,56 @@
           "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
           "summary": "Our database is really really sad, and we don't know why yet."
         }
+      },
+      "IncidentMembership": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the membership was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of this incident membership",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "Unique identifier of the incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the membership was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserV1"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "user": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        },
+        "required": [
+          "id",
+          "user",
+          "incident_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "IncidentRoleAssignmentPayloadV1": {
         "type": "object",
@@ -7486,7 +10141,7 @@
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
             "name": "Incident Lead",
-            "required": true,
+            "required": false,
             "role_type": "lead",
             "shortform": "lead",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -7529,8 +10184,8 @@
           },
           "required": {
             "type": "boolean",
-            "description": "Whether incident require this role to be set",
-            "example": true
+            "description": "DEPRECATED: this will always be false.",
+            "example": false
           },
           "role_type": {
             "type": "string",
@@ -7561,7 +10216,7 @@
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
           "name": "Incident Lead",
-          "required": true,
+          "required": false,
           "role_type": "lead",
           "shortform": "lead",
           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -7574,7 +10229,82 @@
           "instructions",
           "shortform",
           "role_type",
-          "required",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "IncidentRoleV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "role_type": {
+            "type": "string",
+            "description": "Type of incident role",
+            "example": "lead",
+            "enum": [
+              "lead",
+              "reporter",
+              "custom"
+            ]
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack",
+            "example": "lead",
+            "minLength": 1
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "The person currently coordinating the incident",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "role_type": "lead",
+          "shortform": "lead",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "conditions",
+          "id",
+          "name",
+          "description",
+          "instructions",
+          "shortform",
+          "role_type",
           "created_at",
           "updated_at"
         ]
@@ -7584,14 +10314,17 @@
         "properties": {
           "category": {
             "type": "string",
-            "description": "Whether this status is a live or closed status. If you have enabled auto-create, there will also be 'triage' and 'declined' statuses, which cannot be modified.",
+            "description": "What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured",
             "example": "triage",
             "enum": [
               "triage",
               "declined",
               "merged",
+              "canceled",
               "live",
-              "closed"
+              "learning",
+              "closed",
+              "paused"
             ]
           },
           "created_at": {
@@ -7698,13 +10431,10 @@
           "name",
           "description",
           "rank",
-          "required",
-          "show_before_creation",
-          "show_before_closure",
-          "show_in_announcement_post",
-          "set_on_transition",
-          "set_on_visit",
           "set_on_creation",
+          "set_on_acceptance",
+          "set_on_resolution",
+          "set_by_rules",
           "timestamp_type",
           "created_at",
           "updated_at"
@@ -7851,7 +10581,12 @@
           "create_in_triage",
           "severity_aliases",
           "rank",
-          "update_template_mode"
+          "override_auto_close_incidents",
+          "auto_close_incidents",
+          "auto_close_incidents_delay_days",
+          "override_auto_archive_slack_channels",
+          "auto_archive_slack_channels",
+          "auto_archive_slack_channels_delay_days"
         ]
       },
       "IncidentUpdateV2": {
@@ -7876,7 +10611,7 @@
           "message": {
             "type": "string",
             "description": "Message that explains the context behind the update",
-            "example": "The cat is getting irritable, best rescue it soon"
+            "example": "We're working on a fix, hoping to ship in the next 30 minutes"
           },
           "new_incident_status": {
             "$ref": "#/components/schemas/IncidentStatusV1"
@@ -7892,7 +10627,7 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "message": "The cat is getting irritable, best rescue it soon",
+          "message": "We're working on a fix, hoping to ship in the next 30 minutes",
           "new_incident_status": {
             "category": "triage",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -7974,6 +10709,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -8014,7 +10758,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -8070,7 +10814,7 @@
           },
           "slack_team_id": {
             "type": "string",
-            "description": "ID of the Slack team / workspace",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
             "example": "T02A1FSLE8J"
           },
           "status": {
@@ -8154,6 +10898,15 @@
               },
               "values": [
                 {
+                  "value_catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
                   "value_link": "https://google.com/",
                   "value_numeric": "123.456",
                   "value_option": {
@@ -8183,7 +10936,7 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                 "name": "Incident Lead",
-                "required": true,
+                "required": false,
                 "role_type": "lead",
                 "shortform": "lead",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -8235,6 +10988,7 @@
           "name",
           "incident_status",
           "idempotency_key",
+          "did_opt_out_of_post_incident_flow",
           "visibility",
           "mode",
           "organisation_id",
@@ -8244,8 +10998,6 @@
           "custom_field_entries",
           "slack_team_id",
           "slack_channel_id",
-          "active_participants",
-          "passive_participants",
           "created_at",
           "updated_at",
           "reported_at"
@@ -8292,6 +11044,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -8303,6 +11064,22 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ]
+          },
+          "duration_metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentDurationMetricWithValueV2"
+            },
+            "description": "Incident duration metrics and their measurements for this incident",
+            "example": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ]
           },
@@ -8335,7 +11112,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -8414,7 +11191,7 @@
           },
           "slack_team_id": {
             "type": "string",
-            "description": "ID of the Slack team / workspace",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
             "example": "T02A1FSLE8J"
           },
           "summary": {
@@ -8436,6 +11213,30 @@
               "public",
               "private"
             ]
+          },
+          "workload_minutes_late": {
+            "type": "number",
+            "description": "Amount of time spent on the incident in late hours",
+            "example": 40.7,
+            "format": "double"
+          },
+          "workload_minutes_sleeping": {
+            "type": "number",
+            "description": "Amount of time spent on the incident in sleeping hours",
+            "example": 0,
+            "format": "double"
+          },
+          "workload_minutes_total": {
+            "type": "number",
+            "description": "Amount of time spent on the incident in total",
+            "example": 60.7,
+            "format": "double"
+          },
+          "workload_minutes_working": {
+            "type": "number",
+            "description": "Amount of time spent on the incident in working hours",
+            "example": 20,
+            "format": "double"
           }
         },
         "example": {
@@ -8472,6 +11273,15 @@
               },
               "values": [
                 {
+                  "value_catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
                   "value_link": "https://google.com/",
                   "value_numeric": "123.456",
                   "value_option": {
@@ -8483,6 +11293,15 @@
                   "value_text": "This is my text field, I hope you like it"
                 }
               ]
+            }
+          ],
+          "duration_metrics": [
+            {
+              "duration_metric": {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Lasted"
+              },
+              "value_seconds": 1
             }
           ],
           "external_issue_reference": {
@@ -8506,7 +11325,7 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                 "name": "Incident Lead",
-                "required": true,
+                "required": false,
                 "role_type": "lead",
                 "shortform": "lead",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -8562,7 +11381,11 @@
           "slack_team_id": "T02A1FSLE8J",
           "summary": "Our database is really really sad, and we don't know why yet.",
           "updated_at": "2021-08-17T13:28:57.801578Z",
-          "visibility": "public"
+          "visibility": "public",
+          "workload_minutes_late": 40.7,
+          "workload_minutes_sleeping": 0,
+          "workload_minutes_total": 60.7,
+          "workload_minutes_working": 20
         },
         "required": [
           "incident_status",
@@ -8571,6 +11394,7 @@
           "reference",
           "name",
           "idempotency_key",
+          "did_opt_out_of_post_incident_flow",
           "visibility",
           "mode",
           "organisation_id",
@@ -8580,11 +11404,196 @@
           "custom_field_entries",
           "slack_team_id",
           "slack_channel_id",
-          "active_participants",
-          "passive_participants",
           "created_at",
           "updated_at",
           "reported_at"
+        ]
+      },
+      "IncidentWithStatusChangeV2": {
+        "type": "object",
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV2"
+          },
+          "new_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          },
+          "previous_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          },
+          "new_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "previous_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "incident",
+          "previous_status",
+          "new_status"
         ]
       },
       "ListEntriesResponseBody": {
@@ -8601,33 +11610,44 @@
                   "lawrence@incident.io",
                   "lawrence"
                 ],
+                "archived_at": "2021-08-17T14:28:57.801578Z",
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
                       {
                         "catalog_entry": {
+                          "archived_at": "2021-08-17T14:28:57.801578Z",
                           "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "catalog_entry_name": "Primary escalation",
                           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
+                        "helptext": "Collection of standalone automations like auto-closing incidents.",
                         "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                         "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "sort_key": "000020"
+                        "reference": "incident.severity",
+                        "sort_key": "000020",
+                        "unavailable": false,
+                        "value": "abc123"
                       }
                     ],
                     "value": {
                       "catalog_entry": {
+                        "archived_at": "2021-08-17T14:28:57.801578Z",
                         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
+                      "helptext": "Collection of standalone automations like auto-closing incidents.",
                       "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "sort_key": "000020"
+                      "reference": "incident.severity",
+                      "sort_key": "000020",
+                      "unavailable": false,
+                      "value": "abc123"
                     }
                   }
                 },
@@ -8655,33 +11675,44 @@
                 "lawrence@incident.io",
                 "lawrence"
               ],
+              "archived_at": "2021-08-17T14:28:57.801578Z",
               "attribute_values": {
                 "abc123": {
                   "array_value": [
                     {
                       "catalog_entry": {
+                        "archived_at": "2021-08-17T14:28:57.801578Z",
                         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
+                      "helptext": "Collection of standalone automations like auto-closing incidents.",
                       "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "sort_key": "000020"
+                      "reference": "incident.severity",
+                      "sort_key": "000020",
+                      "unavailable": false,
+                      "value": "abc123"
                     }
                   ],
                   "value": {
                     "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "sort_key": "000020"
+                    "reference": "incident.severity",
+                    "sort_key": "000020",
+                    "unavailable": false,
+                    "value": "abc123"
                   }
                 }
               },
@@ -8698,16 +11729,18 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
-            "color": "slate",
+            "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "external_type": "PagerDutyService",
             "icon": "bolt",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
             "ranked": true,
+            "registry_type": "PagerDutyService",
             "required_integrations": [
               "pager_duty"
             ],
@@ -8715,7 +11748,9 @@
               "attributes": [
                 {
                   "array": false,
+                  "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
                   "name": "tier",
                   "type": "Custom[\"Service\"]"
                 }
@@ -8723,6 +11758,7 @@
               "version": 1
             },
             "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
@@ -8838,6 +11874,213 @@
       "ListResponseBody10": {
         "type": "object",
         "properties": {
+          "incident_statuses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentStatusV1"
+            },
+            "example": [
+              {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "incident_statuses": [
+            {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "incident_statuses"
+        ]
+      },
+      "ListResponseBody11": {
+        "type": "object",
+        "properties": {
+          "incident_timestamps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampV2"
+            },
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Impact started",
+                "rank": 1
+              }
+            ]
+          }
+        },
+        "example": {
+          "incident_timestamps": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Impact started",
+              "rank": 1
+            }
+          ]
+        },
+        "required": [
+          "incident_timestamps"
+        ]
+      },
+      "ListResponseBody12": {
+        "type": "object",
+        "properties": {
+          "incident_types": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentTypeV1"
+            },
+            "example": [
+              {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "incident_types": [
+            {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "incident_types"
+        ]
+      },
+      "ListResponseBody13": {
+        "type": "object",
+        "properties": {
+          "incident_updates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentUpdateV2"
+            },
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+                "new_incident_status": {
+                  "category": "triage",
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Closed",
+                  "rank": 4,
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                },
+                "new_severity": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "Issues with **low impact**.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Minor",
+                  "rank": 1,
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                },
+                "updater": {
+                  "api_key": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My test API key"
+                  },
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                }
+              }
+            ]
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResult"
+          }
+        },
+        "example": {
+          "incident_updates": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+              "new_incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "new_severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "updater": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "required": [
+          "incident_updates"
+        ]
+      },
+      "ListResponseBody14": {
+        "type": "object",
+        "properties": {
           "incidents": {
             "type": "array",
             "items": {
@@ -8878,6 +12121,15 @@
                     },
                     "values": [
                       {
+                        "value_catalog_entry": {
+                          "aliases": [
+                            "lawrence@incident.io",
+                            "lawrence"
+                          ],
+                          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Primary On-call"
+                        },
                         "value_link": "https://google.com/",
                         "value_numeric": "123.456",
                         "value_option": {
@@ -8907,7 +12159,7 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                       "name": "Incident Lead",
-                      "required": true,
+                      "required": false,
                       "role_type": "lead",
                       "shortform": "lead",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -8993,6 +12245,15 @@
                   },
                   "values": [
                     {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
                       "value_link": "https://google.com/",
                       "value_numeric": "123.456",
                       "value_option": {
@@ -9022,7 +12283,7 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                     "name": "Incident Lead",
-                    "required": true,
+                    "required": false,
                     "role_type": "lead",
                     "shortform": "lead",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -9077,7 +12338,7 @@
           "incidents"
         ]
       },
-      "ListResponseBody11": {
+      "ListResponseBody15": {
         "type": "object",
         "properties": {
           "incidents": {
@@ -9120,6 +12381,15 @@
                     },
                     "values": [
                       {
+                        "value_catalog_entry": {
+                          "aliases": [
+                            "lawrence@incident.io",
+                            "lawrence"
+                          ],
+                          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Primary On-call"
+                        },
                         "value_link": "https://google.com/",
                         "value_numeric": "123.456",
                         "value_option": {
@@ -9131,6 +12401,15 @@
                         "value_text": "This is my text field, I hope you like it"
                       }
                     ]
+                  }
+                ],
+                "duration_metrics": [
+                  {
+                    "duration_metric": {
+                      "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                      "name": "Lasted"
+                    },
+                    "value_seconds": 1
                   }
                 ],
                 "external_issue_reference": {
@@ -9154,7 +12433,7 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                       "name": "Incident Lead",
-                      "required": true,
+                      "required": false,
                       "role_type": "lead",
                       "shortform": "lead",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -9210,7 +12489,11 @@
                 "slack_team_id": "T02A1FSLE8J",
                 "summary": "Our database is really really sad, and we don't know why yet.",
                 "updated_at": "2021-08-17T13:28:57.801578Z",
-                "visibility": "public"
+                "visibility": "public",
+                "workload_minutes_late": 40.7,
+                "workload_minutes_sleeping": 0,
+                "workload_minutes_total": 60.7,
+                "workload_minutes_working": 20
               }
             ]
           },
@@ -9254,6 +12537,15 @@
                   },
                   "values": [
                     {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
                       "value_link": "https://google.com/",
                       "value_numeric": "123.456",
                       "value_option": {
@@ -9265,6 +12557,15 @@
                       "value_text": "This is my text field, I hope you like it"
                     }
                   ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
                 }
               ],
               "external_issue_reference": {
@@ -9288,7 +12589,7 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                     "name": "Incident Lead",
-                    "required": true,
+                    "required": false,
                     "role_type": "lead",
                     "shortform": "lead",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -9344,7 +12645,11 @@
               "slack_team_id": "T02A1FSLE8J",
               "summary": "Our database is really really sad, and we don't know why yet.",
               "updated_at": "2021-08-17T13:28:57.801578Z",
-              "visibility": "public"
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
             }
           ],
           "pagination_meta": {
@@ -9357,7 +12662,7 @@
           "incidents"
         ]
       },
-      "ListResponseBody12": {
+      "ListResponseBody16": {
         "type": "object",
         "properties": {
           "severities": {
@@ -9393,7 +12698,129 @@
           "severities"
         ]
       },
+      "ListResponseBody17": {
+        "type": "object",
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResult"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserWithRolesV2"
+            },
+            "example": [
+              {
+                "base_role": {
+                  "description": "Elevated permissions for the customer success team.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Customer Success",
+                  "slug": "customer-success"
+                },
+                "custom_roles": [
+                  {
+                    "description": "Elevated permissions for the customer success team.",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Customer Success",
+                    "slug": "customer-success"
+                  }
+                ],
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ]
+          }
+        },
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "users": [
+            {
+              "base_role": {
+                "description": "Elevated permissions for the customer success team.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Customer Success",
+                "slug": "customer-success"
+              },
+              "custom_roles": [
+                {
+                  "description": "Elevated permissions for the customer success team.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Customer Success",
+                  "slug": "customer-success"
+                }
+              ],
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ]
+        },
+        "required": [
+          "users",
+          "pagination_meta"
+        ]
+      },
       "ListResponseBody2": {
+        "type": "object",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActionV2"
+            },
+            "example": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "completed_at": "2021-08-17T13:28:57.801578Z",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Call the fire brigade",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "status": "outstanding",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "actions": [
+            {
+              "assignee": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "completed_at": "2021-08-17T13:28:57.801578Z",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Call the fire brigade",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "status": "outstanding",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "actions"
+        ]
+      },
+      "ListResponseBody3": {
         "type": "object",
         "properties": {
           "custom_field_options": {
@@ -9409,6 +12836,9 @@
                 "value": "Product"
               }
             ]
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResult"
           }
         },
         "example": {
@@ -9419,13 +12849,18 @@
               "sort_key": 10,
               "value": "Product"
             }
-          ]
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
         },
         "required": [
-          "custom_field_options"
+          "custom_field_options",
+          "pagination_meta"
         ]
       },
-      "ListResponseBody3": {
+      "ListResponseBody4": {
         "type": "object",
         "properties": {
           "custom_fields": {
@@ -9435,6 +12870,7 @@
             },
             "example": [
               {
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "description": "Which team is impacted by this issue",
                 "field_type": "single_select",
@@ -9449,6 +12885,7 @@
                   }
                 ],
                 "required": "never",
+                "required_v2": "never",
                 "show_before_closure": true,
                 "show_before_creation": true,
                 "show_before_update": true,
@@ -9461,6 +12898,7 @@
         "example": {
           "custom_fields": [
             {
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Which team is impacted by this issue",
               "field_type": "single_select",
@@ -9475,6 +12913,7 @@
                 }
               ],
               "required": "never",
+              "required_v2": "never",
               "show_before_closure": true,
               "show_before_creation": true,
               "show_before_update": true,
@@ -9487,7 +12926,121 @@
           "custom_fields"
         ]
       },
-      "ListResponseBody4": {
+      "ListResponseBody5": {
+        "type": "object",
+        "properties": {
+          "custom_fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldV2"
+            },
+            "example": [
+              {
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Affected Team",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "custom_fields": [
+            {
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Which team is impacted by this issue",
+              "field_type": "single_select",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Affected Team",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "custom_fields"
+        ]
+      },
+      "ListResponseBody6": {
+        "type": "object",
+        "properties": {
+          "follow_ups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FollowUpV2"
+            },
+            "example": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "completed_at": "2021-08-17T13:28:57.801578Z",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Call the fire brigade",
+                "external_issue_reference": {
+                  "issue_name": "INC-123",
+                  "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                  "provider": "asana"
+                },
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "priority": {
+                  "description": "A follow-up that requires immediate attention.",
+                  "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                  "name": "Urgent",
+                  "rank": 10
+                },
+                "status": "outstanding",
+                "title": "Cat is stuck in the tree",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "follow_ups": [
+            {
+              "assignee": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "completed_at": "2021-08-17T13:28:57.801578Z",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Call the fire brigade",
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "priority": {
+                "description": "A follow-up that requires immediate attention.",
+                "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                "name": "Urgent",
+                "rank": 10
+              },
+              "status": "outstanding",
+              "title": "Cat is stuck in the tree",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "follow_ups"
+        ]
+      },
+      "ListResponseBody7": {
         "type": "object",
         "properties": {
           "incident_attachments": {
@@ -9527,7 +13080,7 @@
           "incident_attachments"
         ]
       },
-      "ListResponseBody5": {
+      "ListResponseBody8": {
         "type": "object",
         "properties": {
           "incident_roles": {
@@ -9542,7 +13095,7 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                 "name": "Incident Lead",
-                "required": true,
+                "required": false,
                 "role_type": "lead",
                 "shortform": "lead",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -9558,7 +13111,7 @@
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
               "name": "Incident Lead",
-              "required": true,
+              "required": false,
               "role_type": "lead",
               "shortform": "lead",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -9569,211 +13122,44 @@
           "incident_roles"
         ]
       },
-      "ListResponseBody6": {
-        "type": "object",
-        "properties": {
-          "incident_statuses": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentStatusV1"
-            },
-            "example": [
-              {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ]
-          }
-        },
-        "example": {
-          "incident_statuses": [
-            {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "required": [
-          "incident_statuses"
-        ]
-      },
-      "ListResponseBody7": {
-        "type": "object",
-        "properties": {
-          "incident_timestamps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentTimestampV2"
-            },
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Impact started",
-                "rank": 1
-              }
-            ]
-          }
-        },
-        "example": {
-          "incident_timestamps": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Impact started",
-              "rank": 1
-            }
-          ]
-        },
-        "required": [
-          "incident_timestamps"
-        ]
-      },
-      "ListResponseBody8": {
-        "type": "object",
-        "properties": {
-          "incident_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentTypeV1"
-            },
-            "example": [
-              {
-                "create_in_triage": "always",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Customer facing production outages",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_default": false,
-                "name": "Production Outage",
-                "private_incidents_only": false,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ]
-          }
-        },
-        "example": {
-          "incident_types": [
-            {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "required": [
-          "incident_types"
-        ]
-      },
       "ListResponseBody9": {
         "type": "object",
         "properties": {
-          "incident_updates": {
+          "incident_roles": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IncidentUpdateV2"
+              "$ref": "#/components/schemas/IncidentRoleV2"
             },
             "example": [
               {
                 "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "message": "The cat is getting irritable, best rescue it soon",
-                "new_incident_status": {
-                  "category": "triage",
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Closed",
-                  "rank": 4,
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                },
-                "new_severity": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "Issues with **low impact**.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Minor",
-                  "rank": 1,
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                },
-                "updater": {
-                  "api_key": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "My test API key"
-                  },
-                  "user": {
-                    "email": "lisa@incident.io",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Lisa Karlin Curtis",
-                    "role": "viewer",
-                    "slack_user_id": "U02AYNF2XJM"
-                  }
-                }
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
               }
             ]
-          },
-          "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResult"
           }
         },
         "example": {
-          "incident_updates": [
+          "incident_roles": [
             {
               "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "message": "The cat is getting irritable, best rescue it soon",
-              "new_incident_status": {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "new_severity": {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "updater": {
-                "api_key": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "My test API key"
-                },
-                "user": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                }
-              }
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
             }
-          ],
-          "pagination_meta": {
-            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
-          }
+          ]
         },
         "required": [
-          "incident_updates"
+          "incident_roles"
         ]
       },
       "ListTypesResponseBody": {
@@ -9789,16 +13175,18 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
-                "color": "slate",
+                "color": "yellow",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "dynamic_resource_parameter": "abc123",
                 "estimated_count": 7,
-                "external_type": "PagerDutyService",
                 "icon": "bolt",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "is_editable": false,
+                "last_synced_at": "2021-08-17T13:28:57.801578Z",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
+                "registry_type": "PagerDutyService",
                 "required_integrations": [
                   "pager_duty"
                 ],
@@ -9806,7 +13194,9 @@
                   "attributes": [
                     {
                       "array": false,
+                      "backlink_attribute": "abc123",
                       "id": "01GW2G3V0S59R238FAHPDS1R66",
+                      "mode": "manual",
                       "name": "tier",
                       "type": "Custom[\"Service\"]"
                     }
@@ -9814,6 +13204,7 @@
                   "version": 1
                 },
                 "semantic_type": "custom",
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "type_name": "Custom[\"BackstageGroup\"]",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
@@ -9826,16 +13217,18 @@
               "annotations": {
                 "incident.io/catalog-importer/id": "id-of-config"
               },
-              "color": "slate",
+              "color": "yellow",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
+              "dynamic_resource_parameter": "abc123",
               "estimated_count": 7,
-              "external_type": "PagerDutyService",
               "icon": "bolt",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_editable": false,
+              "last_synced_at": "2021-08-17T13:28:57.801578Z",
               "name": "Kubernetes Cluster",
               "ranked": true,
+              "registry_type": "PagerDutyService",
               "required_integrations": [
                 "pager_duty"
               ],
@@ -9843,7 +13236,9 @@
                 "attributes": [
                   {
                     "array": false,
+                    "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "mode": "manual",
                     "name": "tier",
                     "type": "Custom[\"Service\"]"
                   }
@@ -9851,6 +13246,7 @@
                 "version": 1
               },
               "semantic_type": "custom",
+              "source_repo_url": "https://github.com/my-company/incident-io-catalog",
               "type_name": "Custom[\"BackstageGroup\"]",
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
@@ -9997,6 +13393,86 @@
           "metadata"
         ]
       },
+      "PrivateIncidentActionCreatedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "private_incident.action_created_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "example": {
+          "event_type": "private_incident.action_created_v1",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.action_created_v1"
+        ]
+      },
+      "PrivateIncidentActionUpdatedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "private_incident.action_updated_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "example": {
+          "event_type": "private_incident.action_updated_v1",
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.action_updated_v1"
+        ]
+      },
       "PrivateIncidentFollowUpCreatedV1ResponseBody": {
         "type": "object",
         "properties": {
@@ -10009,10 +13485,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "private_incident.follow_up_created_v1": {
@@ -10042,10 +13525,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "private_incident.follow_up_updated_v1": {
@@ -10075,10 +13565,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "private_incident.incident_created_v2": {
@@ -10108,10 +13605,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "private_incident.incident_updated_v2": {
@@ -10129,6 +13633,208 @@
           "private_incident.incident_updated_v2"
         ]
       },
+      "PrivateIncidentMembershipGrantedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "private_incident.membership_granted_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          }
+        },
+        "example": {
+          "event_type": "private_incident.membership_granted_v1",
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.membership_granted_v1"
+        ]
+      },
+      "PrivateIncidentMembershipRevokedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "private_incident.membership_revoked_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          }
+        },
+        "example": {
+          "event_type": "private_incident.membership_revoked_v1",
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.membership_revoked_v1"
+        ]
+      },
+      "PublicIncidentActionCreatedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "public_incident.action_created_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "example": {
+          "event_type": "public_incident.action_created_v1",
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.action_created_v1"
+        ]
+      },
+      "PublicIncidentActionUpdatedV1ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "public_incident.action_updated_v1",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "example": {
+          "event_type": "public_incident.action_updated_v1",
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.action_updated_v1"
+        ]
+      },
       "PublicIncidentFollowUpCreatedV1ResponseBody": {
         "type": "object",
         "properties": {
@@ -10141,10 +13847,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "public_incident.follow_up_created_v1": {
@@ -10193,10 +13906,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "public_incident.follow_up_updated_v1": {
@@ -10245,10 +13965,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "public_incident.incident_created_v2": {
@@ -10291,6 +14018,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -10302,6 +14038,15 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ],
             "external_issue_reference": {
@@ -10325,7 +14070,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -10381,12 +14126,221 @@
             "slack_team_id": "T02A1FSLE8J",
             "summary": "Our database is really really sad, and we don't know why yet.",
             "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
           }
         },
         "required": [
           "event_type",
           "public_incident.incident_created_v2"
+        ]
+      },
+      "PublicIncidentIncidentStatusUpdatedV2ResponseBody": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "public_incident.incident_status_updated_v2",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
+          }
+        },
+        "example": {
+          "event_type": "public_incident.incident_status_updated_v2",
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.incident_status_updated_v2"
         ]
       },
       "PublicIncidentIncidentUpdatedV2ResponseBody": {
@@ -10401,10 +14355,17 @@
               "private_incident.incident_created_v2",
               "public_incident.incident_updated_v2",
               "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
               "public_incident.follow_up_created_v1",
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1"
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
             ]
           },
           "public_incident.incident_updated_v2": {
@@ -10447,6 +14408,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -10458,6 +14428,15 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ],
             "external_issue_reference": {
@@ -10481,7 +14460,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -10537,12 +14516,52 @@
             "slack_team_id": "T02A1FSLE8J",
             "summary": "Our database is really really sad, and we don't know why yet.",
             "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
           }
         },
         "required": [
           "event_type",
           "public_incident.incident_updated_v2"
+        ]
+      },
+      "RBACRoleV2": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the purpose for the RBAC role",
+            "example": "Elevated permissions for the customer success team."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the RBAC role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the RBAC role",
+            "example": "Customer Success"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Unique human-readable slug for the RBAC role",
+            "example": "customer-success"
+          }
+        },
+        "example": {
+          "description": "Elevated permissions for the customer success team.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Customer Success",
+          "slug": "customer-success"
+        },
+        "required": [
+          "id",
+          "name",
+          "slug"
         ]
       },
       "RetrospectiveIncidentOptionsV2": {
@@ -10714,33 +14733,44 @@
               "lawrence@incident.io",
               "lawrence"
             ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
             "attribute_values": {
               "abc123": {
                 "array_value": [
                   {
                     "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "sort_key": "000020"
+                    "reference": "incident.severity",
+                    "sort_key": "000020",
+                    "unavailable": false,
+                    "value": "abc123"
                   }
                 ],
                 "value": {
                   "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "sort_key": "000020"
+                  "reference": "incident.severity",
+                  "sort_key": "000020",
+                  "unavailable": false,
+                  "value": "abc123"
                 }
               }
             },
@@ -10756,16 +14786,18 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
-            "color": "slate",
+            "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "external_type": "PagerDutyService",
             "icon": "bolt",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
             "ranked": true,
+            "registry_type": "PagerDutyService",
             "required_integrations": [
               "pager_duty"
             ],
@@ -10773,7 +14805,9 @@
               "attributes": [
                 {
                   "array": false,
+                  "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
                   "name": "tier",
                   "type": "Custom[\"Service\"]"
                 }
@@ -10781,6 +14815,7 @@
               "version": 1
             },
             "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -10828,126 +14863,6 @@
       "ShowResponseBody10": {
         "type": "object",
         "properties": {
-          "severity": {
-            "$ref": "#/components/schemas/SeverityV2"
-          }
-        },
-        "example": {
-          "severity": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Issues with **low impact**.",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Minor",
-            "rank": 1,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "required": [
-          "severity"
-        ]
-      },
-      "ShowResponseBody2": {
-        "type": "object",
-        "properties": {
-          "custom_field_option": {
-            "$ref": "#/components/schemas/CustomFieldOptionV1"
-          }
-        },
-        "example": {
-          "custom_field_option": {
-            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "sort_key": 10,
-            "value": "Product"
-          }
-        },
-        "required": [
-          "custom_field_option"
-        ]
-      },
-      "ShowResponseBody3": {
-        "type": "object",
-        "properties": {
-          "custom_field": {
-            "$ref": "#/components/schemas/CustomFieldV1"
-          }
-        },
-        "example": {
-          "custom_field": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Which team is impacted by this issue",
-            "field_type": "single_select",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Affected Team",
-            "options": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "sort_key": 10,
-                "value": "Product"
-              }
-            ],
-            "required": "never",
-            "show_before_closure": true,
-            "show_before_creation": true,
-            "show_before_update": true,
-            "show_in_announcement_post": true,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "required": [
-          "custom_field"
-        ]
-      },
-      "ShowResponseBody4": {
-        "type": "object",
-        "properties": {
-          "incident_role": {
-            "$ref": "#/components/schemas/IncidentRoleV1"
-          }
-        },
-        "example": {
-          "incident_role": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "The person currently coordinating the incident",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-            "name": "Incident Lead",
-            "required": true,
-            "role_type": "lead",
-            "shortform": "lead",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "required": [
-          "incident_role"
-        ]
-      },
-      "ShowResponseBody5": {
-        "type": "object",
-        "properties": {
-          "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
-          }
-        },
-        "example": {
-          "incident_status": {
-            "category": "triage",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "name": "Closed",
-            "rank": 4,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "required": [
-          "incident_status"
-        ]
-      },
-      "ShowResponseBody6": {
-        "type": "object",
-        "properties": {
           "incident_timestamp": {
             "$ref": "#/components/schemas/IncidentTimestampV2"
           }
@@ -10963,7 +14878,7 @@
           "incident_timestamp"
         ]
       },
-      "ShowResponseBody7": {
+      "ShowResponseBody11": {
         "type": "object",
         "properties": {
           "incident_type": {
@@ -10986,7 +14901,7 @@
           "incident_type"
         ]
       },
-      "ShowResponseBody8": {
+      "ShowResponseBody12": {
         "type": "object",
         "properties": {
           "incident": {
@@ -11028,6 +14943,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -11057,7 +14981,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -11106,7 +15030,7 @@
           "incident"
         ]
       },
-      "ShowResponseBody9": {
+      "ShowResponseBody13": {
         "type": "object",
         "properties": {
           "incident": {
@@ -11148,6 +15072,15 @@
                 },
                 "values": [
                   {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
                     "value_link": "https://google.com/",
                     "value_numeric": "123.456",
                     "value_option": {
@@ -11159,6 +15092,15 @@
                     "value_text": "This is my text field, I hope you like it"
                   }
                 ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
               }
             ],
             "external_issue_reference": {
@@ -11182,7 +15124,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                   "name": "Incident Lead",
-                  "required": true,
+                  "required": false,
                   "role_type": "lead",
                   "shortform": "lead",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -11238,11 +15180,286 @@
             "slack_team_id": "T02A1FSLE8J",
             "summary": "Our database is really really sad, and we don't know why yet.",
             "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
           }
         },
         "required": [
           "incident"
+        ]
+      },
+      "ShowResponseBody14": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "$ref": "#/components/schemas/SeverityV2"
+          }
+        },
+        "example": {
+          "severity": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Issues with **low impact**.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Minor",
+            "rank": 1,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "severity"
+        ]
+      },
+      "ShowResponseBody15": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserWithRolesV2"
+          }
+        },
+        "example": {
+          "user": {
+            "base_role": {
+              "description": "Elevated permissions for the customer success team.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Customer Success",
+              "slug": "customer-success"
+            },
+            "custom_roles": [
+              {
+                "description": "Elevated permissions for the customer success team.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Customer Success",
+                "slug": "customer-success"
+              }
+            ],
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        },
+        "required": [
+          "user"
+        ]
+      },
+      "ShowResponseBody2": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/ActionV2"
+          }
+        },
+        "example": {
+          "action": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "ShowResponseBody3": {
+        "type": "object",
+        "properties": {
+          "custom_field_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV1"
+          }
+        },
+        "example": {
+          "custom_field_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          }
+        },
+        "required": [
+          "custom_field_option"
+        ]
+      },
+      "ShowResponseBody4": {
+        "type": "object",
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV1"
+          }
+        },
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ],
+            "required": "never",
+            "required_v2": "never",
+            "show_before_closure": true,
+            "show_before_creation": true,
+            "show_before_update": true,
+            "show_in_announcement_post": true,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "custom_field"
+        ]
+      },
+      "ShowResponseBody5": {
+        "type": "object",
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV2"
+          }
+        },
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "custom_field"
+        ]
+      },
+      "ShowResponseBody6": {
+        "type": "object",
+        "properties": {
+          "follow_up": {
+            "$ref": "#/components/schemas/FollowUpV2"
+          }
+        },
+        "example": {
+          "follow_up": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "follow_up"
+        ]
+      },
+      "ShowResponseBody7": {
+        "type": "object",
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "incident_role"
+        ]
+      },
+      "ShowResponseBody8": {
+        "type": "object",
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV2"
+          }
+        },
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "incident_role"
+        ]
+      },
+      "ShowResponseBody9": {
+        "type": "object",
+        "properties": {
+          "incident_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "example": {
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "incident_status"
         ]
       },
       "UpdateEntryRequestBody": {
@@ -11267,16 +15484,18 @@
               "abc123": {
                 "array_value": [
                   {
-                    "literal": "SEV123"
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
                   }
                 ],
                 "value": {
-                  "literal": "SEV123"
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
                 }
               }
             },
             "additionalProperties": {
-              "$ref": "#/components/schemas/CatalogAttributeBindingPayloadV2"
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
             }
           },
           "external_id": {
@@ -11305,11 +15524,13 @@
             "abc123": {
               "array_value": [
                 {
-                  "literal": "SEV123"
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
                 }
               ],
               "value": {
-                "literal": "SEV123"
+                "literal": "SEV123",
+                "reference": "incident.severity"
               }
             }
           },
@@ -11364,7 +15585,7 @@
           },
           "required": {
             "type": "string",
-            "description": "When this custom field must be set during the incident lifecycle.",
+            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
             "example": "never",
             "enum": [
               "never",
@@ -11372,9 +15593,19 @@
               "always"
             ]
           },
+          "required_v2": {
+            "type": "string",
+            "description": "When this custom field must be set during the incident lifecycle.",
+            "example": "never",
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
+          },
           "show_before_closure": {
             "type": "boolean",
-            "description": "Whether a custom field should be shown in the incident close modal. If this custom field is required before closure, but no value has been set for it, the field will be shown in the closure modal whatever the value of this setting.",
+            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
             "example": true
           },
           "show_before_creation": {
@@ -11397,6 +15628,7 @@
           "description": "Which team is impacted by this issue",
           "name": "Affected Team",
           "required": "never",
+          "required_v2": "never",
           "show_before_closure": true,
           "show_before_creation": true,
           "show_before_update": true,
@@ -11406,7 +15638,6 @@
           "name",
           "description",
           "field_type",
-          "required",
           "show_before_creation",
           "show_before_closure",
           "show_before_update",
@@ -11416,6 +15647,34 @@
         ]
       },
       "UpdateRequestBody3": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          }
+        },
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "name": "Affected Team"
+        },
+        "required": [
+          "name",
+          "description",
+          "field_type",
+          "cannot_be_unset",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "UpdateRequestBody4": {
         "type": "object",
         "properties": {
           "description": {
@@ -11437,8 +15696,8 @@
           },
           "required": {
             "type": "boolean",
-            "description": "Whether incident require this role to be set",
-            "example": true
+            "description": "DEPRECATED: this will always be false.",
+            "example": false
           },
           "shortform": {
             "type": "string",
@@ -11451,7 +15710,7 @@
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
           "name": "Incident Lead",
-          "required": true,
+          "required": false,
           "shortform": "lead"
         },
         "required": [
@@ -11461,12 +15720,55 @@
           "instructions",
           "shortform",
           "role_type",
-          "required",
           "created_at",
           "updated_at"
         ]
       },
-      "UpdateRequestBody4": {
+      "UpdateRequestBody5": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack",
+            "example": "lead",
+            "minLength": 1
+          }
+        },
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "shortform": "lead"
+        },
+        "required": [
+          "conditions",
+          "name",
+          "description",
+          "instructions",
+          "shortform",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "UpdateRequestBody6": {
         "type": "object",
         "properties": {
           "description": {
@@ -11510,14 +15812,15 @@
           "color": {
             "type": "string",
             "description": "Sets the display color of this type in the dashboard",
-            "example": "slate",
+            "example": "yellow",
             "enum": [
-              "slate",
-              "red",
               "yellow",
               "green",
               "blue",
-              "violet"
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
             ]
           },
           "description": {
@@ -11535,13 +15838,21 @@
               "briefcase",
               "browser",
               "bulb",
+              "calendar",
               "clock",
               "cog",
+              "components",
               "database",
               "doc",
               "email",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
               "server",
               "severity",
+              "store",
               "star",
               "tag",
               "user",
@@ -11558,28 +15869,22 @@
             "description": "If this type should be ranked",
             "example": true
           },
-          "semantic_type": {
-            "type": "string",
-            "description": "Semantic type of this resource",
-            "example": "custom"
-          },
           "source_repo_url": {
             "type": "string",
             "description": "The url of the external repository where this type is managed",
-            "example": "https://github.com/incident-io/catalog-importer"
+            "example": "https://github.com/my-company/incident-io-catalog"
           }
         },
         "example": {
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
-          "color": "slate",
+          "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "bolt",
           "name": "Kubernetes Cluster",
           "ranked": true,
-          "semantic_type": "custom",
-          "source_repo_url": "https://github.com/incident-io/catalog-importer"
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog"
         },
         "required": [
           "name",
@@ -11597,7 +15902,9 @@
             "example": [
               {
                 "array": false,
+                "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "manual",
                 "name": "tier",
                 "type": "Custom[\"Service\"]"
               }
@@ -11613,7 +15920,9 @@
           "attributes": [
             {
               "array": false,
+              "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "mode": "manual",
               "name": "tier",
               "type": "Custom[\"Service\"]"
             }
@@ -11634,7 +15943,8 @@
           "is_editable",
           "annotations",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "mode"
         ]
       },
       "UserReferencePayloadV1": {
@@ -11799,6 +16109,120 @@
           "organisation_id"
         ]
       },
+      "UserWithRolesV2": {
+        "type": "object",
+        "properties": {
+          "base_role": {
+            "$ref": "#/components/schemas/RBACRoleV2"
+          },
+          "custom_roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RBACRoleV2"
+            },
+            "example": [
+              {
+                "description": "Elevated permissions for the customer success team.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Customer Success",
+                "slug": "customer-success"
+              }
+            ]
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the user.",
+            "example": "lisa@incident.io"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the user",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the user",
+            "example": "Lisa Karlin Curtis"
+          },
+          "role": {
+            "type": "string",
+            "description": "DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.",
+            "example": "viewer",
+            "enum": [
+              "viewer",
+              "responder",
+              "administrator",
+              "owner",
+              "unset"
+            ]
+          },
+          "slack_user_id": {
+            "type": "string",
+            "description": "Slack ID of the user",
+            "example": "U02AYNF2XJM"
+          }
+        },
+        "example": {
+          "base_role": {
+            "description": "Elevated permissions for the customer success team.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Customer Success",
+            "slug": "customer-success"
+          },
+          "custom_roles": [
+            {
+              "description": "Elevated permissions for the customer success team.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Customer Success",
+              "slug": "customer-success"
+            }
+          ],
+          "email": "lisa@incident.io",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Lisa Karlin Curtis",
+          "role": "viewer",
+          "slack_user_id": "U02AYNF2XJM"
+        },
+        "required": [
+          "base_role",
+          "custom_roles",
+          "role",
+          "id",
+          "slack_role",
+          "name",
+          "deprecated_base_role",
+          "organisation_id"
+        ]
+      },
+      "WebhookIncidentUserV2": {
+        "type": "object",
+        "properties": {
+          "actor_user_id": {
+            "type": "string",
+            "description": "The ID of the user who performed this action",
+            "example": "abc123"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "The ID of the incident",
+            "example": "abc123"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "The ID of the user",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "actor_user_id": "abc123",
+          "incident_id": "abc123",
+          "user_id": "abc123"
+        },
+        "required": [
+          "incident_id",
+          "user_id"
+        ]
+      },
       "WebhookPrivateResourceV2": {
         "type": "object",
         "properties": {
@@ -11820,11 +16244,19 @@
   "tags": [
     {
       "name": "Actions V1",
-      "description": "Manage incident actions.\n\nIncidents have two types of actions associated to them:\n\n- Actions, used during an incident response as ephemeral todo lists\n- Follow-ups, actions which are for after the incident and can be exported to external\n\tissue trackers\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n\nExporting follow-ups to external issue trackers can be done in the incident homepage.\n"
+      "description": "Manage incident actions.\n\nThese endpoints have been deprecated in favour of Actions V2 and Follow-ups V2, as these\nconcepts have become increasingly separate.\n\nIncidents have two types of actions associated to them:\n\n- Actions, used during an incident response as ephemeral todo lists\n- Follow-ups, actions which are for after the incident and can be exported to external\n\tissue trackers\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n\nExporting follow-ups to external issue trackers can be done in the incident homepage.\n"
+    },
+    {
+      "name": "Actions V2",
+      "description": "Manage incident actions.\n\nIncident actions are used during an incident, to track work such as 'restart the database' or 'contact the customer'.\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n"
+    },
+    {
+      "name": "Alert Events V2",
+      "description": "Create alerts within incident.io.\n\nThe alerts API allows you to create alerts within incident.io by posting alert events. You\ncan use alerts to automatically trigger incidents.\n\nTo create an alert, you must first configure an alert source in the incident.io dashboard.\n"
     },
     {
       "name": "Catalog V2",
-      "description": "Manage and browse catalog resources.\n\n> This endpoint is in beta, released for early testing but excluded from our backwards\n> compatibility guarantee at this time. Contact support@incident.io if you have\n> questions about availability or want to try this out.\n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation.\n\nThe catalog has a number of types which are synced from your connected integrations, such\nas GitHub Repositories or PagerDuty Services, but you can also create custom types\nspecifically tailored to your company.\n\nExamples might be a Service type with an Alert channel which you can point at a Slack\nchannel, or Team which specifies its Manager and Technical Lead.\n"
+      "description": "Manage and browse catalog resources.\n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation. These different categories of thing\nbecome catalog types, and each instance (like a particular service or team) is a\ncatalog entry.\n\nEach type is made up of a series of attributes, and each attribute has a type. Types\ncan even have attributes that refer to other catalog types.\n\nWe automatically create catalog types when you connect an integration, such as GitHub \nrepositories or PagerDuty services and teams. You can use this API to create custom\ntypes, that are specifically tailored to your organisation.\n\nExamples might be a 'Service' type with an 'Alert channel' which you can point at a \nSlack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack\nusers. You can then use these types to create powerful new workflows.\n"
     },
     {
       "name": "Custom Field Options V1",
@@ -11832,18 +16264,34 @@
     },
     {
       "name": "Custom Fields V1",
-      "description": "Manage custom fields.\n\nCustom fields are used to attach metadata to incidents, which you can use when searching\nfor incidents in the dashboard, triggering workflows, building announcement rules or for\nyour own data needs.\n\nEach field has a type:\n\n- Single-select, single value selected from a predefined list of options (ie. Incident Type)\n- Multi-select, as above but you can pick more than one option (ie. Teams)\n- Text, freeform text field (ie. Customer ID)\n- Link, link URL that is synced to Slack bookmarks on the incident channel (ie. External Status Page)\n- Number, integer or fractional numbers (ie. Customers Affected)\n\nWe may add more custom field types in the future - we'd love to hear any other types you'd like to use!\n"
+      "description": "Manage custom fields.\n\nCustom fields are used to attach metadata to incidents, which you can use when searching\nfor incidents in the dashboard, triggering workflows, building announcement rules or for\nyour own data needs.\n\nEach field has a type:\n\n- Single-select, single value selected from a predefined list of options (e.g. Detection Method)\n- Multi-select, as above but you can pick more than one option (e.g. Affected Teams)\n- Text, freeform text field (e.g. Customer ID)\n- Link, link URL that is synced to Slack bookmarks on the incident channel (e.g. External Status Page)\n- Number, integer or fractional numbers (e.g. # Customers Affected)\n\nWe may add more custom field types in the future - we'd love to hear any other types you'd like to use!\n"
+    },
+    {
+      "name": "Custom Fields V2",
+      "description": "Manage custom fields.\n\nCustom fields are used to attach metadata to incidents, which you can use when searching\nfor incidents in the dashboard, triggering workflows, building announcement rules or for\nyour own data needs.\n\nEach field has a type:\n\n- Single-select, single value selected from a predefined list of options (e.g. Detection Method)\n- Multi-select, as above but you can pick more than one option (e.g. Affected Teams)\n- Text, freeform text field (e.g. Customer ID)\n- Link, link URL that is synced to Slack bookmarks on the incident channel (e.g. External Status Page)\n- Number, integer or fractional numbers (e.g. # Customers Affected)\n\nSingle-select and multi-select fields can also be powered by the Catalog. This will mean a field has a\ncatalog_type_id, which links it to the catalog type that it references.\n\nWe may add more custom field types in the future - we'd love to hear any other types you'd like to use!\n"
+    },
+    {
+      "name": "Follow-ups V2",
+      "description": "Manage incident follow-ups.\n\nIncidents can have follow-ups associated with them, which track work that should be done\nafter an incident (e.g. improving some documentation, or upgrading a dependency). They can\nalso be exported to external issue trackers.\n\nYou can manage follow-ups in the incident Slack channel with <code>/incident follow-ups</code>, or on\nthe incident homepage.\n"
     },
     {
       "name": "Incident Attachments V1",
       "description": "Create, list and delete incident attachments.\n\nIncident Attachments allows you to connect resources from external systems into incidents.\nExamples include: PagerDuty incidents and GitHub pull requests.\n"
     },
     {
+      "name": "Incident Memberships V1",
+      "description": "Manage private incident memberships"
+    },
+    {
       "name": "Incident Roles V1",
       "description": "Manage incident roles.\n\nDuring an incident, you can assign responders to one of the incident roles that are\nconfigured in your organisation settings.\n\nEvery organisation will have a special 'lead' role, which signifies the incident lead or\ncommander. This role cannot be deleted, but can be renamed in the incident.io dashboard.\n"
     },
     {
-      "name": "IncidentStatuses V1",
+      "name": "Incident Roles V2",
+      "description": "Manage incident roles.\n\nDuring an incident, you can assign responders to one of the incident roles that are\nconfigured in your organisation settings.\n\nEvery organisation will have a special 'lead' role, which signifies the incident lead or\ncommander. This role cannot be deleted, but can be renamed in the incident.io dashboard.\n"
+    },
+    {
+      "name": "Incident Statuses V1",
       "description": "Manage incident statuses.\n\nEach incident has a status, picked from one of the statuses configured in your\norganisations settings.\n\nStatuses help communicate where an incident is in its lifecycle. You can use\nstatuses when filtering incidents in the dashboard, and in workflows and announcement\nrules.\n"
     },
     {
@@ -11871,6 +16319,10 @@
       "description": "Manage incident severities.\n\nEach incident has a severity, picked from one of the severities configured in your\norganisations settings.\n\nSeverities help categorise incidents, and communicate urgency/impact. You can use\nseverities when filtering incidents in the dashboard, and in workflows and announcement\nrules.\n"
     },
     {
+      "name": "Users V2",
+      "description": "View users.\n\nUsers all have a single base role, and can be assigned multiple custom roles. They can be managed via your Slack workspace or SAML provider.\n"
+    },
+    {
       "name": "Utilities V1",
       "description": "Miscelaneous utility endpoints.\n\nCollection of utility functions that can help build integrations against this API.\n"
     },
@@ -11884,6 +16336,62 @@
     }
   ],
   "x-webhooks": {
+    "/x-webhooks/private_incident.action_created_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PrivateIncidentActionCreatedV1",
+        "description": "This webhook is emitted whenever a follow-up for a private incident is created.",
+        "operationId": "Webhooks#PrivateIncidentActionCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateIncidentActionCreatedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "private_incident.action_created_v1",
+                  "private_incident.action_created_v1": {
+                    "id": "abc123"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/private_incident.action_updated_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PrivateIncidentActionUpdatedV1",
+        "description": "This webhook is emitted whenever a follow-up for a private incident is updated.",
+        "operationId": "Webhooks#PrivateIncidentActionUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateIncidentActionUpdatedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "private_incident.action_updated_v1",
+                  "private_incident.action_updated_v1": {
+                    "id": "abc123"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/x-webhooks/private_incident.follow_up_created_v1": {
       "get": {
         "tags": [
@@ -11988,6 +16496,160 @@
                   "event_type": "private_incident.incident_updated_v2",
                   "private_incident.incident_updated_v2": {
                     "id": "abc123"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/private_incident.membership_granted_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PrivateIncidentMembershipGrantedV1",
+        "description": "This webhook is emitted whenever a user is given access to a private incident.",
+        "operationId": "Webhooks#PrivateIncidentMembershipGrantedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateIncidentMembershipGrantedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "private_incident.membership_granted_v1",
+                  "private_incident.membership_granted_v1": {
+                    "actor_user_id": "abc123",
+                    "incident_id": "abc123",
+                    "user_id": "abc123"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/private_incident.membership_revoked_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PrivateIncidentMembershipRevokedV1",
+        "description": "This webhook is emitted whenever a user's access to a private incident is revoked.",
+        "operationId": "Webhooks#PrivateIncidentMembershipRevokedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateIncidentMembershipRevokedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "private_incident.membership_revoked_v1",
+                  "private_incident.membership_revoked_v1": {
+                    "actor_user_id": "abc123",
+                    "incident_id": "abc123",
+                    "user_id": "abc123"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/public_incident.action_created_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PublicIncidentActionCreatedV1",
+        "description": "This webhook is emitted whenever a follow-up is created.",
+        "operationId": "Webhooks#PublicIncidentActionCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicIncidentActionCreatedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "public_incident.action_created_v1",
+                  "public_incident.action_created_v1": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "follow_up": true,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "status": "outstanding",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/public_incident.action_updated_v1": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PublicIncidentActionUpdatedV1",
+        "description": "This webhook is emitted whenever a follow-up is updated.",
+        "operationId": "Webhooks#PublicIncidentActionUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicIncidentActionUpdatedV1ResponseBody"
+                },
+                "example": {
+                  "event_type": "public_incident.action_updated_v1",
+                  "public_incident.action_updated_v1": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "follow_up": true,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "status": "outstanding",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
               }
@@ -12142,6 +16804,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -12153,6 +16824,15 @@
                             "value_text": "This is my text field, I hope you like it"
                           }
                         ]
+                      }
+                    ],
+                    "duration_metrics": [
+                      {
+                        "duration_metric": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Lasted"
+                        },
+                        "value_seconds": 1
                       }
                     ],
                     "external_issue_reference": {
@@ -12176,7 +16856,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -12232,7 +16912,204 @@
                     "slack_team_id": "T02A1FSLE8J",
                     "summary": "Our database is really really sad, and we don't know why yet.",
                     "updated_at": "2021-08-17T13:28:57.801578Z",
-                    "visibility": "public"
+                    "visibility": "public",
+                    "workload_minutes_late": 40.7,
+                    "workload_minutes_sleeping": 0,
+                    "workload_minutes_total": 60.7,
+                    "workload_minutes_working": 20
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-webhooks/public_incident.incident_status_updated_v2": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "PublicIncidentIncidentStatusUpdatedV2",
+        "description": "This webhook is emitted whenever an incident's status changes.",
+        "operationId": "Webhooks#PublicIncidentIncidentStatusUpdatedV2",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicIncidentIncidentStatusUpdatedV2ResponseBody"
+                },
+                "example": {
+                  "event_type": "public_incident.incident_status_updated_v2",
+                  "public_incident.incident_status_updated_v2": {
+                    "incident": {
+                      "call_url": "https://zoom.us/foo",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "creator": {
+                        "api_key": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My test API key"
+                        },
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      },
+                      "custom_field_entries": [
+                        {
+                          "custom_field": {
+                            "description": "Which team is impacted by this issue",
+                            "field_type": "single_select",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Affected Team",
+                            "options": [
+                              {
+                                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "sort_key": 10,
+                                "value": "Product"
+                              }
+                            ]
+                          },
+                          "values": [
+                            {
+                              "value_catalog_entry": {
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
+                                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "name": "Primary On-call"
+                              },
+                              "value_link": "https://google.com/",
+                              "value_numeric": "123.456",
+                              "value_option": {
+                                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "sort_key": 10,
+                                "value": "Product"
+                              },
+                              "value_text": "This is my text field, I hope you like it"
+                            }
+                          ]
+                        }
+                      ],
+                      "duration_metrics": [
+                        {
+                          "duration_metric": {
+                            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                            "name": "Lasted"
+                          },
+                          "value_seconds": 1
+                        }
+                      ],
+                      "external_issue_reference": {
+                        "issue_name": "INC-123",
+                        "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                        "provider": "asana"
+                      },
+                      "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                      "incident_role_assignments": [
+                        {
+                          "assignee": {
+                            "email": "lisa@incident.io",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Lisa Karlin Curtis",
+                            "role": "viewer",
+                            "slack_user_id": "U02AYNF2XJM"
+                          },
+                          "role": {
+                            "created_at": "2021-08-17T13:28:57.801578Z",
+                            "description": "The person currently coordinating the incident",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                            "name": "Incident Lead",
+                            "required": false,
+                            "role_type": "lead",
+                            "shortform": "lead",
+                            "updated_at": "2021-08-17T13:28:57.801578Z"
+                          }
+                        }
+                      ],
+                      "incident_status": {
+                        "category": "triage",
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                        "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                        "name": "Closed",
+                        "rank": 4,
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      },
+                      "incident_timestamp_values": [
+                        {
+                          "incident_timestamp": {
+                            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                            "name": "Impact started",
+                            "rank": 1
+                          },
+                          "value": {
+                            "value": "2021-08-17T13:28:57.801578Z"
+                          }
+                        }
+                      ],
+                      "incident_type": {
+                        "create_in_triage": "always",
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "description": "Customer facing production outages",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "is_default": false,
+                        "name": "Production Outage",
+                        "private_incidents_only": false,
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      },
+                      "mode": "standard",
+                      "name": "Our database is sad",
+                      "permalink": "https://app.incident.io/incidents/123",
+                      "postmortem_document_url": "https://docs.google.com/my_doc_id",
+                      "reference": "INC-123",
+                      "severity": {
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "description": "Issues with **low impact**.",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Minor",
+                        "rank": 1,
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      },
+                      "slack_channel_id": "C02AW36C1M5",
+                      "slack_channel_name": "inc-165-green-parrot",
+                      "slack_team_id": "T02A1FSLE8J",
+                      "summary": "Our database is really really sad, and we don't know why yet.",
+                      "updated_at": "2021-08-17T13:28:57.801578Z",
+                      "visibility": "public",
+                      "workload_minutes_late": 40.7,
+                      "workload_minutes_sleeping": 0,
+                      "workload_minutes_total": 60.7,
+                      "workload_minutes_working": 20
+                    },
+                    "new_status": {
+                      "category": "triage",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                      "name": "Closed",
+                      "rank": 4,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "previous_status": {
+                      "category": "triage",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                      "name": "Closed",
+                      "rank": 4,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
                   }
                 }
               }
@@ -12293,6 +17170,15 @@
                         },
                         "values": [
                           {
+                            "value_catalog_entry": {
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
+                              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
                             "value_link": "https://google.com/",
                             "value_numeric": "123.456",
                             "value_option": {
@@ -12304,6 +17190,15 @@
                             "value_text": "This is my text field, I hope you like it"
                           }
                         ]
+                      }
+                    ],
+                    "duration_metrics": [
+                      {
+                        "duration_metric": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Lasted"
+                        },
+                        "value_seconds": 1
                       }
                     ],
                     "external_issue_reference": {
@@ -12327,7 +17222,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
                           "name": "Incident Lead",
-                          "required": true,
+                          "required": false,
                           "role_type": "lead",
                           "shortform": "lead",
                           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -12383,8 +17278,341 @@
                     "slack_team_id": "T02A1FSLE8J",
                     "summary": "Our database is really really sad, and we don't know why yet.",
                     "updated_at": "2021-08-17T13:28:57.801578Z",
-                    "visibility": "public"
+                    "visibility": "public",
+                    "workload_minutes_late": 40.7,
+                    "workload_minutes_sleeping": 0,
+                    "workload_minutes_total": 60.7,
+                    "workload_minutes_working": 20
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_route.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertRouteCreatedV1",
+        "description": "This entry is created whenever an alert route is created",
+        "operationId": "Audit logs#AlertRouteCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_route.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Production incidents",
+                      "type": "alert_route"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_route.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertRouteDeletedV1",
+        "description": "This entry is created whenever an alert route is deleted",
+        "operationId": "Audit logs#AlertRouteDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_route.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Production incidents",
+                      "type": "alert_route"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_route.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertRouteUpdatedV1",
+        "description": "This entry is created whenever an alert route is updated",
+        "operationId": "Audit logs#AlertRouteUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_route.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Production incidents",
+                      "type": "alert_route"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_schema.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertSchemaUpdatedV1",
+        "description": "This entry is created whenever alert attributes are updated",
+        "operationId": "Audit logs#AlertSchemaUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_schema.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Alert schema",
+                      "type": "alert_schema"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_source_config.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertSourceConfigCreatedV1",
+        "description": "This entry is created whenever an alert source is created",
+        "operationId": "Audit logs#AlertSourceConfigCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_source_config.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog alerts",
+                      "type": "alert_source"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_source_config.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertSourceConfigDeletedV1",
+        "description": "This entry is created whenever an alert source is deleted",
+        "operationId": "Audit logs#AlertSourceConfigDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_source_config.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog alerts",
+                      "type": "alert_source"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/alert_source_config.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "AlertSourceConfigUpdatedV1",
+        "description": "This entry is created whenever an alert source is updated",
+        "operationId": "Audit logs#AlertSourceConfigUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "alert_source_config.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog alerts",
+                      "type": "alert_source"
+                    }
+                  ],
+                  "version": 1
                 }
               }
             }
@@ -12406,7 +17634,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "announcement_rule.created",
@@ -12453,7 +17681,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "announcement_rule.deleted",
@@ -12500,7 +17728,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "announcement_rule.updated",
@@ -12547,7 +17775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "api_key.created",
@@ -12594,7 +17822,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "api_key.deleted",
@@ -12627,6 +17855,147 @@
         }
       }
     },
+    "/x-audit-logs/catalog_type.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "CatalogTypeCreatedV1",
+        "description": "This entry is created whenever a catalog type is created",
+        "operationId": "Audit logs#CatalogTypeCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "catalog_type.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Service",
+                      "type": "catalog_type"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/catalog_type.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "CatalogTypeDeletedV1",
+        "description": "This entry is created whenever a catalog type is deleted",
+        "operationId": "Audit logs#CatalogTypeDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "catalog_type.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Service",
+                      "type": "catalog_type"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/catalog_type.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "CatalogTypeUpdatedV1",
+        "description": "This entry is created whenever a catalog type is updated",
+        "operationId": "Audit logs#CatalogTypeUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "catalog_type.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Service",
+                      "type": "catalog_type"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/x-audit-logs/custom_field.created.1": {
       "get": {
         "tags": [
@@ -12641,7 +18010,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "custom_field.created",
@@ -12688,7 +18057,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "custom_field.deleted",
@@ -12735,7 +18104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "custom_field.updated",
@@ -12768,6 +18137,288 @@
         }
       }
     },
+    "/x-audit-logs/debrief_invite_rule.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "DebriefInviteRuleCreatedV1",
+        "description": "This entry is created whenever a debrief invite rule is created",
+        "operationId": "Audit logs#DebriefInviteRuleCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "debrief_invite_rule.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Invite founders for critical incidents",
+                      "type": "debrief_invite_rule"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/debrief_invite_rule.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "DebriefInviteRuleDeletedV1",
+        "description": "This entry is created whenever a debrief invite rule is deleted",
+        "operationId": "Audit logs#DebriefInviteRuleDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "debrief_invite_rule.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Invite founders for critical incidents",
+                      "type": "debrief_invite_rule"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/debrief_invite_rule.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "DebriefInviteRuleUpdatedV1",
+        "description": "This entry is created whenever a debrief invite rule is updated",
+        "operationId": "Audit logs#DebriefInviteRuleUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "debrief_invite_rule.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Invite founders for critical incidents",
+                      "type": "debrief_invite_rule"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/escalation_path.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "EscalationPathCreatedV1",
+        "description": "This entry is created whenever an escalation path is created",
+        "operationId": "Audit logs#EscalationPathCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "escalation_path.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Critical incidents",
+                      "type": "escalation_path"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/escalation_path.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "EscalationPathDeletedV1",
+        "description": "This entry is created whenever an escalation path is deleted",
+        "operationId": "Audit logs#EscalationPathDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "escalation_path.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Critical incidents",
+                      "type": "escalation_path"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/escalation_path.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "EscalationPathUpdatedV1",
+        "description": "This entry is created whenever an escalation path is updated",
+        "operationId": "Audit logs#EscalationPathUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "escalation_path.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Critical incidents",
+                      "type": "escalation_path"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/x-audit-logs/follow_up_priority.created.1": {
       "get": {
         "tags": [
@@ -12782,7 +18433,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "follow_up_priority.created",
@@ -12829,7 +18480,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "follow_up_priority.deleted",
@@ -12876,7 +18527,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "follow_up_priority.updated",
@@ -12923,7 +18574,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_duration_metric.created",
@@ -12970,7 +18621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_duration_metric.deleted",
@@ -13017,7 +18668,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_duration_metric.updated",
@@ -13064,7 +18715,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_role.created",
@@ -13111,7 +18762,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_role.deleted",
@@ -13158,7 +18809,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_role.updated",
@@ -13205,7 +18856,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_status.created",
@@ -13252,7 +18903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_status.deleted",
@@ -13299,7 +18950,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_status.updated",
@@ -13346,7 +18997,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_timestamp.created",
@@ -13393,7 +19044,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_timestamp.deleted",
@@ -13440,7 +19091,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_timestamp.updated",
@@ -13487,7 +19138,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_type.created",
@@ -13534,7 +19185,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_type.deleted",
@@ -13581,7 +19232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "incident_type.updated",
@@ -13628,7 +19279,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "integration.installed",
@@ -13675,7 +19326,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "integration.uninstalled",
@@ -13708,6 +19359,288 @@
         }
       }
     },
+    "/x-audit-logs/internal_status_page.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "InternalStatusPageCreatedV1",
+        "description": "This entry is created whenever an internal status page is created",
+        "operationId": "Audit logs#InternalStatusPageCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "internal_status_page.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Public Page",
+                      "type": "internal_status_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/internal_status_page.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "InternalStatusPageDeletedV1",
+        "description": "This entry is created whenever an internal status page is deleted",
+        "operationId": "Audit logs#InternalStatusPageDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "internal_status_page.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Public Page",
+                      "type": "internal_status_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/internal_status_page.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "InternalStatusPageUpdatedV1",
+        "description": "This entry is created whenever an internal status page has its configuration updated",
+        "operationId": "Audit logs#InternalStatusPageUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "internal_status_page.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Public Page",
+                      "type": "internal_status_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/nudge.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "NudgeCreatedV1",
+        "description": "This entry is created whenever a nudge is created",
+        "operationId": "Audit logs#NudgeCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "nudge.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Reminder to take a break",
+                      "type": "nudge"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/nudge.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "NudgeDeletedV1",
+        "description": "This entry is created whenever a nudge is deleted",
+        "operationId": "Audit logs#NudgeDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "nudge.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Reminder to take a break",
+                      "type": "nudge"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/nudge.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "NudgeUpdatedV1",
+        "description": "This entry is created whenever a nudge is updated",
+        "operationId": "Audit logs#NudgeUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "nudge.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Reminder to take a break",
+                      "type": "nudge"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/x-audit-logs/policy.created.1": {
       "get": {
         "tags": [
@@ -13722,7 +19655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "policy.created",
@@ -13769,7 +19702,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "policy.deleted",
@@ -13816,7 +19749,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "policy.updated",
@@ -13839,6 +19772,147 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Follow-ups must be closed within 3 weeks",
                       "type": "policy"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/post_incident_task.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "PostIncidentTaskCreatedV1",
+        "description": "This entry is created whenever a post-incident task is created",
+        "operationId": "Audit logs#PostIncidentTaskCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "post_incident_task.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Schedule a debrief",
+                      "type": "post_incident_task"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/post_incident_task.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "PostIncidentTaskDeletedV1",
+        "description": "This entry is created whenever a post-incident task is deleted",
+        "operationId": "Audit logs#PostIncidentTaskDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "post_incident_task.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Schedule a debrief",
+                      "type": "post_incident_task"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/post_incident_task.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "PostIncidentTaskUpdatedV1",
+        "description": "This entry is created whenever a post-incident task is updated",
+        "operationId": "Audit logs#PostIncidentTaskUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "post_incident_task.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Schedule a debrief",
+                      "type": "post_incident_task"
                     }
                   ],
                   "version": 1
@@ -13913,7 +19987,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "private_incident.access_requested",
@@ -13960,7 +20034,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "private_incident_membership.granted",
@@ -14012,7 +20086,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "private_incident_membership.revoked",
@@ -14064,7 +20138,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "rbac_role.created",
@@ -14111,7 +20185,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "rbac_role.deleted",
@@ -14158,7 +20232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "rbac_role.updated",
@@ -14181,6 +20255,147 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Engineering",
                       "type": "rbac_role"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/schedule.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "ScheduleCreatedV1",
+        "description": "This entry is created whenever a schedule is created",
+        "operationId": "Audit logs#ScheduleCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "schedule.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "On-call",
+                      "type": "schedule"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/schedule.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "ScheduleDeletedV1",
+        "description": "This entry is created whenever a schedule is deleted",
+        "operationId": "Audit logs#ScheduleDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "schedule.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "On-call",
+                      "type": "schedule"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/schedule.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "ScheduleUpdatedV1",
+        "description": "This entry is created whenever a schedule is updated",
+        "operationId": "Audit logs#ScheduleUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "schedule.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "On-call",
+                      "type": "schedule"
                     }
                   ],
                   "version": 1
@@ -14258,7 +20473,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "severity.created",
@@ -14305,7 +20520,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "severity.deleted",
@@ -14352,7 +20567,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "severity.updated",
@@ -14399,7 +20614,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "status_page.created",
@@ -14446,7 +20661,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "status_page.deleted",
@@ -14493,7 +20708,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "status_page.updated",
@@ -14526,6 +20741,288 @@
         }
       }
     },
+    "/x-audit-logs/status_page_sub_page.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageSubPageCreatedV1",
+        "description": "This entry is created whenever a status page sub-page is created",
+        "operationId": "Audit logs#StatusPageSubPageCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_sub_page.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Superpayments France",
+                      "type": "status_page_sub_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/status_page_sub_page.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageSubPageDeletedV1",
+        "description": "This entry is created whenever a status page sub-page is deleted",
+        "operationId": "Audit logs#StatusPageSubPageDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_sub_page.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Superpayments France",
+                      "type": "status_page_sub_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/status_page_sub_page.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageSubPageUpdatedV1",
+        "description": "This entry is created whenever a status page sub-page has its configuration updated",
+        "operationId": "Audit logs#StatusPageSubPageUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_sub_page.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Superpayments France",
+                      "type": "status_page_sub_page"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/status_page_template.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageTemplateCreatedV1",
+        "description": "This entry is created whenever a status page template is created",
+        "operationId": "Audit logs#StatusPageTemplateCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_template.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Investigating",
+                      "type": "status_page_template"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/status_page_template.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageTemplateDeletedV1",
+        "description": "This entry is created whenever a status page template is deleted",
+        "operationId": "Audit logs#StatusPageTemplateDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_template.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Investigating",
+                      "type": "status_page_template"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/status_page_template.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "StatusPageTemplateUpdatedV1",
+        "description": "This entry is created whenever a status page template is updated",
+        "operationId": "Audit logs#StatusPageTemplateUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "status_page_template.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Investigating",
+                      "type": "status_page_template"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/x-audit-logs/user.created.1": {
       "get": {
         "tags": [
@@ -14540,7 +21037,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "user.created",
@@ -14587,7 +21084,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "user.deactivated",
@@ -14634,7 +21131,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "user.reinstated",
@@ -14734,7 +21231,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "user.updated",
@@ -14781,7 +21278,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "workflow.created",
@@ -14828,7 +21325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "workflow.deleted",
@@ -14875,7 +21372,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnnouncementRuleCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
                 },
                 "example": {
                   "action": "workflow.updated",

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -240,7 +240,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 		}
 	}
 
-	// Update type schemas to match config
+	// Update type schemas to match config (excluding backlinks)
 	OUT("\n↻ Syncing catalog type schemas...")
 	for _, outputType := range cfg.Outputs() {
 		baseModel, enumModels := output.MarshalType(outputType)
@@ -396,7 +396,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 						ExternalID:      value,
 						Name:            value,
 						Aliases:         []string{},
-						AttributeValues: map[string]client.CatalogAttributeBindingPayloadV2{},
+						AttributeValues: map[string]client.EngineParamBindingPayloadV2{},
 					})
 				}
 
@@ -455,7 +455,7 @@ func newEntriesClient(cl *client.ClientWithResponses, existingCatalogTypes []cli
 		Update: func(ctx context.Context, entry *client.CatalogEntryV2, payload client.UpdateEntryRequestBody) (*client.CatalogEntryV2, error) {
 			existingPayload := client.UpdateEntryRequestBody{
 				Aliases:         lo.ToPtr(entry.Aliases),
-				AttributeValues: map[string]client.CatalogAttributeBindingPayloadV2{},
+				AttributeValues: map[string]client.EngineParamBindingPayloadV2{},
 				ExternalId:      entry.ExternalId,
 				Name:            entry.Name,
 				Rank:            &entry.Rank,
@@ -464,16 +464,16 @@ func newEntriesClient(cl *client.ClientWithResponses, existingCatalogTypes []cli
 				existingPayload.Rank = nil
 			}
 			for attrID, attr := range entry.AttributeValues {
-				result := client.CatalogAttributeBindingPayloadV2{}
+				result := client.EngineParamBindingPayloadV2{}
 				if attr.Value != nil {
-					result.Value = &client.CatalogAttributeValuePayloadV2{
+					result.Value = &client.EngineParamBindingValuePayloadV2{
 						Literal: attr.Value.Literal,
 					}
 				}
 				if attr.ArrayValue != nil {
-					arrayValue := []client.CatalogAttributeValuePayloadV2{}
+					arrayValue := []client.EngineParamBindingValuePayloadV2{}
 					for _, elementValue := range *attr.ArrayValue {
-						arrayValue = append(arrayValue, client.CatalogAttributeValuePayloadV2{
+						arrayValue = append(arrayValue, client.EngineParamBindingValuePayloadV2{
 							Literal: elementValue.Literal,
 						})
 					}

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -51,12 +51,19 @@ func MarshalType(output *Output) (base *CatalogTypeModel, enumTypes []*CatalogTy
 			attrType = attr.Type.String
 		}
 
+		mode := client.CatalogTypeAttributePayloadV2ModeManual
+		if attr.BacklinkAttribute.Valid {
+			mode = client.CatalogTypeAttributePayloadV2ModeBacklink
+		}
+
 		base.Attributes = append(
 			base.Attributes, client.CatalogTypeAttributePayloadV2{
-				Id:    lo.ToPtr(attr.ID),
-				Name:  attr.Name,
-				Type:  attrType,
-				Array: attr.Array,
+				Id:                lo.ToPtr(attr.ID),
+				Name:              attr.Name,
+				Type:              attrType,
+				Array:             attr.Array,
+				BacklinkAttribute: attr.BacklinkAttribute.Ptr(),
+				Mode:              lo.ToPtr(mode),
 			})
 
 		// The enums we generate should be returned as types too, as we'll need to sync them
@@ -72,6 +79,7 @@ func MarshalType(output *Output) (base *CatalogTypeModel, enumTypes []*CatalogTy
 						Id:   lo.ToPtr("description"),
 						Name: "Description",
 						Type: "String",
+						Mode: lo.ToPtr(client.CatalogTypeAttributePayloadV2ModeManual),
 					},
 				},
 				SourceAttribute: lo.ToPtr(*attr),

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -27,7 +27,7 @@ type CatalogEntryModel struct {
 	Name            string
 	Aliases         []string
 	Rank            int32
-	AttributeValues map[string]client.CatalogAttributeBindingPayloadV2
+	AttributeValues map[string]client.EngineParamBindingPayloadV2
 }
 
 // MarshalType builds the base catalog type model for the output, and any associated enum
@@ -155,10 +155,10 @@ func MarshalEntries(ctx context.Context, logger kitlog.Logger, output *Output, e
 
 		// Attribute values are built best effort, as it might not be the case that upstream
 		// source entries have these fields, or have fields of the correct type.
-		attributeValues := map[string]client.CatalogAttributeBindingPayloadV2{}
+		attributeValues := map[string]client.EngineParamBindingPayloadV2{}
 
 		for attributeID, src := range attributeSources {
-			binding := client.CatalogAttributeBindingPayloadV2{}
+			binding := client.EngineParamBindingPayloadV2{}
 
 			if attributeByID[attributeID].Array {
 				valueLiterals, err := expr.EvaluateArray[any](ctx, logger, src, entry)
@@ -169,14 +169,14 @@ func MarshalEntries(ctx context.Context, logger kitlog.Logger, output *Output, e
 					continue
 				}
 
-				arrayValue := []client.CatalogAttributeValuePayloadV2{}
+				arrayValue := []client.EngineParamBindingValuePayloadV2{}
 				for _, literalAny := range valueLiterals {
 					literal, ok := literalAny.(string)
 					if !ok {
 						continue
 					}
 
-					arrayValue = append(arrayValue, client.CatalogAttributeValuePayloadV2{
+					arrayValue = append(arrayValue, client.EngineParamBindingValuePayloadV2{
 						Literal: lo.ToPtr(literal),
 					})
 				}
@@ -191,7 +191,7 @@ func MarshalEntries(ctx context.Context, logger kitlog.Logger, output *Output, e
 					continue
 				}
 
-				binding.Value = &client.CatalogAttributeValuePayloadV2{
+				binding.Value = &client.EngineParamBindingValuePayloadV2{
 					Literal: literal,
 				}
 			}

--- a/output/output.go
+++ b/output/output.go
@@ -48,12 +48,13 @@ func (s SourceConfig) Validate() error {
 }
 
 type Attribute struct {
-	ID     string         `json:"id"`
-	Name   string         `json:"name"`
-	Type   null.String    `json:"type"`
-	Array  bool           `json:"array"`
-	Source null.String    `json:"source"`
-	Enum   *AttributeEnum `json:"enum"`
+	ID                string         `json:"id"`
+	Name              string         `json:"name"`
+	Type              null.String    `json:"type"`
+	Array             bool           `json:"array"`
+	Source            null.String    `json:"source"`
+	Enum              *AttributeEnum `json:"enum"`
+	BacklinkAttribute null.String    `json:"backlink_attribute"`
 }
 
 func (a Attribute) Validate() error {

--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -213,24 +213,24 @@ func Entries(ctx context.Context, logger kitlog.Logger, cl EntriesClient, catalo
 					entry.Name == model.Name &&
 						reflect.DeepEqual(entry.Aliases, model.Aliases) && entry.Rank == model.Rank
 
-				currentBindings := map[string]client.CatalogAttributeBindingPayloadV2{}
+				currentBindings := map[string]client.EngineParamBindingPayloadV2{}
 				for attributeID, value := range entry.AttributeValues {
-					current := client.CatalogAttributeBindingPayloadV2{}
+					current := client.EngineParamBindingPayloadV2{}
 					// Our API behaves strangely with empty arrays, and will omit them. This patch
 					// ensures the array is present so our comparison doesn't trigger falsly.
 					if value.ArrayValue == nil && value.Value == nil {
-						value.ArrayValue = lo.ToPtr([]client.CatalogAttributeValueV2{})
+						value.ArrayValue = lo.ToPtr([]client.EngineParamBindingValueV2{})
 					}
 
 					if value.ArrayValue != nil {
-						current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.CatalogAttributeValueV2, _ int) client.CatalogAttributeValuePayloadV2 {
-							return client.CatalogAttributeValuePayloadV2{
+						current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.EngineParamBindingValueV2, _ int) client.EngineParamBindingValuePayloadV2 {
+							return client.EngineParamBindingValuePayloadV2{
 								Literal: binding.Literal,
 							}
 						}))
 					}
 					if value.Value != nil {
-						current.Value = &client.CatalogAttributeValuePayloadV2{
+						current.Value = &client.EngineParamBindingValuePayloadV2{
 							Literal: value.Value.Literal,
 						}
 					}
@@ -301,7 +301,7 @@ func GetEntries(ctx context.Context, cl *client.ClientWithResponses, catalogType
 	for {
 		result, err := cl.CatalogV2ListEntriesWithResponse(ctx, &client.CatalogV2ListEntriesParams{
 			CatalogTypeId: catalogTypeID,
-			PageSize:      lo.ToPtr(int(250)),
+			PageSize:      lo.ToPtr(int64(250)),
 			After:         after,
 		})
 		if err != nil {


### PR DESCRIPTION
We're introducing backlink attributes, which allow you to say 'find all the features that this team owns' or similar, based on another catalog type.

This is challenging for the importer as this means attributes in an importer config can reference each other. e.g. if I'm creating both Teams and Features in my catalog, I need to wait until Features exists before creating the backlink attribute in Teams.

To resolve this, we split the UpdateTypeSchema process into two parts:
1. Create/Update all the types and their schemas
2. Create any new backlinks that don't exist yet (as the other attribute must now be present).

Note that to make the code sane, I've pulled the 'if dryRun' up one level as dryRun doesn't have any of these concerns.

This will fail with a 422 until we release the feature and flip the feature flag.