### PR TITLE
Enable debug logging in the retryable HTTP client

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -99,7 +99,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 	}
 
 	// Build incident.io client
-	cl, err := client.New(ctx, opt.APIKey, opt.APIEndpoint, Version(), clientOptions...)
+	cl, err := client.New(ctx, opt.APIKey, opt.APIEndpoint, Version(), logger, clientOptions...)
 	if err != nil {
 		return err
 	}

--- a/cmd/catalog-importer/cmd/types.go
+++ b/cmd/catalog-importer/cmd/types.go
@@ -36,7 +36,7 @@ func (opt *TypesOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 	}
 
 	// Build incident.io client
-	cl, err := client.New(ctx, opt.APIKey, opt.APIEndpoint, Version())
+	cl, err := client.New(ctx, opt.APIKey, opt.APIEndpoint, Version(), logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This passes the global logger in to the retryablehttp client we use, meaning that, if `--debug` is enabled, we'll emit debug logs about what HTTP requests are happening and whether they're being retried.