### PR TITLE
Update container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM alpine:20230329 AS runtime
+FROM alpine:20240329 AS runtime
 
-# goreleaser supplies this for us
+# Add certificates so we can make HTTPS requests.
+RUN apk add --no-cache ca-certificates
+
+# goreleaser supplies this for us.
 COPY catalog-importer /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/catalog-importer"]


### PR DESCRIPTION
As we don't have certificates in our docker image which means we fail to connect to our HTTPS API.

```
✔ Loaded config (1 pipelines, 1 sources, 1 outputs)
✔ Connected to incident.io API (https://api.incident.io)
catalog-importer: error: listing catalog types: Get "https://api.incident.io/v2/catalog_types": GET https://api.incident.io/v2/catalog_types giving up after 8 attempt(s): Get "https://api.incident.io/v2/catalog_types": tls: failed to verify certificate: x509: certificate signed by unknown authority
```