### PR TITLE
Update Team to use User rather than SlackUser

### DIFF
--- a/docs/simple/importer.jsonnet
+++ b/docs/simple/importer.jsonnet
@@ -39,19 +39,19 @@ local catalog = import 'catalog.jsonnet';
             {
               id: 'tech_lead',
               name: 'Tech lead',
-              type: 'SlackUser',
+              type: 'User',
               source: '$.tech_lead',
             },
             {
               id: 'engineering_manager',
               name: 'Engineering manager',
-              type: 'SlackUser',
+              type: 'User',
               source: '$.engineering_manager',
             },
             {
               id: 'product_manager',
               name: 'Product manager',
-              type: 'SlackUser',
+              type: 'User',
               source: '$.product_manager',
             },
             {
@@ -81,7 +81,7 @@ local catalog = import 'catalog.jsonnet';
             {
               id: 'members',
               name: 'Members',
-              type: 'SlackUser',
+              type: 'User',
               array: true,
               source: '$.members',
             },


### PR DESCRIPTION
According to [this documentation](https://help.incident.io/en/articles/9144404-teams-in-catalog-migrating-from-slackusers-to-users#h_b8069a6995), the Team catalog type should use `User` rather than `SlackUser`.