### PR TITLE
Support categories on catalog types

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -78,6 +78,17 @@ const (
 	CatalogTypeAttributeV2ModePath     CatalogTypeAttributeV2Mode = "path"
 )
 
+// Defines values for CatalogTypeV2Categories.
+const (
+	CatalogTypeV2CategoriesCustomer        CatalogTypeV2Categories = "customer"
+	CatalogTypeV2CategoriesIssueTracker    CatalogTypeV2Categories = "issue-tracker"
+	CatalogTypeV2CategoriesOnCall          CatalogTypeV2Categories = "on-call"
+	CatalogTypeV2CategoriesProductFeatures CatalogTypeV2Categories = "product-features"
+	CatalogTypeV2CategoriesService         CatalogTypeV2Categories = "service"
+	CatalogTypeV2CategoriesTeam            CatalogTypeV2Categories = "team"
+	CatalogTypeV2CategoriesUser            CatalogTypeV2Categories = "user"
+)
+
 // Defines values for CatalogTypeV2Color.
 const (
 	CatalogTypeV2ColorBlue   CatalogTypeV2Color = "blue"
@@ -121,6 +132,12 @@ const (
 const (
 	Firing   CreateHTTPRequestBodyStatus = "firing"
 	Resolved CreateHTTPRequestBodyStatus = "resolved"
+)
+
+// Defines values for CreateManagedResourceRequestBodyResourceType.
+const (
+	CreateManagedResourceRequestBodyResourceTypeSchedule CreateManagedResourceRequestBodyResourceType = "schedule"
+	CreateManagedResourceRequestBodyResourceTypeWorkflow CreateManagedResourceRequestBodyResourceType = "workflow"
 )
 
 // Defines values for CreateRequestBody10Mode.
@@ -212,6 +229,17 @@ const (
 const (
 	CreateRequestBody9VisibilityPrivate CreateRequestBody9Visibility = "private"
 	CreateRequestBody9VisibilityPublic  CreateRequestBody9Visibility = "public"
+)
+
+// Defines values for CreateTypeRequestBodyCategories.
+const (
+	CreateTypeRequestBodyCategoriesCustomer        CreateTypeRequestBodyCategories = "customer"
+	CreateTypeRequestBodyCategoriesIssueTracker    CreateTypeRequestBodyCategories = "issue-tracker"
+	CreateTypeRequestBodyCategoriesOnCall          CreateTypeRequestBodyCategories = "on-call"
+	CreateTypeRequestBodyCategoriesProductFeatures CreateTypeRequestBodyCategories = "product-features"
+	CreateTypeRequestBodyCategoriesService         CreateTypeRequestBodyCategories = "service"
+	CreateTypeRequestBodyCategoriesTeam            CreateTypeRequestBodyCategories = "team"
+	CreateTypeRequestBodyCategoriesUser            CreateTypeRequestBodyCategories = "user"
 )
 
 // Defines values for CreateTypeRequestBodyColor.
@@ -315,6 +343,41 @@ const (
 	Text         CustomFieldV2FieldType = "text"
 )
 
+// Defines values for EscalationPathNodeLevelV2TimeToAckIntervalCondition.
+const (
+	EscalationPathNodeLevelV2TimeToAckIntervalConditionActive   EscalationPathNodeLevelV2TimeToAckIntervalCondition = "active"
+	EscalationPathNodeLevelV2TimeToAckIntervalConditionInactive EscalationPathNodeLevelV2TimeToAckIntervalCondition = "inactive"
+)
+
+// Defines values for EscalationPathNodePayloadV2Type.
+const (
+	EscalationPathNodePayloadV2TypeIfElse        EscalationPathNodePayloadV2Type = "if_else"
+	EscalationPathNodePayloadV2TypeLevel         EscalationPathNodePayloadV2Type = "level"
+	EscalationPathNodePayloadV2TypeNotifyChannel EscalationPathNodePayloadV2Type = "notify_channel"
+	EscalationPathNodePayloadV2TypeRepeat        EscalationPathNodePayloadV2Type = "repeat"
+)
+
+// Defines values for EscalationPathNodeV2Type.
+const (
+	EscalationPathNodeV2TypeIfElse        EscalationPathNodeV2Type = "if_else"
+	EscalationPathNodeV2TypeLevel         EscalationPathNodeV2Type = "level"
+	EscalationPathNodeV2TypeNotifyChannel EscalationPathNodeV2Type = "notify_channel"
+	EscalationPathNodeV2TypeRepeat        EscalationPathNodeV2Type = "repeat"
+)
+
+// Defines values for EscalationPathTargetV2Type.
+const (
+	EscalationPathTargetV2TypeSchedule     EscalationPathTargetV2Type = "schedule"
+	EscalationPathTargetV2TypeSlackChannel EscalationPathTargetV2Type = "slack_channel"
+	EscalationPathTargetV2TypeUser         EscalationPathTargetV2Type = "user"
+)
+
+// Defines values for EscalationPathTargetV2Urgency.
+const (
+	High EscalationPathTargetV2Urgency = "high"
+	Low  EscalationPathTargetV2Urgency = "low"
+)
+
 // Defines values for ExpressionOperationPayloadV2OperationType.
 const (
 	ExpressionOperationPayloadV2OperationTypeBranches ExpressionOperationPayloadV2OperationType = "branches"
@@ -398,6 +461,7 @@ const (
 	IdentityV1RolesIncidentEditor            IdentityV1Roles = "incident_editor"
 	IdentityV1RolesIncidentMembershipsEditor IdentityV1Roles = "incident_memberships_editor"
 	IdentityV1RolesManageSettings            IdentityV1Roles = "manage_settings"
+	IdentityV1RolesOnCallEditor              IdentityV1Roles = "on_call_editor"
 	IdentityV1RolesPrivateWorkflowsEditor    IdentityV1Roles = "private_workflows_editor"
 	IdentityV1RolesSchedulesEditor           IdentityV1Roles = "schedules_editor"
 	IdentityV1RolesSchedulesReader           IdentityV1Roles = "schedules_reader"
@@ -474,11 +538,24 @@ const (
 	IncidentV2VisibilityPublic  IncidentV2Visibility = "public"
 )
 
+// Defines values for ManagedResourceV2ManagedBy.
+const (
+	ManagedResourceV2ManagedByDashboard ManagedResourceV2ManagedBy = "dashboard"
+	ManagedResourceV2ManagedByExternal  ManagedResourceV2ManagedBy = "external"
+	ManagedResourceV2ManagedByTerraform ManagedResourceV2ManagedBy = "terraform"
+)
+
+// Defines values for ManagedResourceV2ResourceType.
+const (
+	ManagedResourceV2ResourceTypeSchedule ManagedResourceV2ResourceType = "schedule"
+	ManagedResourceV2ResourceTypeWorkflow ManagedResourceV2ResourceType = "workflow"
+)
+
 // Defines values for ManagementMetaV2ManagedBy.
 const (
-	ManagementMetaV2ManagedByDashboard ManagementMetaV2ManagedBy = "dashboard"
-	ManagementMetaV2ManagedByExternal  ManagementMetaV2ManagedBy = "external"
-	ManagementMetaV2ManagedByTerraform ManagementMetaV2ManagedBy = "terraform"
+	Dashboard ManagementMetaV2ManagedBy = "dashboard"
+	External  ManagementMetaV2ManagedBy = "external"
+	Terraform ManagementMetaV2ManagedBy = "terraform"
 )
 
 // Defines values for ScheduleRotationHandoverV2IntervalType.
@@ -490,24 +567,13 @@ const (
 
 // Defines values for ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday.
 const (
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayFriday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "friday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayMonday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "monday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySaturday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "saturday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySunday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "sunday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayThursday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "thursday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayTuesday   ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "tuesday"
-	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayWednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
-)
-
-// Defines values for ScheduleRotationWorkingIntervalV2Weekday.
-const (
-	ScheduleRotationWorkingIntervalV2WeekdayFriday    ScheduleRotationWorkingIntervalV2Weekday = "friday"
-	ScheduleRotationWorkingIntervalV2WeekdayMonday    ScheduleRotationWorkingIntervalV2Weekday = "monday"
-	ScheduleRotationWorkingIntervalV2WeekdaySaturday  ScheduleRotationWorkingIntervalV2Weekday = "saturday"
-	ScheduleRotationWorkingIntervalV2WeekdaySunday    ScheduleRotationWorkingIntervalV2Weekday = "sunday"
-	ScheduleRotationWorkingIntervalV2WeekdayThursday  ScheduleRotationWorkingIntervalV2Weekday = "thursday"
-	ScheduleRotationWorkingIntervalV2WeekdayTuesday   ScheduleRotationWorkingIntervalV2Weekday = "tuesday"
-	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
+	Friday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "friday"
+	Monday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "monday"
+	Saturday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "saturday"
+	Sunday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "sunday"
+	Thursday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "thursday"
+	Tuesday   ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "tuesday"
+	Wednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
 )
 
 // Defines values for UpdateRequestBody2Required.
@@ -524,6 +590,17 @@ const (
 	Never            UpdateRequestBody2RequiredV2 = "never"
 )
 
+// Defines values for UpdateTypeRequestBodyCategories.
+const (
+	UpdateTypeRequestBodyCategoriesCustomer        UpdateTypeRequestBodyCategories = "customer"
+	UpdateTypeRequestBodyCategoriesIssueTracker    UpdateTypeRequestBodyCategories = "issue-tracker"
+	UpdateTypeRequestBodyCategoriesOnCall          UpdateTypeRequestBodyCategories = "on-call"
+	UpdateTypeRequestBodyCategoriesProductFeatures UpdateTypeRequestBodyCategories = "product-features"
+	UpdateTypeRequestBodyCategoriesService         UpdateTypeRequestBodyCategories = "service"
+	UpdateTypeRequestBodyCategoriesTeam            UpdateTypeRequestBodyCategories = "team"
+	UpdateTypeRequestBodyCategoriesUser            UpdateTypeRequestBodyCategories = "user"
+)
+
 // Defines values for UpdateTypeRequestBodyColor.
 const (
 	Blue   UpdateTypeRequestBodyColor = "blue"
@@ -537,30 +614,30 @@ const (
 
 // Defines values for UpdateTypeRequestBodyIcon.
 const (
-	Bolt       UpdateTypeRequestBodyIcon = "bolt"
-	Box        UpdateTypeRequestBodyIcon = "box"
-	Briefcase  UpdateTypeRequestBodyIcon = "briefcase"
-	Browser    UpdateTypeRequestBodyIcon = "browser"
-	Bulb       UpdateTypeRequestBodyIcon = "bulb"
-	Calendar   UpdateTypeRequestBodyIcon = "calendar"
-	Clock      UpdateTypeRequestBodyIcon = "clock"
-	Cog        UpdateTypeRequestBodyIcon = "cog"
-	Components UpdateTypeRequestBodyIcon = "components"
-	Database   UpdateTypeRequestBodyIcon = "database"
-	Doc        UpdateTypeRequestBodyIcon = "doc"
-	Email      UpdateTypeRequestBodyIcon = "email"
-	Files      UpdateTypeRequestBodyIcon = "files"
-	Flag       UpdateTypeRequestBodyIcon = "flag"
-	Folder     UpdateTypeRequestBodyIcon = "folder"
-	Globe      UpdateTypeRequestBodyIcon = "globe"
-	Money      UpdateTypeRequestBodyIcon = "money"
-	Server     UpdateTypeRequestBodyIcon = "server"
-	Severity   UpdateTypeRequestBodyIcon = "severity"
-	Star       UpdateTypeRequestBodyIcon = "star"
-	Store      UpdateTypeRequestBodyIcon = "store"
-	Tag        UpdateTypeRequestBodyIcon = "tag"
-	User       UpdateTypeRequestBodyIcon = "user"
-	Users      UpdateTypeRequestBodyIcon = "users"
+	UpdateTypeRequestBodyIconBolt       UpdateTypeRequestBodyIcon = "bolt"
+	UpdateTypeRequestBodyIconBox        UpdateTypeRequestBodyIcon = "box"
+	UpdateTypeRequestBodyIconBriefcase  UpdateTypeRequestBodyIcon = "briefcase"
+	UpdateTypeRequestBodyIconBrowser    UpdateTypeRequestBodyIcon = "browser"
+	UpdateTypeRequestBodyIconBulb       UpdateTypeRequestBodyIcon = "bulb"
+	UpdateTypeRequestBodyIconCalendar   UpdateTypeRequestBodyIcon = "calendar"
+	UpdateTypeRequestBodyIconClock      UpdateTypeRequestBodyIcon = "clock"
+	UpdateTypeRequestBodyIconCog        UpdateTypeRequestBodyIcon = "cog"
+	UpdateTypeRequestBodyIconComponents UpdateTypeRequestBodyIcon = "components"
+	UpdateTypeRequestBodyIconDatabase   UpdateTypeRequestBodyIcon = "database"
+	UpdateTypeRequestBodyIconDoc        UpdateTypeRequestBodyIcon = "doc"
+	UpdateTypeRequestBodyIconEmail      UpdateTypeRequestBodyIcon = "email"
+	UpdateTypeRequestBodyIconFiles      UpdateTypeRequestBodyIcon = "files"
+	UpdateTypeRequestBodyIconFlag       UpdateTypeRequestBodyIcon = "flag"
+	UpdateTypeRequestBodyIconFolder     UpdateTypeRequestBodyIcon = "folder"
+	UpdateTypeRequestBodyIconGlobe      UpdateTypeRequestBodyIcon = "globe"
+	UpdateTypeRequestBodyIconMoney      UpdateTypeRequestBodyIcon = "money"
+	UpdateTypeRequestBodyIconServer     UpdateTypeRequestBodyIcon = "server"
+	UpdateTypeRequestBodyIconSeverity   UpdateTypeRequestBodyIcon = "severity"
+	UpdateTypeRequestBodyIconStar       UpdateTypeRequestBodyIcon = "star"
+	UpdateTypeRequestBodyIconStore      UpdateTypeRequestBodyIcon = "store"
+	UpdateTypeRequestBodyIconTag        UpdateTypeRequestBodyIcon = "tag"
+	UpdateTypeRequestBodyIconUser       UpdateTypeRequestBodyIcon = "user"
+	UpdateTypeRequestBodyIconUsers      UpdateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for UpdateWorkflowRequestBodyRunsOnIncidentModes.
@@ -638,10 +715,10 @@ const (
 
 // Defines values for WorkflowSlimState.
 const (
-	WorkflowSlimStateActive   WorkflowSlimState = "active"
-	WorkflowSlimStateDisabled WorkflowSlimState = "disabled"
-	WorkflowSlimStateDraft    WorkflowSlimState = "draft"
-	WorkflowSlimStateError    WorkflowSlimState = "error"
+	Active   WorkflowSlimState = "active"
+	Disabled WorkflowSlimState = "disabled"
+	Draft    WorkflowSlimState = "draft"
+	Error    WorkflowSlimState = "error"
 )
 
 // Defines values for ActionsV1ListParamsIncidentMode.
@@ -983,6 +1060,9 @@ type CatalogTypeV2 struct {
 	// Annotations Annotations that can track metadata about this type
 	Annotations map[string]string `json:"annotations"`
 
+	// Categories What categories is this type considered part of
+	Categories []CatalogTypeV2Categories `json:"categories"`
+
 	// Color Sets the display color of this type in the dashboard
 	Color CatalogTypeV2Color `json:"color"`
 
@@ -1036,6 +1116,9 @@ type CatalogTypeV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// CatalogTypeV2Categories defines model for CatalogTypeV2.Categories.
+type CatalogTypeV2Categories string
+
 // CatalogTypeV2Color Sets the display color of this type in the dashboard
 type CatalogTypeV2Color string
 
@@ -1051,11 +1134,20 @@ type ConditionGroupPayloadV2 struct {
 // ConditionGroupV2 defines model for ConditionGroupV2.
 type ConditionGroupV2 struct {
 	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV2 `json:"conditions"`
+	Conditions []ConditionV3 `json:"conditions"`
 }
 
 // ConditionOperationV2 defines model for ConditionOperationV2.
 type ConditionOperationV2 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV3 defines model for ConditionOperationV3.
+type ConditionOperationV3 struct {
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -1084,6 +1176,15 @@ type ConditionSubjectV2 struct {
 	Reference string `json:"reference"`
 }
 
+// ConditionSubjectV3 defines model for ConditionSubjectV3.
+type ConditionSubjectV3 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
 // ConditionV2 defines model for ConditionV2.
 type ConditionV2 struct {
 	Operation ConditionOperationV2 `json:"operation"`
@@ -1091,6 +1192,15 @@ type ConditionV2 struct {
 	// ParamBindings Bindings for the operation parameters
 	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
 	Subject       ConditionSubjectV2     `json:"subject"`
+}
+
+// ConditionV3 defines model for ConditionV3.
+type ConditionV3 struct {
+	Operation ConditionOperationV3 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV3 `json:"param_bindings"`
+	Subject       ConditionSubjectV3     `json:"subject"`
 }
 
 // CreateEntryRequestBody defines model for CreateEntryRequestBody.
@@ -1124,7 +1234,7 @@ type CreateHTTPRequestBody struct {
 	// DeduplicationKey A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.
 	DeduplicationKey *string `json:"deduplication_key,omitempty"`
 
-	// Description Description that optionally adds more detail to title
+	// Description Description that optionally adds more detail to title. Supports markdown.
 	Description *string `json:"description,omitempty"`
 
 	// Metadata Any additional metadata that you've configured your alert source to parse
@@ -1142,6 +1252,43 @@ type CreateHTTPRequestBody struct {
 
 // CreateHTTPRequestBodyStatus Current status of this alert
 type CreateHTTPRequestBodyStatus string
+
+// CreateManagedResourceRequestBody defines model for CreateManagedResourceRequestBody.
+type CreateManagedResourceRequestBody struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations map[string]string `json:"annotations"`
+
+	// ResourceId The ID of the related resource
+	ResourceId string `json:"resource_id"`
+
+	// ResourceType The type of the related resource
+	ResourceType CreateManagedResourceRequestBodyResourceType `json:"resource_type"`
+}
+
+// CreateManagedResourceRequestBodyResourceType The type of the related resource
+type CreateManagedResourceRequestBodyResourceType string
+
+// CreateManagedResourceResponseBody defines model for CreateManagedResourceResponseBody.
+type CreateManagedResourceResponseBody struct {
+	ManagedResource ManagedResourceV2 `json:"managed_resource"`
+}
+
+// CreatePathRequestBody defines model for CreatePathRequestBody.
+type CreatePathRequestBody struct {
+	// Name The name of this escalation path, for the user's reference.
+	Name string `json:"name"`
+
+	// Path The nodes that form the levels and branches of this escalation path.
+	Path []EscalationPathNodePayloadV2 `json:"path"`
+
+	// WorkingHours The working hours for this escalation path.
+	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
+}
+
+// CreatePathResponseBody defines model for CreatePathResponseBody.
+type CreatePathResponseBody struct {
+	EscalationPath EscalationPathV2 `json:"escalation_path"`
+}
 
 // CreateRequestBody defines model for CreateRequestBody.
 type CreateRequestBody struct {
@@ -1414,6 +1561,9 @@ type CreateTypeRequestBody struct {
 	// Annotations Annotations that can track metadata about this type
 	Annotations *map[string]string `json:"annotations,omitempty"`
 
+	// Categories What categories is this type considered part of
+	Categories *[]CreateTypeRequestBodyCategories `json:"categories,omitempty"`
+
 	// Color Sets the display color of this type in the dashboard
 	Color *CreateTypeRequestBodyColor `json:"color,omitempty"`
 
@@ -1435,6 +1585,9 @@ type CreateTypeRequestBody struct {
 	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
 	TypeName *string `json:"type_name,omitempty"`
 }
+
+// CreateTypeRequestBodyCategories defines model for CreateTypeRequestBody.Categories.
+type CreateTypeRequestBodyCategories string
 
 // CreateTypeRequestBodyColor Sets the display color of this type in the dashboard
 type CreateTypeRequestBodyColor string
@@ -1709,6 +1862,13 @@ type EngineParamBindingV2 struct {
 	Value      *EngineParamBindingValueV2   `json:"value,omitempty"`
 }
 
+// EngineParamBindingV3 defines model for EngineParamBindingV3.
+type EngineParamBindingV3 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV3 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV3   `json:"value,omitempty"`
+}
+
 // EngineParamBindingValuePayloadV2 defines model for EngineParamBindingValuePayloadV2.
 type EngineParamBindingValuePayloadV2 struct {
 	// Literal If set, this is the literal value of the step parameter
@@ -1720,6 +1880,18 @@ type EngineParamBindingValuePayloadV2 struct {
 
 // EngineParamBindingValueV2 defines model for EngineParamBindingValueV2.
 type EngineParamBindingValueV2 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV3 defines model for EngineParamBindingValueV3.
+type EngineParamBindingValueV3 struct {
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -1745,6 +1917,120 @@ type EngineReferenceV2 struct {
 	Type string `json:"type"`
 }
 
+// EscalationPathNodeIfElsePayloadV2 defines model for EscalationPathNodeIfElsePayloadV2.
+type EscalationPathNodeIfElsePayloadV2 struct {
+	// Conditions The condition that defines which branch to take
+	Conditions *[]ConditionPayloadV2 `json:"conditions,omitempty"`
+
+	// ElsePath The nodes that form the levels if our condition is not met
+	ElsePath []EscalationPathNodePayloadV2 `json:"else_path"`
+
+	// ThenPath The nodes that form the levels if our condition is met
+	ThenPath []EscalationPathNodePayloadV2 `json:"then_path"`
+}
+
+// EscalationPathNodeIfElseV2 defines model for EscalationPathNodeIfElseV2.
+type EscalationPathNodeIfElseV2 struct {
+	// Conditions The condition that defines which branch to take
+	Conditions []ConditionV2 `json:"conditions"`
+
+	// ElsePath The nodes that form the levels if our condition is not met
+	ElsePath []EscalationPathNodeV2 `json:"else_path"`
+
+	// ThenPath The nodes that form the levels if our condition is met
+	ThenPath []EscalationPathNodeV2 `json:"then_path"`
+}
+
+// EscalationPathNodeLevelV2 defines model for EscalationPathNodeLevelV2.
+type EscalationPathNodeLevelV2 struct {
+	// Targets The targets for this level
+	Targets []EscalationPathTargetV2 `json:"targets"`
+
+	// TimeToAckIntervalCondition If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+	TimeToAckIntervalCondition *EscalationPathNodeLevelV2TimeToAckIntervalCondition `json:"time_to_ack_interval_condition,omitempty"`
+
+	// TimeToAckSeconds How long should we wait for this level to acknowledge before escalating?
+	TimeToAckSeconds *int64 `json:"time_to_ack_seconds,omitempty"`
+
+	// TimeToAckWeekdayIntervalConfigId If the time to ack is relative to a time window, this identifies which window it is relative to
+	TimeToAckWeekdayIntervalConfigId *string `json:"time_to_ack_weekday_interval_config_id,omitempty"`
+}
+
+// EscalationPathNodeLevelV2TimeToAckIntervalCondition If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+type EscalationPathNodeLevelV2TimeToAckIntervalCondition string
+
+// EscalationPathNodePayloadV2 defines model for EscalationPathNodePayloadV2.
+type EscalationPathNodePayloadV2 struct {
+	// Id Unique internal ID of the escalation path node
+	Id     string                             `json:"id"`
+	IfElse *EscalationPathNodeIfElsePayloadV2 `json:"if_else,omitempty"`
+	Level  *EscalationPathNodeLevelV2         `json:"level,omitempty"`
+	Repeat *EscalationPathNodeRepeatV2        `json:"repeat,omitempty"`
+
+	// Type The type of this node: level or branch
+	Type EscalationPathNodePayloadV2Type `json:"type"`
+}
+
+// EscalationPathNodePayloadV2Type The type of this node: level or branch
+type EscalationPathNodePayloadV2Type string
+
+// EscalationPathNodeRepeatV2 defines model for EscalationPathNodeRepeatV2.
+type EscalationPathNodeRepeatV2 struct {
+	// RepeatTimes How many times to repeat these steps
+	RepeatTimes int64 `json:"repeat_times"`
+
+	// ToNode Which node ID we begin repeating from
+	ToNode string `json:"to_node"`
+}
+
+// EscalationPathNodeV2 defines model for EscalationPathNodeV2.
+type EscalationPathNodeV2 struct {
+	// Id Unique internal ID of the escalation path node
+	Id     string                      `json:"id"`
+	IfElse *EscalationPathNodeIfElseV2 `json:"if_else,omitempty"`
+	Level  *EscalationPathNodeLevelV2  `json:"level,omitempty"`
+	Repeat *EscalationPathNodeRepeatV2 `json:"repeat,omitempty"`
+
+	// Type The type of this node: level or branch
+	Type EscalationPathNodeV2Type `json:"type"`
+}
+
+// EscalationPathNodeV2Type The type of this node: level or branch
+type EscalationPathNodeV2Type string
+
+// EscalationPathTargetV2 defines model for EscalationPathTargetV2.
+type EscalationPathTargetV2 struct {
+	// Id Uniquely identifies an entity of this type
+	Id string `json:"id"`
+
+	// Type Controls what type of entity this target identifies, such as EscalationPolicy or User
+	Type EscalationPathTargetV2Type `json:"type"`
+
+	// Urgency The urgency of this escalation path target
+	Urgency EscalationPathTargetV2Urgency `json:"urgency"`
+}
+
+// EscalationPathTargetV2Type Controls what type of entity this target identifies, such as EscalationPolicy or User
+type EscalationPathTargetV2Type string
+
+// EscalationPathTargetV2Urgency The urgency of this escalation path target
+type EscalationPathTargetV2Urgency string
+
+// EscalationPathV2 defines model for EscalationPathV2.
+type EscalationPathV2 struct {
+	// Id Unique identifier for this escalation path.
+	Id string `json:"id"`
+
+	// Name The name of this escalation path, for the user's reference.
+	Name string `json:"name"`
+
+	// Path The nodes that form the levels and branches of this escalation path.
+	Path []EscalationPathNodeV2 `json:"path"`
+
+	// WorkingHours The working hours for this escalation path.
+	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
+}
+
 // ExpressionBranchPayloadV2 defines model for ExpressionBranchPayloadV2.
 type ExpressionBranchPayloadV2 struct {
 	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
@@ -1756,7 +2042,7 @@ type ExpressionBranchPayloadV2 struct {
 type ExpressionBranchV2 struct {
 	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
 	ConditionGroups []ConditionGroupV2   `json:"condition_groups"`
-	Result          EngineParamBindingV2 `json:"result"`
+	Result          EngineParamBindingV3 `json:"result"`
 }
 
 // ExpressionBranchesOptsPayloadV2 defines model for ExpressionBranchesOptsPayloadV2.
@@ -1780,7 +2066,7 @@ type ExpressionElseBranchPayloadV2 struct {
 
 // ExpressionElseBranchV2 defines model for ExpressionElseBranchV2.
 type ExpressionElseBranchV2 struct {
-	Result EngineParamBindingV2 `json:"result"`
+	Result EngineParamBindingV3 `json:"result"`
 }
 
 // ExpressionFilterOptsPayloadV2 defines model for ExpressionFilterOptsPayloadV2.
@@ -2539,6 +2825,30 @@ type ListWorkflowsResponseBody struct {
 	Workflows []WorkflowSlim `json:"workflows"`
 }
 
+// ManagedResourceV2 defines model for ManagedResourceV2.
+type ManagedResourceV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations map[string]string `json:"annotations"`
+
+	// ManagedBy How is this resource managed
+	ManagedBy ManagedResourceV2ManagedBy `json:"managed_by"`
+
+	// ResourceId The ID of the related resource
+	ResourceId string `json:"resource_id"`
+
+	// ResourceType The type of the related resource
+	ResourceType ManagedResourceV2ResourceType `json:"resource_type"`
+
+	// SourceUrl The url of the external repository where this resource is managed (if there is one)
+	SourceUrl *string `json:"source_url,omitempty"`
+}
+
+// ManagedResourceV2ManagedBy How is this resource managed
+type ManagedResourceV2ManagedBy string
+
+// ManagedResourceV2ResourceType The type of the related resource
+type ManagedResourceV2ResourceType string
+
 // ManagementMetaV2 defines model for ManagementMetaV2.
 type ManagementMetaV2 struct {
 	// Annotations Annotations that track metadata about this resource
@@ -2692,9 +3002,9 @@ type ScheduleRotationCreatePayloadV2 struct {
 	Layers *[]ScheduleLayerCreatePayloadV2 `json:"layers,omitempty"`
 
 	// Name Name of the rotation
-	Name            string                               `json:"name"`
-	Users           *[]UserReferencePayloadV1            `json:"users,omitempty"`
-	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
+	Name            string                    `json:"name"`
+	Users           *[]UserReferencePayloadV1 `json:"users,omitempty"`
+	WorkingInterval *[]WeekdayIntervalV2      `json:"working_interval,omitempty"`
 }
 
 // ScheduleRotationHandoverV2 defines model for ScheduleRotationHandoverV2.
@@ -2740,9 +3050,9 @@ type ScheduleRotationV2 struct {
 	Layers []ScheduleLayerV2 `json:"layers"`
 
 	// Name Human readable name synced from external provider
-	Name            string                               `json:"name"`
-	Users           *[]UserV1                            `json:"users,omitempty"`
-	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
+	Name            string               `json:"name"`
+	Users           *[]UserV1            `json:"users,omitempty"`
+	WorkingInterval *[]WeekdayIntervalV2 `json:"working_interval,omitempty"`
 }
 
 // ScheduleRotationWorkingIntervalUpdatePayloadV2 defines model for ScheduleRotationWorkingIntervalUpdatePayloadV2.
@@ -2759,21 +3069,6 @@ type ScheduleRotationWorkingIntervalUpdatePayloadV2 struct {
 
 // ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday Weekday this interval applies to
 type ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday string
-
-// ScheduleRotationWorkingIntervalV2 defines model for ScheduleRotationWorkingIntervalV2.
-type ScheduleRotationWorkingIntervalV2 struct {
-	// EndTime End time of the interval, in 24hr format
-	EndTime string `json:"end_time"`
-
-	// StartTime Start time of the interval, in 24hr format
-	StartTime string `json:"start_time"`
-
-	// Weekday Weekday this interval applies to
-	Weekday ScheduleRotationWorkingIntervalV2Weekday `json:"weekday"`
-}
-
-// ScheduleRotationWorkingIntervalV2Weekday Weekday this interval applies to
-type ScheduleRotationWorkingIntervalV2Weekday string
 
 // ScheduleUpdatePayloadV2 defines model for ScheduleUpdatePayloadV2.
 type ScheduleUpdatePayloadV2 struct {
@@ -2937,7 +3232,7 @@ type StepConfig struct {
 	Name string `json:"name"`
 
 	// ParamBindings Bindings for the step parameters
-	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
+	ParamBindings []EngineParamBindingV3 `json:"param_bindings"`
 }
 
 // StepConfigPayload defines model for StepConfigPayload.
@@ -3094,6 +3389,9 @@ type UpdateTypeRequestBody struct {
 	// Annotations Annotations that can track metadata about this type
 	Annotations *map[string]string `json:"annotations,omitempty"`
 
+	// Categories What categories is this type considered part of
+	Categories *[]UpdateTypeRequestBodyCategories `json:"categories,omitempty"`
+
 	// Color Sets the display color of this type in the dashboard
 	Color *UpdateTypeRequestBodyColor `json:"color,omitempty"`
 
@@ -3112,6 +3410,9 @@ type UpdateTypeRequestBody struct {
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
 }
+
+// UpdateTypeRequestBodyCategories defines model for UpdateTypeRequestBody.Categories.
+type UpdateTypeRequestBodyCategories string
 
 // UpdateTypeRequestBodyColor Sets the display color of this type in the dashboard
 type UpdateTypeRequestBodyColor string
@@ -3230,6 +3531,31 @@ type UserWithRolesV2 struct {
 
 // UserWithRolesV2Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
 type UserWithRolesV2Role string
+
+// WeekdayIntervalConfigV2 defines model for WeekdayIntervalConfigV2.
+type WeekdayIntervalConfigV2 struct {
+	// Id The unique identifier for this set of working intervals
+	Id string `json:"id"`
+
+	// Name A human readable label for this set of working intervals
+	Name string `json:"name"`
+
+	// Timezone How to interpret all the intervals
+	Timezone         string              `json:"timezone"`
+	WeekdayIntervals []WeekdayIntervalV2 `json:"weekday_intervals"`
+}
+
+// WeekdayIntervalV2 defines model for WeekdayIntervalV2.
+type WeekdayIntervalV2 struct {
+	// EndTime End time of the interval, in 24hr format
+	EndTime string `json:"end_time"`
+
+	// StartTime Start time of the interval, in 24hr format
+	StartTime string `json:"start_time"`
+
+	// Weekday Weekday this interval applies to
+	Weekday string `json:"weekday"`
+}
 
 // Workflow defines model for Workflow.
 type Workflow struct {
@@ -3595,6 +3921,12 @@ type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody3
 // CustomFieldsV2UpdateJSONRequestBody defines body for CustomFieldsV2Update for application/json ContentType.
 type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody3
 
+// EscalationsV2CreatePathJSONRequestBody defines body for EscalationsV2CreatePath for application/json ContentType.
+type EscalationsV2CreatePathJSONRequestBody = CreatePathRequestBody
+
+// EscalationsV2UpdatePathJSONRequestBody defines body for EscalationsV2UpdatePath for application/json ContentType.
+type EscalationsV2UpdatePathJSONRequestBody = CreatePathRequestBody
+
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
 type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody7
 
@@ -3606,6 +3938,9 @@ type IncidentsV2CreateJSONRequestBody = CreateRequestBody10
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
 type IncidentsV2EditJSONRequestBody = EditRequestBody
+
+// ManagedResourcesV2CreateManagedResourceJSONRequestBody defines body for ManagedResourcesV2CreateManagedResource for application/json ContentType.
+type ManagedResourcesV2CreateManagedResourceJSONRequestBody = CreateManagedResourceRequestBody
 
 // SchedulesV2CreateJSONRequestBody defines body for SchedulesV2Create for application/json ContentType.
 type SchedulesV2CreateJSONRequestBody = CreateRequestBody11
@@ -3916,6 +4251,22 @@ type ClientInterface interface {
 
 	CustomFieldsV2Update(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EscalationsV2CreatePath request with any body
+	EscalationsV2CreatePathWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EscalationsV2CreatePath(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EscalationsV2DestroyPath request
+	EscalationsV2DestroyPath(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EscalationsV2ShowPath request
+	EscalationsV2ShowPath(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EscalationsV2UpdatePath request with any body
+	EscalationsV2UpdatePathWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EscalationsV2UpdatePath(ctx context.Context, id string, body EscalationsV2UpdatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FollowUpsV2List request
 	FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3965,6 +4316,11 @@ type ClientInterface interface {
 	IncidentsV2EditWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ManagedResourcesV2CreateManagedResource request with any body
+	ManagedResourcesV2CreateManagedResourceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ManagedResourcesV2CreateManagedResource(ctx context.Context, body ManagedResourcesV2CreateManagedResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SchedulesV2ListScheduleEntries request
 	SchedulesV2ListScheduleEntries(ctx context.Context, params *SchedulesV2ListScheduleEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4998,6 +5354,78 @@ func (c *Client) CustomFieldsV2Update(ctx context.Context, id string, body Custo
 	return c.Client.Do(req)
 }
 
+func (c *Client) EscalationsV2CreatePathWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2CreatePathRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2CreatePath(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2CreatePathRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2DestroyPath(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2DestroyPathRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2ShowPath(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2ShowPathRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2UpdatePathWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2UpdatePathRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2UpdatePath(ctx context.Context, id string, body EscalationsV2UpdatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2UpdatePathRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewFollowUpsV2ListRequest(c.Server, params)
 	if err != nil {
@@ -5204,6 +5632,30 @@ func (c *Client) IncidentsV2EditWithBody(ctx context.Context, id string, content
 
 func (c *Client) IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentsV2EditRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ManagedResourcesV2CreateManagedResourceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewManagedResourcesV2CreateManagedResourceRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ManagedResourcesV2CreateManagedResource(ctx context.Context, body ManagedResourcesV2CreateManagedResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewManagedResourcesV2CreateManagedResourceRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7849,6 +8301,161 @@ func NewCustomFieldsV2UpdateRequestWithBody(server string, id string, contentTyp
 	return req, nil
 }
 
+// NewEscalationsV2CreatePathRequest calls the generic EscalationsV2CreatePath builder with application/json body
+func NewEscalationsV2CreatePathRequest(server string, body EscalationsV2CreatePathJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEscalationsV2CreatePathRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewEscalationsV2CreatePathRequestWithBody generates requests for EscalationsV2CreatePath with any type of body
+func NewEscalationsV2CreatePathRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalation_paths")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewEscalationsV2DestroyPathRequest generates requests for EscalationsV2DestroyPath
+func NewEscalationsV2DestroyPathRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalation_paths/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEscalationsV2ShowPathRequest generates requests for EscalationsV2ShowPath
+func NewEscalationsV2ShowPathRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalation_paths/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEscalationsV2UpdatePathRequest calls the generic EscalationsV2UpdatePath builder with application/json body
+func NewEscalationsV2UpdatePathRequest(server string, id string, body EscalationsV2UpdatePathJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEscalationsV2UpdatePathRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewEscalationsV2UpdatePathRequestWithBody generates requests for EscalationsV2UpdatePath with any type of body
+func NewEscalationsV2UpdatePathRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalation_paths/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewFollowUpsV2ListRequest generates requests for FollowUpsV2List
 func NewFollowUpsV2ListRequest(server string, params *FollowUpsV2ListParams) (*http.Request, error) {
 	var err error
@@ -8561,6 +9168,46 @@ func NewIncidentsV2EditRequestWithBody(server string, id string, contentType str
 	}
 
 	operationPath := fmt.Sprintf("/v2/incidents/%s/actions/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewManagedResourcesV2CreateManagedResourceRequest calls the generic ManagedResourcesV2CreateManagedResource builder with application/json body
+func NewManagedResourcesV2CreateManagedResourceRequest(server string, body ManagedResourcesV2CreateManagedResourceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewManagedResourcesV2CreateManagedResourceRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewManagedResourcesV2CreateManagedResourceRequestWithBody generates requests for ManagedResourcesV2CreateManagedResource with any type of body
+func NewManagedResourcesV2CreateManagedResourceRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/managed_resources")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -9451,6 +10098,22 @@ type ClientWithResponsesInterface interface {
 
 	CustomFieldsV2UpdateWithResponse(ctx context.Context, id string, body CustomFieldsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*CustomFieldsV2UpdateResponse, error)
 
+	// EscalationsV2CreatePath request with any body
+	EscalationsV2CreatePathWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2CreatePathResponse, error)
+
+	EscalationsV2CreatePathWithResponse(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2CreatePathResponse, error)
+
+	// EscalationsV2DestroyPath request
+	EscalationsV2DestroyPathWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2DestroyPathResponse, error)
+
+	// EscalationsV2ShowPath request
+	EscalationsV2ShowPathWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2ShowPathResponse, error)
+
+	// EscalationsV2UpdatePath request with any body
+	EscalationsV2UpdatePathWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2UpdatePathResponse, error)
+
+	EscalationsV2UpdatePathWithResponse(ctx context.Context, id string, body EscalationsV2UpdatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2UpdatePathResponse, error)
+
 	// FollowUpsV2List request
 	FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error)
 
@@ -9500,6 +10163,11 @@ type ClientWithResponsesInterface interface {
 	IncidentsV2EditWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
 
 	IncidentsV2EditWithResponse(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
+
+	// ManagedResourcesV2CreateManagedResource request with any body
+	ManagedResourcesV2CreateManagedResourceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ManagedResourcesV2CreateManagedResourceResponse, error)
+
+	ManagedResourcesV2CreateManagedResourceWithResponse(ctx context.Context, body ManagedResourcesV2CreateManagedResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*ManagedResourcesV2CreateManagedResourceResponse, error)
 
 	// SchedulesV2ListScheduleEntries request
 	SchedulesV2ListScheduleEntriesWithResponse(ctx context.Context, params *SchedulesV2ListScheduleEntriesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListScheduleEntriesResponse, error)
@@ -10859,6 +11527,93 @@ func (r CustomFieldsV2UpdateResponse) StatusCode() int {
 	return 0
 }
 
+type EscalationsV2CreatePathResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CreatePathResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2CreatePathResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2CreatePathResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EscalationsV2DestroyPathResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2DestroyPathResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2DestroyPathResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EscalationsV2ShowPathResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreatePathResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2ShowPathResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2ShowPathResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EscalationsV2UpdatePathResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreatePathResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2UpdatePathResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2UpdatePathResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type FollowUpsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -11160,6 +11915,28 @@ func (r IncidentsV2EditResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r IncidentsV2EditResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ManagedResourcesV2CreateManagedResourceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreateManagedResourceResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r ManagedResourcesV2CreateManagedResourceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ManagedResourcesV2CreateManagedResourceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12166,6 +12943,58 @@ func (c *ClientWithResponses) CustomFieldsV2UpdateWithResponse(ctx context.Conte
 	return ParseCustomFieldsV2UpdateResponse(rsp)
 }
 
+// EscalationsV2CreatePathWithBodyWithResponse request with arbitrary body returning *EscalationsV2CreatePathResponse
+func (c *ClientWithResponses) EscalationsV2CreatePathWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2CreatePathResponse, error) {
+	rsp, err := c.EscalationsV2CreatePathWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2CreatePathResponse(rsp)
+}
+
+func (c *ClientWithResponses) EscalationsV2CreatePathWithResponse(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2CreatePathResponse, error) {
+	rsp, err := c.EscalationsV2CreatePath(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2CreatePathResponse(rsp)
+}
+
+// EscalationsV2DestroyPathWithResponse request returning *EscalationsV2DestroyPathResponse
+func (c *ClientWithResponses) EscalationsV2DestroyPathWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2DestroyPathResponse, error) {
+	rsp, err := c.EscalationsV2DestroyPath(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2DestroyPathResponse(rsp)
+}
+
+// EscalationsV2ShowPathWithResponse request returning *EscalationsV2ShowPathResponse
+func (c *ClientWithResponses) EscalationsV2ShowPathWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2ShowPathResponse, error) {
+	rsp, err := c.EscalationsV2ShowPath(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2ShowPathResponse(rsp)
+}
+
+// EscalationsV2UpdatePathWithBodyWithResponse request with arbitrary body returning *EscalationsV2UpdatePathResponse
+func (c *ClientWithResponses) EscalationsV2UpdatePathWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2UpdatePathResponse, error) {
+	rsp, err := c.EscalationsV2UpdatePathWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2UpdatePathResponse(rsp)
+}
+
+func (c *ClientWithResponses) EscalationsV2UpdatePathWithResponse(ctx context.Context, id string, body EscalationsV2UpdatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2UpdatePathResponse, error) {
+	rsp, err := c.EscalationsV2UpdatePath(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2UpdatePathResponse(rsp)
+}
+
 // FollowUpsV2ListWithResponse request returning *FollowUpsV2ListResponse
 func (c *ClientWithResponses) FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error) {
 	rsp, err := c.FollowUpsV2List(ctx, params, reqEditors...)
@@ -12322,6 +13151,23 @@ func (c *ClientWithResponses) IncidentsV2EditWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseIncidentsV2EditResponse(rsp)
+}
+
+// ManagedResourcesV2CreateManagedResourceWithBodyWithResponse request with arbitrary body returning *ManagedResourcesV2CreateManagedResourceResponse
+func (c *ClientWithResponses) ManagedResourcesV2CreateManagedResourceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ManagedResourcesV2CreateManagedResourceResponse, error) {
+	rsp, err := c.ManagedResourcesV2CreateManagedResourceWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseManagedResourcesV2CreateManagedResourceResponse(rsp)
+}
+
+func (c *ClientWithResponses) ManagedResourcesV2CreateManagedResourceWithResponse(ctx context.Context, body ManagedResourcesV2CreateManagedResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*ManagedResourcesV2CreateManagedResourceResponse, error) {
+	rsp, err := c.ManagedResourcesV2CreateManagedResource(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseManagedResourcesV2CreateManagedResourceResponse(rsp)
 }
 
 // SchedulesV2ListScheduleEntriesWithResponse request returning *SchedulesV2ListScheduleEntriesResponse
@@ -13933,6 +14779,100 @@ func ParseCustomFieldsV2UpdateResponse(rsp *http.Response) (*CustomFieldsV2Updat
 	return response, nil
 }
 
+// ParseEscalationsV2CreatePathResponse parses an HTTP response from a EscalationsV2CreatePathWithResponse call
+func ParseEscalationsV2CreatePathResponse(rsp *http.Response) (*EscalationsV2CreatePathResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2CreatePathResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CreatePathResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEscalationsV2DestroyPathResponse parses an HTTP response from a EscalationsV2DestroyPathWithResponse call
+func ParseEscalationsV2DestroyPathResponse(rsp *http.Response) (*EscalationsV2DestroyPathResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2DestroyPathResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseEscalationsV2ShowPathResponse parses an HTTP response from a EscalationsV2ShowPathWithResponse call
+func ParseEscalationsV2ShowPathResponse(rsp *http.Response) (*EscalationsV2ShowPathResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2ShowPathResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreatePathResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEscalationsV2UpdatePathResponse parses an HTTP response from a EscalationsV2UpdatePathWithResponse call
+func ParseEscalationsV2UpdatePathResponse(rsp *http.Response) (*EscalationsV2UpdatePathResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2UpdatePathResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreatePathResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseFollowUpsV2ListResponse parses an HTTP response from a FollowUpsV2ListWithResponse call
 func ParseFollowUpsV2ListResponse(rsp *http.Response) (*FollowUpsV2ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -14277,6 +15217,32 @@ func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ShowResponseBody13
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseManagedResourcesV2CreateManagedResourceResponse parses an HTTP response from a ManagedResourcesV2CreateManagedResourceWithResponse call
+func ParseManagedResourcesV2CreateManagedResourceResponse(rsp *http.Response) (*ManagedResourcesV2CreateManagedResourceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ManagedResourcesV2CreateManagedResourceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateManagedResourceResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/client/openapi3.json
+++ b/client/openapi3.json
@@ -53,7 +53,11 @@
             "name": "incident_mode",
             "schema": {
               "description": "Filter to actions from incidents of the given mode. If not set, only actions from `real` incidents are returned",
-              "enum": ["real", "test", "tutorial"],
+              "enum": [
+                "real",
+                "test",
+                "tutorial"
+              ],
               "example": "real",
               "type": "string"
             }
@@ -98,7 +102,9 @@
           }
         },
         "summary": "List Actions V1",
-        "tags": ["Actions V1"],
+        "tags": [
+          "Actions V1"
+        ],
         "deprecated": true
       }
     },
@@ -157,13 +163,17 @@
           }
         },
         "summary": "Show Actions V1",
-        "tags": ["Actions V1"],
+        "tags": [
+          "Actions V1"
+        ],
         "deprecated": true
       }
     },
     "/v1/custom_field_options": {
       "get": {
-        "tags": ["Custom Field Options V1"],
+        "tags": [
+          "Custom Field Options V1"
+        ],
         "summary": "List Custom Field Options V1",
         "description": "Show custom field options for a custom field",
         "operationId": "Custom Field Options V1#List",
@@ -236,7 +246,9 @@
         }
       },
       "post": {
-        "tags": ["Custom Field Options V1"],
+        "tags": [
+          "Custom Field Options V1"
+        ],
         "summary": "Create Custom Field Options V1",
         "description": "Create a custom field option. If the sort key is not supplied, it'll default to 1000, so the option appears near the end of the list.",
         "operationId": "Custom Field Options V1#Create",
@@ -279,7 +291,9 @@
     },
     "/v1/custom_field_options/{id}": {
       "delete": {
-        "tags": ["Custom Field Options V1"],
+        "tags": [
+          "Custom Field Options V1"
+        ],
         "summary": "Delete Custom Field Options V1",
         "description": "Delete a custom field option",
         "operationId": "Custom Field Options V1#Delete",
@@ -304,7 +318,9 @@
         }
       },
       "get": {
-        "tags": ["Custom Field Options V1"],
+        "tags": [
+          "Custom Field Options V1"
+        ],
         "summary": "Show Custom Field Options V1",
         "description": "Get a single custom field option",
         "operationId": "Custom Field Options V1#Show",
@@ -344,7 +360,9 @@
         }
       },
       "put": {
-        "tags": ["Custom Field Options V1"],
+        "tags": [
+          "Custom Field Options V1"
+        ],
         "summary": "Update Custom Field Options V1",
         "description": "Update a custom field option",
         "operationId": "Custom Field Options V1#Update",
@@ -442,7 +460,9 @@
           }
         },
         "summary": "List Custom Fields V1",
-        "tags": ["Custom Fields V1"],
+        "tags": [
+          "Custom Fields V1"
+        ],
         "deprecated": true
       },
       "post": {
@@ -507,7 +527,9 @@
           }
         },
         "summary": "Create Custom Fields V1",
-        "tags": ["Custom Fields V1"],
+        "tags": [
+          "Custom Fields V1"
+        ],
         "deprecated": true
       }
     },
@@ -535,7 +557,9 @@
           }
         },
         "summary": "Delete Custom Fields V1",
-        "tags": ["Custom Fields V1"],
+        "tags": [
+          "Custom Fields V1"
+        ],
         "deprecated": true
       },
       "get": {
@@ -593,7 +617,9 @@
           }
         },
         "summary": "Show Custom Fields V1",
-        "tags": ["Custom Fields V1"],
+        "tags": [
+          "Custom Fields V1"
+        ],
         "deprecated": true
       },
       "put": {
@@ -671,13 +697,17 @@
           }
         },
         "summary": "Update Custom Fields V1",
-        "tags": ["Custom Fields V1"],
+        "tags": [
+          "Custom Fields V1"
+        ],
         "deprecated": true
       }
     },
     "/v1/identity": {
       "get": {
-        "tags": ["Utilities V1"],
+        "tags": [
+          "Utilities V1"
+        ],
         "summary": "Identity Utilities V1",
         "description": "Test if your API key is valid, and which roles it has.",
         "operationId": "Utilities V1#Identity",
@@ -693,7 +723,9 @@
                   "identity": {
                     "dashboard_url": "https://app.incident.io/my-org",
                     "name": "Alertmanager token",
-                    "roles": ["incident_creator"]
+                    "roles": [
+                      "incident_creator"
+                    ]
                   }
                 }
               }
@@ -704,7 +736,9 @@
     },
     "/v1/incident_attachments": {
       "get": {
-        "tags": ["Incident Attachments V1"],
+        "tags": [
+          "Incident Attachments V1"
+        ],
         "summary": "List Incident Attachments V1",
         "description": "List all incident attachements for a given external resource or incident. You must provide either a specific incident ID or a specific external resource type and external ID.",
         "operationId": "Incident Attachments V1#List",
@@ -793,7 +827,9 @@
         }
       },
       "post": {
-        "tags": ["Incident Attachments V1"],
+        "tags": [
+          "Incident Attachments V1"
+        ],
         "summary": "Create Incident Attachments V1",
         "description": "Attaches an external resource to an incident",
         "operationId": "Incident Attachments V1#Create",
@@ -842,7 +878,9 @@
     },
     "/v1/incident_attachments/{id}": {
       "delete": {
-        "tags": ["Incident Attachments V1"],
+        "tags": [
+          "Incident Attachments V1"
+        ],
         "summary": "Delete Incident Attachments V1",
         "description": "Unattaches an external resouce from an incident",
         "operationId": "Incident Attachments V1#Delete",
@@ -869,7 +907,9 @@
     },
     "/v1/incident_memberships": {
       "post": {
-        "tags": ["Incident Memberships V1"],
+        "tags": [
+          "Incident Memberships V1"
+        ],
         "summary": "Create Incident Memberships V1",
         "description": "Makes a user a member of a private incident",
         "operationId": "Incident Memberships V1#Create",
@@ -918,7 +958,9 @@
     },
     "/v1/incident_memberships/actions/revoke": {
       "post": {
-        "tags": ["Incident Memberships V1"],
+        "tags": [
+          "Incident Memberships V1"
+        ],
         "summary": "Revoke Incident Memberships V1",
         "description": "Revoke a user's membership of a private incident",
         "operationId": "Incident Memberships V1#Revoke",
@@ -975,7 +1017,9 @@
           }
         },
         "summary": "List Incident Roles V1",
-        "tags": ["Incident Roles V1"],
+        "tags": [
+          "Incident Roles V1"
+        ],
         "deprecated": true
       },
       "post": {
@@ -1024,7 +1068,9 @@
           }
         },
         "summary": "Create Incident Roles V1",
-        "tags": ["Incident Roles V1"],
+        "tags": [
+          "Incident Roles V1"
+        ],
         "deprecated": true
       }
     },
@@ -1052,7 +1098,9 @@
           }
         },
         "summary": "Delete Incident Roles V1",
-        "tags": ["Incident Roles V1"],
+        "tags": [
+          "Incident Roles V1"
+        ],
         "deprecated": true
       },
       "get": {
@@ -1098,7 +1146,9 @@
           }
         },
         "summary": "Show Incident Roles V1",
-        "tags": ["Incident Roles V1"],
+        "tags": [
+          "Incident Roles V1"
+        ],
         "deprecated": true
       },
       "put": {
@@ -1161,13 +1211,17 @@
           }
         },
         "summary": "Update Incident Roles V1",
-        "tags": ["Incident Roles V1"],
+        "tags": [
+          "Incident Roles V1"
+        ],
         "deprecated": true
       }
     },
     "/v1/incident_statuses": {
       "get": {
-        "tags": ["Incident Statuses V1"],
+        "tags": [
+          "Incident Statuses V1"
+        ],
         "summary": "List Incident Statuses V1",
         "description": "List all incident statuses for an organisation.",
         "operationId": "Incident Statuses V1#List",
@@ -1198,7 +1252,9 @@
         }
       },
       "post": {
-        "tags": ["Incident Statuses V1"],
+        "tags": [
+          "Incident Statuses V1"
+        ],
         "summary": "Create Incident Statuses V1",
         "description": "Create a new incident status",
         "operationId": "Incident Statuses V1#Create",
@@ -1244,7 +1300,9 @@
     },
     "/v1/incident_statuses/{id}": {
       "delete": {
-        "tags": ["Incident Statuses V1"],
+        "tags": [
+          "Incident Statuses V1"
+        ],
         "summary": "Delete Incident Statuses V1",
         "description": "Delete an incident status",
         "operationId": "Incident Statuses V1#Delete",
@@ -1269,7 +1327,9 @@
         }
       },
       "get": {
-        "tags": ["Incident Statuses V1"],
+        "tags": [
+          "Incident Statuses V1"
+        ],
         "summary": "Show Incident Statuses V1",
         "description": "Get a single incident status.",
         "operationId": "Incident Statuses V1#Show",
@@ -1312,7 +1372,9 @@
         }
       },
       "put": {
-        "tags": ["Incident Statuses V1"],
+        "tags": [
+          "Incident Statuses V1"
+        ],
         "summary": "Update Incident Statuses V1",
         "description": "Update an existing incident status",
         "operationId": "Incident Statuses V1#Update",
@@ -1371,7 +1433,9 @@
     },
     "/v1/incident_types": {
       "get": {
-        "tags": ["Incident Types V1"],
+        "tags": [
+          "Incident Types V1"
+        ],
         "summary": "List Incident Types V1",
         "description": "List all incident types for an organisation.",
         "operationId": "Incident Types V1#List",
@@ -1405,7 +1469,9 @@
     },
     "/v1/incident_types/{id}": {
       "get": {
-        "tags": ["Incident Types V1"],
+        "tags": [
+          "Incident Types V1"
+        ],
         "summary": "Show Incident Types V1",
         "description": "Get a single incident type.",
         "operationId": "Incident Types V1#Show",
@@ -1487,14 +1553,18 @@
             "examples": {
               "default": {
                 "summary": "default",
-                "value": ["declined"]
+                "value": [
+                  "declined"
+                ]
               }
             },
             "in": "query",
             "name": "status",
             "schema": {
               "description": "Filter for incidents in these statuses",
-              "example": ["declined"],
+              "example": [
+                "declined"
+              ],
               "items": {
                 "example": "declined",
                 "type": "string"
@@ -1544,7 +1614,10 @@
                           "values": [
                             {
                               "value_catalog_entry": {
-                                "aliases": ["lawrence@incident.io", "lawrence"],
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
                                 "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "name": "Primary On-call"
@@ -1638,7 +1711,9 @@
           }
         },
         "summary": "List Incidents V1",
-        "tags": ["Incidents V1"],
+        "tags": [
+          "Incidents V1"
+        ],
         "deprecated": true
       },
       "post": {
@@ -1733,7 +1808,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -1821,7 +1899,9 @@
           }
         },
         "summary": "Create Incidents V1",
-        "tags": ["Incidents V1"],
+        "tags": [
+          "Incidents V1"
+        ],
         "deprecated": true
       }
     },
@@ -1883,7 +1963,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -1971,13 +2054,17 @@
           }
         },
         "summary": "Show Incidents V1",
-        "tags": ["Incidents V1"],
+        "tags": [
+          "Incidents V1"
+        ],
         "deprecated": true
       }
     },
     "/v1/openapi.json": {
       "get": {
-        "tags": ["Utilities V1"],
+        "tags": [
+          "Utilities V1"
+        ],
         "summary": "OpenAPI Utilities V1",
         "description": "Get the OpenAPI (v2) definition.",
         "operationId": "Utilities V1#OpenAPI",
@@ -2000,7 +2087,9 @@
     },
     "/v1/openapiV3.json": {
       "get": {
-        "tags": ["Utilities V1"],
+        "tags": [
+          "Utilities V1"
+        ],
         "summary": "OpenAPIV3 Utilities V1",
         "description": "Get the OpenAPI (v3) definition.",
         "operationId": "Utilities V1#OpenAPIV3",
@@ -2023,7 +2112,9 @@
     },
     "/v1/severities": {
       "get": {
-        "tags": ["Severities V1"],
+        "tags": [
+          "Severities V1"
+        ],
         "summary": "List Severities V1",
         "description": "List all incident severities for an organisation.",
         "operationId": "Severities V1#List",
@@ -2053,7 +2144,9 @@
         }
       },
       "post": {
-        "tags": ["Severities V1"],
+        "tags": [
+          "Severities V1"
+        ],
         "summary": "Create Severities V1",
         "description": "Create a new severity",
         "operationId": "Severities V1#Create",
@@ -2098,7 +2191,9 @@
     },
     "/v1/severities/{id}": {
       "delete": {
-        "tags": ["Severities V1"],
+        "tags": [
+          "Severities V1"
+        ],
         "summary": "Delete Severities V1",
         "description": "Delete a severity",
         "operationId": "Severities V1#Delete",
@@ -2123,7 +2218,9 @@
         }
       },
       "get": {
-        "tags": ["Severities V1"],
+        "tags": [
+          "Severities V1"
+        ],
         "summary": "Show Severities V1",
         "description": "Get a single incident severity.",
         "operationId": "Severities V1#Show",
@@ -2165,7 +2262,9 @@
         }
       },
       "put": {
-        "tags": ["Severities V1"],
+        "tags": [
+          "Severities V1"
+        ],
         "summary": "Update Severities V1",
         "description": "Update an existing severity",
         "operationId": "Severities V1#Update",
@@ -2224,7 +2323,9 @@
     },
     "/v2/actions": {
       "get": {
-        "tags": ["Actions V2"],
+        "tags": [
+          "Actions V2"
+        ],
         "summary": "List Actions V2",
         "description": "List all actions for an organisation.",
         "operationId": "Actions V2#List",
@@ -2302,7 +2403,9 @@
     },
     "/v2/actions/{id}": {
       "get": {
-        "tags": ["Actions V2"],
+        "tags": [
+          "Actions V2"
+        ],
         "summary": "Show Actions V2",
         "description": "Get a single incident action.",
         "operationId": "Actions V2#Show",
@@ -2354,7 +2457,9 @@
     },
     "/v2/alert_events/http/{alert_source_config_id}": {
       "post": {
-        "tags": ["Alert Events V2"],
+        "tags": [
+          "Alert Events V2"
+        ],
         "summary": "CreateHTTP Alert Events V2",
         "description": "Create an alert event using an HTTP source.",
         "operationId": "Alert Events V2#CreateHTTP",
@@ -2396,7 +2501,9 @@
                 "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
                 "metadata": {
                   "service": "hello.world.com",
-                  "team": ["my-team"]
+                  "team": [
+                    "my-team"
+                  ]
                 },
                 "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
                 "status": "firing",
@@ -2426,7 +2533,9 @@
     },
     "/v2/catalog_entries": {
       "get": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "ListEntries Catalog V2",
         "description": "List entries for a catalog type.",
         "operationId": "Catalog V2#ListEntries",
@@ -2483,7 +2592,10 @@
                 "example": {
                   "catalog_entries": [
                     {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "archived_at": "2021-08-17T14:28:57.801578Z",
                       "attribute_values": {
                         "abc123": {
@@ -2538,6 +2650,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -2550,7 +2665,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -2586,7 +2703,9 @@
         }
       },
       "post": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "CreateEntry Catalog V2",
         "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.",
         "operationId": "Catalog V2#CreateEntry",
@@ -2598,7 +2717,10 @@
                 "$ref": "#/components/schemas/CreateEntryRequestBody"
               },
               "example": {
-                "aliases": ["lawrence@incident.io", "lawrence"],
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
@@ -2631,7 +2753,10 @@
                 },
                 "example": {
                   "catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
@@ -2690,7 +2815,9 @@
     },
     "/v2/catalog_entries/{id}": {
       "delete": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "DestroyEntry Catalog V2",
         "description": "Archives a catalog entry.",
         "operationId": "Catalog V2#DestroyEntry",
@@ -2715,7 +2842,9 @@
         }
       },
       "get": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "ShowEntry Catalog V2",
         "description": "Show a single catalog entry.",
         "operationId": "Catalog V2#ShowEntry",
@@ -2743,7 +2872,10 @@
                 },
                 "example": {
                   "catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
@@ -2797,6 +2929,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -2809,7 +2944,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -2841,7 +2978,9 @@
         }
       },
       "put": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "UpdateEntry Catalog V2",
         "description": "Updates an existing catalog entry.",
         "operationId": "Catalog V2#UpdateEntry",
@@ -2867,7 +3006,10 @@
                 "$ref": "#/components/schemas/UpdateEntryRequestBody"
               },
               "example": {
-                "aliases": ["lawrence@incident.io", "lawrence"],
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
@@ -2899,7 +3041,10 @@
                 },
                 "example": {
                   "catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "archived_at": "2021-08-17T14:28:57.801578Z",
                     "attribute_values": {
                       "abc123": {
@@ -2953,6 +3098,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -2965,7 +3113,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -2999,7 +3149,9 @@
     },
     "/v2/catalog_resources": {
       "get": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "ListResources Catalog V2",
         "description": "List available engine resources for the catalog.\n\nA resource represents a type of data that can be held within the catalog, so this\nendpoint can be used to see what attribute types can be used when updating the\nschema of a catalog type.\n",
         "operationId": "Catalog V2#ListResources",
@@ -3030,7 +3182,9 @@
     },
     "/v2/catalog_types": {
       "get": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "ListTypes Catalog V2",
         "description": "List all catalog types for an organisation, including those synced from external resources.",
         "operationId": "Catalog V2#ListTypes",
@@ -3048,6 +3202,9 @@
                       "annotations": {
                         "incident.io/catalog-importer/id": "id-of-config"
                       },
+                      "categories": [
+                        "issue-tracker"
+                      ],
                       "color": "yellow",
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -3060,7 +3217,9 @@
                       "name": "Kubernetes Cluster",
                       "ranked": true,
                       "registry_type": "PagerDutyService",
-                      "required_integrations": ["pager_duty"],
+                      "required_integrations": [
+                        "pager_duty"
+                      ],
                       "schema": {
                         "attributes": [
                           {
@@ -3093,7 +3252,9 @@
         }
       },
       "post": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "CreateType Catalog V2",
         "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
         "operationId": "Catalog V2#CreateType",
@@ -3108,6 +3269,9 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
+                "categories": [
+                  "issue-tracker"
+                ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "bolt",
@@ -3132,6 +3296,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -3144,7 +3311,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -3178,7 +3347,9 @@
     },
     "/v2/catalog_types/{id}": {
       "delete": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "DestroyType Catalog V2",
         "description": "Archives a catalog type and associated entries.",
         "operationId": "Catalog V2#DestroyType",
@@ -3203,7 +3374,9 @@
         }
       },
       "get": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "ShowType Catalog V2",
         "description": "Show a single catalog type.",
         "operationId": "Catalog V2#ShowType",
@@ -3234,6 +3407,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -3246,7 +3422,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -3278,7 +3456,9 @@
         }
       },
       "put": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "UpdateType Catalog V2",
         "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
         "operationId": "Catalog V2#UpdateType",
@@ -3307,6 +3487,9 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
+                "categories": [
+                  "issue-tracker"
+                ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "bolt",
@@ -3330,6 +3513,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -3342,7 +3528,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -3376,7 +3564,9 @@
     },
     "/v2/catalog_types/{id}/actions/update_schema": {
       "post": {
-        "tags": ["Catalog V2"],
+        "tags": [
+          "Catalog V2"
+        ],
         "summary": "UpdateTypeSchema Catalog V2",
         "description": "Update an existing catalog types schema, adding or removing attributes.\n\nUpdating the schema is handled separately from creating and updating types, so that you don't\nhave to worry about dependencies between types. For example, if type A has an attribute that\nrelies on type B, you would have to create type B first.\n\nBy allowing the creation of types without a schema, they can be created in any order, but it\nmeans that you need to make a separate call to this endpoint to update the schema.",
         "operationId": "Catalog V2#UpdateTypeSchema",
@@ -3435,6 +3625,9 @@
                     "annotations": {
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
+                    "categories": [
+                      "issue-tracker"
+                    ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -3447,7 +3640,9 @@
                     "name": "Kubernetes Cluster",
                     "ranked": true,
                     "registry_type": "PagerDutyService",
-                    "required_integrations": ["pager_duty"],
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
@@ -3481,7 +3676,9 @@
     },
     "/v2/custom_fields": {
       "get": {
-        "tags": ["Custom Fields V2"],
+        "tags": [
+          "Custom Fields V2"
+        ],
         "summary": "List Custom Fields V2",
         "description": "List all custom fields for an organisation.",
         "operationId": "Custom Fields V2#List",
@@ -3512,7 +3709,9 @@
         }
       },
       "post": {
-        "tags": ["Custom Fields V2"],
+        "tags": [
+          "Custom Fields V2"
+        ],
         "summary": "Create Custom Fields V2",
         "description": "Create a new custom field",
         "operationId": "Custom Fields V2#Create",
@@ -3558,7 +3757,9 @@
     },
     "/v2/custom_fields/{id}": {
       "delete": {
-        "tags": ["Custom Fields V2"],
+        "tags": [
+          "Custom Fields V2"
+        ],
         "summary": "Delete Custom Fields V2",
         "description": "Delete a custom field",
         "operationId": "Custom Fields V2#Delete",
@@ -3583,7 +3784,9 @@
         }
       },
       "get": {
-        "tags": ["Custom Fields V2"],
+        "tags": [
+          "Custom Fields V2"
+        ],
         "summary": "Show Custom Fields V2",
         "description": "Get a single custom field.",
         "operationId": "Custom Fields V2#Show",
@@ -3626,7 +3829,9 @@
         }
       },
       "put": {
-        "tags": ["Custom Fields V2"],
+        "tags": [
+          "Custom Fields V2"
+        ],
         "summary": "Update Custom Fields V2",
         "description": "Update the details of a custom field",
         "operationId": "Custom Fields V2#Update",
@@ -3683,9 +3888,518 @@
         }
       }
     },
+    "/v2/escalation_paths": {
+      "post": {
+        "tags": [
+          "Escalations V2"
+        ],
+        "summary": "CreatePath Escalations V2",
+        "description": "Create an escalation path.\n\nAn escalation path is a series of steps that describe how a page should be escalated,\nrepresented as graph, supporting conditional branches based on alert priority and working\nintervals.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
+        "operationId": "Escalations V2#CreatePath",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePathRequestBody"
+              },
+              "example": {
+                "name": "Urgent Support",
+                "path": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "if_else": {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ],
+                      "else_path": [
+                        {}
+                      ],
+                      "then_path": [
+                        {}
+                      ]
+                    },
+                    "level": {
+                      "targets": [
+                        {
+                          "id": "lawrencejones",
+                          "type": "user",
+                          "urgency": "high"
+                        }
+                      ],
+                      "time_to_ack_interval_condition": "active",
+                      "time_to_ack_seconds": 1800,
+                      "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "repeat": {
+                      "repeat_times": 3,
+                      "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "type": "if_else"
+                  }
+                ],
+                "working_hours": [
+                  {
+                    "id": "abc123",
+                    "name": "abc123",
+                    "timezone": "abc123",
+                    "weekday_intervals": [
+                      {
+                        "end_time": "17:00",
+                        "start_time": "09:00",
+                        "weekday": "abc123"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePathResponseBody"
+                },
+                "example": {
+                  "escalation_path": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Urgent Support",
+                    "path": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "if_else": {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "else_path": [
+                            {}
+                          ],
+                          "then_path": [
+                            {}
+                          ]
+                        },
+                        "level": {
+                          "targets": [
+                            {
+                              "id": "lawrencejones",
+                              "type": "user",
+                              "urgency": "high"
+                            }
+                          ],
+                          "time_to_ack_interval_condition": "active",
+                          "time_to_ack_seconds": 1800,
+                          "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "repeat": {
+                          "repeat_times": 3,
+                          "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "type": "if_else"
+                      }
+                    ],
+                    "working_hours": [
+                      {
+                        "id": "abc123",
+                        "name": "abc123",
+                        "timezone": "abc123",
+                        "weekday_intervals": [
+                          {
+                            "end_time": "17:00",
+                            "start_time": "09:00",
+                            "weekday": "abc123"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/escalation_paths/{id}": {
+      "delete": {
+        "tags": [
+          "Escalations V2"
+        ],
+        "summary": "DestroyPath Escalations V2",
+        "description": "Archives an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
+        "operationId": "Escalations V2#DestroyPath",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this escalation path.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this escalation path.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Escalations V2"
+        ],
+        "summary": "ShowPath Escalations V2",
+        "description": "Show an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
+        "operationId": "Escalations V2#ShowPath",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this escalation path.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this escalation path.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePathResponseBody"
+                },
+                "example": {
+                  "escalation_path": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Urgent Support",
+                    "path": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "if_else": {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "else_path": [
+                            {}
+                          ],
+                          "then_path": [
+                            {}
+                          ]
+                        },
+                        "level": {
+                          "targets": [
+                            {
+                              "id": "lawrencejones",
+                              "type": "user",
+                              "urgency": "high"
+                            }
+                          ],
+                          "time_to_ack_interval_condition": "active",
+                          "time_to_ack_seconds": 1800,
+                          "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "repeat": {
+                          "repeat_times": 3,
+                          "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "type": "if_else"
+                      }
+                    ],
+                    "working_hours": [
+                      {
+                        "id": "abc123",
+                        "name": "abc123",
+                        "timezone": "abc123",
+                        "weekday_intervals": [
+                          {
+                            "end_time": "17:00",
+                            "start_time": "09:00",
+                            "weekday": "abc123"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Escalations V2"
+        ],
+        "summary": "UpdatePath Escalations V2",
+        "description": "Updates an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
+        "operationId": "Escalations V2#UpdatePath",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this escalation path.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this escalation path.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePathRequestBody"
+              },
+              "example": {
+                "name": "Urgent Support",
+                "path": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "if_else": {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ],
+                      "else_path": [
+                        {}
+                      ],
+                      "then_path": [
+                        {}
+                      ]
+                    },
+                    "level": {
+                      "targets": [
+                        {
+                          "id": "lawrencejones",
+                          "type": "user",
+                          "urgency": "high"
+                        }
+                      ],
+                      "time_to_ack_interval_condition": "active",
+                      "time_to_ack_seconds": 1800,
+                      "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "repeat": {
+                      "repeat_times": 3,
+                      "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "type": "if_else"
+                  }
+                ],
+                "working_hours": [
+                  {
+                    "id": "abc123",
+                    "name": "abc123",
+                    "timezone": "abc123",
+                    "weekday_intervals": [
+                      {
+                        "end_time": "17:00",
+                        "start_time": "09:00",
+                        "weekday": "abc123"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePathResponseBody"
+                },
+                "example": {
+                  "escalation_path": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Urgent Support",
+                    "path": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "if_else": {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "else_path": [
+                            {}
+                          ],
+                          "then_path": [
+                            {}
+                          ]
+                        },
+                        "level": {
+                          "targets": [
+                            {
+                              "id": "lawrencejones",
+                              "type": "user",
+                              "urgency": "high"
+                            }
+                          ],
+                          "time_to_ack_interval_condition": "active",
+                          "time_to_ack_seconds": 1800,
+                          "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "repeat": {
+                          "repeat_times": 3,
+                          "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "type": "if_else"
+                      }
+                    ],
+                    "working_hours": [
+                      {
+                        "id": "abc123",
+                        "name": "abc123",
+                        "timezone": "abc123",
+                        "weekday_intervals": [
+                          {
+                            "end_time": "17:00",
+                            "start_time": "09:00",
+                            "weekday": "abc123"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/follow_ups": {
       "get": {
-        "tags": ["Follow-ups V2"],
+        "tags": [
+          "Follow-ups V2"
+        ],
         "summary": "List Follow-ups V2",
         "description": "List all follow-ups for an organisation.",
         "operationId": "Follow-ups V2#List",
@@ -3770,7 +4484,9 @@
     },
     "/v2/follow_ups/{id}": {
       "get": {
-        "tags": ["Follow-ups V2"],
+        "tags": [
+          "Follow-ups V2"
+        ],
         "summary": "Show Follow-ups V2",
         "description": "Get a single incident follow-up.",
         "operationId": "Follow-ups V2#Show",
@@ -3834,7 +4550,9 @@
     },
     "/v2/incident_roles": {
       "get": {
-        "tags": ["Incident Roles V2"],
+        "tags": [
+          "Incident Roles V2"
+        ],
         "summary": "List Incident Roles V2",
         "description": "List all incident roles for an organisation.",
         "operationId": "Incident Roles V2#List",
@@ -3866,7 +4584,9 @@
         }
       },
       "post": {
-        "tags": ["Incident Roles V2"],
+        "tags": [
+          "Incident Roles V2"
+        ],
         "summary": "Create Incident Roles V2",
         "description": "Create a new incident role",
         "operationId": "Incident Roles V2#Create",
@@ -3914,7 +4634,9 @@
     },
     "/v2/incident_roles/{id}": {
       "delete": {
-        "tags": ["Incident Roles V2"],
+        "tags": [
+          "Incident Roles V2"
+        ],
         "summary": "Delete Incident Roles V2",
         "description": "Removes an existing role",
         "operationId": "Incident Roles V2#Delete",
@@ -3939,7 +4661,9 @@
         }
       },
       "get": {
-        "tags": ["Incident Roles V2"],
+        "tags": [
+          "Incident Roles V2"
+        ],
         "summary": "Show Incident Roles V2",
         "description": "Get a single incident role.",
         "operationId": "Incident Roles V2#Show",
@@ -3983,7 +4707,9 @@
         }
       },
       "put": {
-        "tags": ["Incident Roles V2"],
+        "tags": [
+          "Incident Roles V2"
+        ],
         "summary": "Update Incident Roles V2",
         "description": "Update an existing incident role",
         "operationId": "Incident Roles V2#Update",
@@ -4045,7 +4771,9 @@
     },
     "/v2/incident_timestamps": {
       "get": {
-        "tags": ["Incident Timestamps V2"],
+        "tags": [
+          "Incident Timestamps V2"
+        ],
         "summary": "List Incident Timestamps V2",
         "description": "List all incident timestamps for an organisation.",
         "operationId": "Incident Timestamps V2#List",
@@ -4074,7 +4802,9 @@
     },
     "/v2/incident_timestamps/{id}": {
       "get": {
-        "tags": ["Incident Timestamps V2"],
+        "tags": [
+          "Incident Timestamps V2"
+        ],
         "summary": "Show Incident Timestamps V2",
         "description": "Get a single incident timestamp.",
         "operationId": "Incident Timestamps V2#Show",
@@ -4115,7 +4845,9 @@
     },
     "/v2/incident_updates": {
       "get": {
-        "tags": ["Incident Updates V2"],
+        "tags": [
+          "Incident Updates V2"
+        ],
         "summary": "List Incident Updates V2",
         "description": "List all incident updates for an organisation, or for a specific incident.",
         "operationId": "Incident Updates V2#List",
@@ -4221,7 +4953,9 @@
     },
     "/v2/incidents": {
       "get": {
-        "tags": ["Incidents V2"],
+        "tags": [
+          "Incidents V2"
+        ],
         "summary": "List Incidents V2",
         "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at\n\nFind all incidents created_at before or after a given date.\nPossible values are \"gte\" (greater than or equal to) and \"lte\" (less than or equal to). The\nfollowing example finds all incidents created before or on 2021-01-02:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard&mode[one_of]=retrospective&mode[one_of]=test&mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
         "operationId": "Incidents V2#List",
@@ -4261,7 +4995,9 @@
               "type": "object",
               "description": "Filter on incident status. The accepted operators are 'one_of', or 'not_in'.",
               "example": {
-                "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4269,11 +5005,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
             }
           },
           {
@@ -4285,7 +5025,9 @@
               "type": "object",
               "description": "Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{\"one_of\": [\"triage\", \"active\", \"post-incident\", \"closed\"] }`, meaning that canceled, declined and merged incidents are not included.",
               "example": {
-                "one_of": ["active"]
+                "one_of": [
+                  "active"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4293,11 +5035,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "one_of": ["active"]
+              "one_of": [
+                "active"
+              ]
             }
           },
           {
@@ -4309,7 +5055,9 @@
               "type": "object",
               "description": "Filter on incident created at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.",
               "example": {
-                "created_at[gte]": ["2024-05-01"]
+                "created_at[gte]": [
+                  "2024-05-01"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4317,11 +5065,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "created_at[gte]": ["2024-05-01"]
+              "created_at[gte]": [
+                "2024-05-01"
+              ]
             }
           },
           {
@@ -4333,7 +5085,9 @@
               "type": "object",
               "description": "Filter on incident severity. The accepted operators are 'one_of', 'not_in', 'gte', 'lte'.",
               "example": {
-                "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4341,11 +5095,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
             }
           },
           {
@@ -4357,7 +5115,9 @@
               "type": "object",
               "description": "Filter on incident type. The accepted operators are 'one_of, or 'not_in'.",
               "example": {
-                "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4365,11 +5125,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "one_of": ["01GBSQF3FHF7FWZQNWGHAVQ804"]
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
             }
           },
           {
@@ -4391,7 +5155,9 @@
               "additionalProperties": {
                 "type": "object",
                 "example": {
-                  "abc123": ["value"]
+                  "abc123": [
+                    "value"
+                  ]
                 },
                 "additionalProperties": {
                   "type": "array",
@@ -4399,7 +5165,9 @@
                     "type": "string",
                     "example": "value"
                   },
-                  "example": ["value"]
+                  "example": [
+                    "value"
+                  ]
                 }
               }
             },
@@ -4431,7 +5199,9 @@
               "additionalProperties": {
                 "type": "object",
                 "example": {
-                  "abc123": ["value"]
+                  "abc123": [
+                    "value"
+                  ]
                 },
                 "additionalProperties": {
                   "type": "array",
@@ -4439,7 +5209,9 @@
                     "type": "string",
                     "example": "value"
                   },
-                  "example": ["value"]
+                  "example": [
+                    "value"
+                  ]
                 }
               }
             },
@@ -4461,7 +5233,9 @@
               "type": "object",
               "description": "Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{\"one_of\": [\"standard\", \"retrospective\"] }`, meaning that test and tutorial incidents are not included.",
               "example": {
-                "one_of": ["retrospective"]
+                "one_of": [
+                  "retrospective"
+                ]
               },
               "additionalProperties": {
                 "type": "array",
@@ -4469,11 +5243,15 @@
                   "type": "string",
                   "example": "some_value"
                 },
-                "example": ["some_value"]
+                "example": [
+                  "some_value"
+                ]
               }
             },
             "example": {
-              "one_of": ["retrospective"]
+              "one_of": [
+                "retrospective"
+              ]
             }
           }
         ],
@@ -4522,7 +5300,10 @@
                           "values": [
                             {
                               "value_catalog_entry": {
-                                "aliases": ["lawrence@incident.io", "lawrence"],
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
                                 "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "name": "Primary On-call"
@@ -4645,7 +5426,9 @@
         }
       },
       "post": {
-        "tags": ["Incidents V2"],
+        "tags": [
+          "Incidents V2"
+        ],
         "summary": "Create Incidents V2",
         "description": "Create a new incident.\n\nNote that if the incident mode is set to \"retrospective\" then the new incident\nwill not be announced in Slack.\n",
         "operationId": "Incidents V2#Create",
@@ -4752,7 +5535,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -4871,7 +5657,9 @@
     },
     "/v2/incidents/{id}": {
       "get": {
-        "tags": ["Incidents V2"],
+        "tags": [
+          "Incidents V2"
+        ],
         "summary": "Show Incidents V2",
         "description": "Get a single incident.\n\nThe ID supplied can be either the incident's full ID, or the numeric part of its\nreference. For example, to get INC-123, you could use either its full ID or:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents/123\n",
         "operationId": "Incidents V2#Show",
@@ -4933,7 +5721,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -5052,7 +5843,9 @@
     },
     "/v2/incidents/{id}/actions/edit": {
       "post": {
-        "tags": ["Incidents V2"],
+        "tags": [
+          "Incidents V2"
+        ],
         "summary": "Edit Incidents V2",
         "description": "Edit an existing incident.\n\nThis endpoint allows you to edit the properties of an existing incident: e.g. set the severity or update custom fields.\n\nWhen using this endpoint, only fields that are provided will be edited (omitted fields\nwill be ignored).\n",
         "operationId": "Incidents V2#Edit",
@@ -5166,7 +5959,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -5283,9 +6079,61 @@
         }
       }
     },
+    "/v2/managed_resources": {
+      "post": {
+        "tags": [
+          "Managed Resources V2"
+        ],
+        "summary": "CreateManagedResource Managed Resources V2",
+        "description": "Called by external providers such as Terraform, this can 'claim' an incident.io resource as being managed externally.",
+        "operationId": "Managed Resources V2#CreateManagedResource",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateManagedResourceRequestBody"
+              },
+              "example": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "resource_id": "abc123",
+                "resource_type": "schedule"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateManagedResourceResponseBody"
+                },
+                "example": {
+                  "managed_resource": {
+                    "annotations": {
+                      "incident.io/terraform/version": "3.0.0"
+                    },
+                    "managed_by": "dashboard",
+                    "resource_id": "abc123",
+                    "resource_type": "schedule",
+                    "source_url": "https://github.com/my-company/infrastructure"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/schedule_entries": {
       "get": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "ListScheduleEntries Schedules V2",
         "description": "Get a list of schedule entries.",
         "operationId": "Schedules V2#ListScheduleEntries",
@@ -5405,7 +6253,9 @@
     },
     "/v2/schedules": {
       "get": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "List Schedules V2",
         "description": "List configured schedules.",
         "operationId": "Schedules V2#List",
@@ -5525,7 +6375,9 @@
         }
       },
       "post": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "Create Schedules V2",
         "description": "Create a new schedule.",
         "operationId": "Schedules V2#Create",
@@ -5667,7 +6519,9 @@
     },
     "/v2/schedules/{id}": {
       "delete": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "Destroy Schedules V2",
         "description": "Archives a single schedule.",
         "operationId": "Schedules V2#Destroy",
@@ -5692,7 +6546,9 @@
         }
       },
       "get": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "Show Schedules V2",
         "description": "Get a single schedule.",
         "operationId": "Schedules V2#Show",
@@ -5791,7 +6647,9 @@
         }
       },
       "put": {
-        "tags": ["Schedules V2"],
+        "tags": [
+          "Schedules V2"
+        ],
         "summary": "Update Schedules V2",
         "description": "Update a schedule.",
         "operationId": "Schedules V2#Update",
@@ -5947,7 +6805,9 @@
     },
     "/v2/users": {
       "get": {
-        "tags": ["Users V2"],
+        "tags": [
+          "Users V2"
+        ],
         "summary": "List Users V2",
         "description": "List users for an organisation.",
         "operationId": "Users V2#List",
@@ -6049,7 +6909,9 @@
     },
     "/v2/users/{id}": {
       "get": {
-        "tags": ["Users V2"],
+        "tags": [
+          "Users V2"
+        ],
         "summary": "Show Users V2",
         "description": "Get a single user.",
         "operationId": "Users V2#Show",
@@ -6106,7 +6968,9 @@
     },
     "/v2/workflows": {
       "get": {
-        "tags": ["Workflows V2"],
+        "tags": [
+          "Workflows V2"
+        ],
         "summary": "ListWorkflows Workflows V2",
         "description": "List all workflows",
         "operationId": "Workflows V2#ListWorkflows",
@@ -6308,7 +7172,10 @@
                         }
                       ],
                       "runs_from": "2021-08-17T13:28:57.801578Z",
-                      "runs_on_incident_modes": ["standard", "retrospective"],
+                      "runs_on_incident_modes": [
+                        "standard",
+                        "retrospective"
+                      ],
                       "runs_on_incidents": "newly_created",
                       "state": "active",
                       "steps": [
@@ -6331,7 +7198,9 @@
         }
       },
       "post": {
-        "tags": ["Workflows V2"],
+        "tags": [
+          "Workflows V2"
+        ],
         "summary": "CreateWorkflow Workflows V2",
         "description": "Create a new workflow",
         "operationId": "Workflows V2#CreateWorkflow",
@@ -6486,8 +7355,13 @@
                 "folder": "My folder 01",
                 "include_private_incidents": true,
                 "name": "My workflow",
-                "once_for": ["incident.url"],
-                "runs_on_incident_modes": ["standard", "retrospective"],
+                "once_for": [
+                  "incident.url"
+                ],
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
                 "runs_on_incidents": "newly_created",
                 "state": "active",
                 "steps": [
@@ -6720,7 +7594,10 @@
                       }
                     ],
                     "runs_from": "2021-08-17T13:28:57.801578Z",
-                    "runs_on_incident_modes": ["standard", "retrospective"],
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
                     "runs_on_incidents": "newly_created",
                     "state": "active",
                     "steps": [
@@ -6762,7 +7639,9 @@
     },
     "/v2/workflows/{id}": {
       "delete": {
-        "tags": ["Workflows V2"],
+        "tags": [
+          "Workflows V2"
+        ],
         "summary": "DestroyWorkflow Workflows V2",
         "description": "Archives a workflow",
         "operationId": "Workflows V2#DestroyWorkflow",
@@ -6787,7 +7666,9 @@
         }
       },
       "get": {
-        "tags": ["Workflows V2"],
+        "tags": [
+          "Workflows V2"
+        ],
         "summary": "ShowWorkflow Workflows V2",
         "description": "Show a workflow by ID",
         "operationId": "Workflows V2#ShowWorkflow",
@@ -7009,7 +7890,10 @@
                       }
                     ],
                     "runs_from": "2021-08-17T13:28:57.801578Z",
-                    "runs_on_incident_modes": ["standard", "retrospective"],
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
                     "runs_on_incidents": "newly_created",
                     "state": "active",
                     "steps": [
@@ -7049,7 +7933,9 @@
         }
       },
       "put": {
-        "tags": ["Workflows V2"],
+        "tags": [
+          "Workflows V2"
+        ],
         "summary": "UpdateWorkflow Workflows V2",
         "description": "Updates a workflow",
         "operationId": "Workflows V2#UpdateWorkflow",
@@ -7223,8 +8109,13 @@
                 "folder": "My folder 01",
                 "include_private_incidents": true,
                 "name": "My workflow",
-                "once_for": ["incident.url"],
-                "runs_on_incident_modes": ["standard", "retrospective"],
+                "once_for": [
+                  "incident.url"
+                ],
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
                 "runs_on_incidents": "newly_created",
                 "state": "active",
                 "steps": [
@@ -7456,7 +8347,10 @@
                       }
                     ],
                     "runs_from": "2021-08-17T13:28:57.801578Z",
-                    "runs_on_incident_modes": ["standard", "retrospective"],
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
                     "runs_on_incidents": "newly_created",
                     "state": "active",
                     "steps": [
@@ -7592,7 +8486,12 @@
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "My test API key"
         },
-        "required": ["id", "name", "roles", "created_by"]
+        "required": [
+          "id",
+          "name",
+          "roles",
+          "created_by"
+        ]
       },
       "ActionV1": {
         "type": "object",
@@ -7639,7 +8538,12 @@
             "type": "string",
             "description": "Status of the action",
             "example": "outstanding",
-            "enum": ["outstanding", "completed", "deleted", "not_doing"]
+            "enum": [
+              "outstanding",
+              "completed",
+              "deleted",
+              "not_doing"
+            ]
           },
           "updated_at": {
             "type": "string",
@@ -7716,7 +8620,12 @@
             "type": "string",
             "description": "Status of the action",
             "example": "outstanding",
-            "enum": ["outstanding", "completed", "deleted", "not_doing"]
+            "enum": [
+              "outstanding",
+              "completed",
+              "deleted",
+              "not_doing"
+            ]
           },
           "updated_at": {
             "type": "string",
@@ -7792,7 +8701,10 @@
           "after": "abc123",
           "after_url": "abc123"
         },
-        "required": ["after", "after_url"]
+        "required": [
+          "after",
+          "after_url"
+        ]
       },
       "AlertResult": {
         "type": "object",
@@ -7801,19 +8713,25 @@
             "type": "string",
             "description": "The deduplication key that the event has been processed with",
             "example": "unique-key",
-            "enum": ["unique-key"]
+            "enum": [
+              "unique-key"
+            ]
           },
           "message": {
             "type": "string",
             "description": "Human readable message giving detail about the event",
             "example": "Event accepted for processing",
-            "enum": ["Event accepted for processing"]
+            "enum": [
+              "Event accepted for processing"
+            ]
           },
           "status": {
             "type": "string",
             "description": "Status of the event",
             "example": "success",
-            "enum": ["success"]
+            "enum": [
+              "success"
+            ]
           }
         },
         "example": {
@@ -7821,7 +8739,11 @@
           "message": "Event accepted for processing",
           "status": "success"
         },
-        "required": ["status", "message", "deduplication_key"]
+        "required": [
+          "status",
+          "message",
+          "deduplication_key"
+        ]
       },
       "AllResponseBody": {
         "type": "object",
@@ -8047,7 +8969,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -8138,7 +9063,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
-            "related_incidents": ["INC-237"],
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -8194,7 +9121,10 @@
                   "values": [
                     {
                       "value_catalog_entry": {
-                        "aliases": ["lawrence@incident.io", "lawrence"],
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
                         "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "name": "Primary On-call"
@@ -8358,7 +9288,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -8449,7 +9382,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
-            "related_incidents": ["INC-237"],
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -8470,7 +9405,9 @@
             "workload_minutes_working": 20
           }
         },
-        "required": ["event_type"]
+        "required": [
+          "event_type"
+        ]
       },
       "AuditLogActorMetadataV2": {
         "type": "object",
@@ -8547,7 +9484,10 @@
           "name": "John Doe",
           "type": "user"
         },
-        "required": ["id", "type"]
+        "required": [
+          "id",
+          "type"
+        ]
       },
       "AuditLogEntryContextV2": {
         "type": "object",
@@ -8567,7 +9507,9 @@
           "location": "1.2.3.4",
           "user_agent": "Chrome/91.0.4472.114"
         },
-        "required": ["location"]
+        "required": [
+          "location"
+        ]
       },
       "AuditLogPrivateIncidentAccessAttemptedMetadataV2": {
         "type": "object",
@@ -8576,7 +9518,10 @@
             "type": "string",
             "description": "Whether or not the user was able to access the private incident",
             "example": "granted",
-            "enum": ["granted", "denied"]
+            "enum": [
+              "granted",
+              "denied"
+            ]
           }
         },
         "example": {
@@ -8639,7 +9584,10 @@
           "name": "John Doe",
           "type": "user"
         },
-        "required": ["id", "type"]
+        "required": [
+          "id",
+          "type"
+        ]
       },
       "AuditLogUserRoleMembershipChangedMetadataV2": {
         "type": "object",
@@ -8850,7 +9798,10 @@
           "unavailable": false,
           "value": "abc123"
         },
-        "required": ["label", "sort_key"]
+        "required": [
+          "label",
+          "sort_key"
+        ]
       },
       "CatalogEntryReferenceV2": {
         "type": "object",
@@ -8899,7 +9850,10 @@
               "example": "abc123"
             },
             "description": "Optional aliases that can be used to reference this entry",
-            "example": ["lawrence@incident.io", "lawrence"]
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
           },
           "archived_at": {
             "type": "string",
@@ -8994,7 +9948,10 @@
           }
         },
         "example": {
-          "aliases": ["lawrence@incident.io", "lawrence"],
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
           "archived_at": "2021-08-17T14:28:57.801578Z",
           "attribute_values": {
             "abc123": {
@@ -9062,7 +10019,11 @@
             "type": "string",
             "description": "Which category of resource",
             "example": "custom",
-            "enum": ["primitive", "custom", "external"]
+            "enum": [
+              "primitive",
+              "custom",
+              "external"
+            ]
           },
           "description": {
             "type": "string",
@@ -9114,7 +10075,9 @@
         "example": {
           "attribute_id": "abc123"
         },
-        "required": ["attribute_id"]
+        "required": [
+          "attribute_id"
+        ]
       },
       "CatalogTypeAttributePathItemV2": {
         "type": "object",
@@ -9134,7 +10097,10 @@
           "attribute_id": "abc123",
           "attribute_name": "abc123"
         },
-        "required": ["attribute_id", "attribute_name"]
+        "required": [
+          "attribute_id",
+          "attribute_name"
+        ]
       },
       "CatalogTypeAttributePayloadV2": {
         "type": "object",
@@ -9204,7 +10170,11 @@
           ],
           "type": "Custom[\"Service\"]"
         },
-        "required": ["name", "type", "array"]
+        "required": [
+          "name",
+          "type",
+          "array"
+        ]
       },
       "CatalogTypeAttributeV2": {
         "type": "object",
@@ -9276,7 +10246,13 @@
           ],
           "type": "Custom[\"Service\"]"
         },
-        "required": ["id", "mode", "name", "type", "array"]
+        "required": [
+          "id",
+          "mode",
+          "name",
+          "type",
+          "array"
+        ]
       },
       "CatalogTypeSchemaV2": {
         "type": "object",
@@ -9330,7 +10306,10 @@
           ],
           "version": 1
         },
-        "required": ["attributes", "version"]
+        "required": [
+          "attributes",
+          "version"
+        ]
       },
       "CatalogTypeV2": {
         "type": "object",
@@ -9345,6 +10324,26 @@
               "type": "string",
               "example": "abc123"
             }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "issue-tracker",
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-features",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ]
+            },
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ]
           },
           "color": {
             "type": "string",
@@ -9451,7 +10450,9 @@
               "example": "abc123"
             },
             "description": "If populated, the integrations required for this type",
-            "example": ["pager_duty"]
+            "example": [
+              "pager_duty"
+            ]
           },
           "schema": {
             "$ref": "#/components/schemas/CatalogTypeSchemaV2"
@@ -9482,6 +10483,9 @@
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
+          "categories": [
+            "issue-tracker"
+          ],
           "color": "yellow",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -9494,7 +10498,9 @@
           "name": "Kubernetes Cluster",
           "ranked": true,
           "registry_type": "PagerDutyService",
-          "required_integrations": ["pager_duty"],
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
@@ -9528,6 +10534,7 @@
           "ranked",
           "schema",
           "icon",
+          "categories",
           "color",
           "is_editable",
           "annotations",
@@ -9591,7 +10598,9 @@
             }
           ]
         },
-        "required": ["conditions"]
+        "required": [
+          "conditions"
+        ]
       },
       "ConditionGroupV2": {
         "type": "object",
@@ -9599,7 +10608,7 @@
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionV2"
+              "$ref": "#/components/schemas/ConditionV3"
             },
             "description": "All conditions in this list must be satisfied for the group to be satisfied",
             "example": [
@@ -9662,7 +10671,9 @@
             }
           ]
         },
-        "required": ["conditions"]
+        "required": [
+          "conditions"
+        ]
       },
       "ConditionOperationV2": {
         "type": "object",
@@ -9682,7 +10693,34 @@
           "label": "Lawrence Jones",
           "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
         },
-        "required": ["label", "value"]
+        "required": [
+          "label",
+          "value",
+          "sort_key"
+        ]
+      },
+      "ConditionOperationV3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
       },
       "ConditionPayloadV2": {
         "type": "object",
@@ -9737,7 +10775,11 @@
           ],
           "subject": "incident.severity"
         },
-        "required": ["subject", "operation", "param_bindings"]
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
       },
       "ConditionSubjectV2": {
         "type": "object",
@@ -9757,7 +10799,34 @@
           "label": "Incident Severity",
           "reference": "incident.severity"
         },
-        "required": ["label", "reference"]
+        "required": [
+          "label",
+          "reference",
+          "icon"
+        ]
+      },
+      "ConditionSubjectV3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
       },
       "ConditionV2": {
         "type": "object",
@@ -9818,7 +10887,77 @@
             "reference": "incident.severity"
           }
         },
-        "required": ["subject", "operation", "param_bindings"]
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings",
+          "params"
+        ]
+      },
+      "ConditionV3": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV3"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV3"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV3"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
       },
       "CreateEntryRequestBody": {
         "type": "object",
@@ -9830,7 +10969,10 @@
               "example": "abc123"
             },
             "description": "Optional aliases that can be used to reference this entry",
-            "example": ["lawrence@incident.io", "lawrence"]
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
           },
           "attribute_values": {
             "type": "object",
@@ -9876,7 +11018,10 @@
           }
         },
         "example": {
-          "aliases": ["lawrence@incident.io", "lawrence"],
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
           "attribute_values": {
             "abc123": {
               "array_value": [
@@ -9896,7 +11041,11 @@
           "name": "Primary On-call",
           "rank": 3
         },
-        "required": ["catalog_type_id", "name", "attribute_values"]
+        "required": [
+          "catalog_type_id",
+          "name",
+          "attribute_values"
+        ]
       },
       "CreateEntryResponseBody": {
         "type": "object",
@@ -9907,7 +11056,10 @@
         },
         "example": {
           "catalog_entry": {
-            "aliases": ["lawrence@incident.io", "lawrence"],
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
             "archived_at": "2021-08-17T14:28:57.801578Z",
             "attribute_values": {
               "abc123": {
@@ -9958,7 +11110,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["catalog_entry"]
+        "required": [
+          "catalog_entry"
+        ]
       },
       "CreateHTTPRequestBody": {
         "type": "object",
@@ -9970,7 +11124,7 @@
           },
           "description": {
             "type": "string",
-            "description": "Description that optionally adds more detail to title ",
+            "description": "Description that optionally adds more detail to title. Supports markdown.",
             "example": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix..."
           },
           "metadata": {
@@ -9978,7 +11132,9 @@
             "description": "Any additional metadata that you've configured your alert source to parse",
             "example": {
               "service": "hello.world.com",
-              "team": ["my-team"]
+              "team": [
+                "my-team"
+              ]
             },
             "additionalProperties": true
           },
@@ -9991,7 +11147,10 @@
             "type": "string",
             "description": "Current status of this alert",
             "example": "firing",
-            "enum": ["firing", "resolved"]
+            "enum": [
+              "firing",
+              "resolved"
+            ]
           },
           "title": {
             "type": "string",
@@ -10004,13 +11163,18 @@
           "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
           "metadata": {
             "service": "hello.world.com",
-            "team": ["my-team"]
+            "team": [
+              "my-team"
+            ]
           },
           "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
           "status": "firing",
           "title": "*errors.withMessage: PG::Error failed to connect"
         },
-        "required": ["title", "status"]
+        "required": [
+          "title",
+          "status"
+        ]
       },
       "CreateManagedResourceRequestBody": {
         "type": "object",
@@ -10035,7 +11199,10 @@
             "type": "string",
             "description": "The type of the related resource",
             "example": "schedule",
-            "enum": ["workflow", "schedule"]
+            "enum": [
+              "workflow",
+              "schedule"
+            ]
           }
         },
         "example": {
@@ -10070,7 +11237,257 @@
             "source_url": "https://github.com/my-company/infrastructure"
           }
         },
-        "required": ["managed_resource"]
+        "required": [
+          "managed_resource"
+        ]
+      },
+      "CreatePathRequestBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of this escalation path, for the user's reference.",
+            "example": "Urgent Support"
+          },
+          "path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "description": "The nodes that form the levels and branches of this escalation path.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "working_hours": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
+            },
+            "description": "The working hours for this escalation path.",
+            "example": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "abc123"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "name": "Urgent Support",
+          "path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "working_hours": [
+            {
+              "id": "abc123",
+              "name": "abc123",
+              "timezone": "abc123",
+              "weekday_intervals": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "abc123"
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "name",
+          "path"
+        ]
+      },
+      "CreatePathResponseBody": {
+        "type": "object",
+        "properties": {
+          "escalation_path": {
+            "$ref": "#/components/schemas/EscalationPathV2"
+          }
+        },
+        "example": {
+          "escalation_path": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Urgent Support",
+            "path": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ],
+            "working_hours": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "abc123"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "escalation_path"
+        ]
       },
       "CreateRequestBody": {
         "type": "object",
@@ -10098,7 +11515,10 @@
           "sort_key": 10,
           "value": "Product"
         },
-        "required": ["custom_field_id", "value"]
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
       },
       "CreateRequestBody10": {
         "type": "object",
@@ -10180,7 +11600,12 @@
             "type": "string",
             "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
             "example": "standard",
-            "enum": ["standard", "retrospective", "test", "tutorial"]
+            "enum": [
+              "standard",
+              "retrospective",
+              "test",
+              "tutorial"
+            ]
           },
           "name": {
             "type": "string",
@@ -10214,7 +11639,10 @@
             "type": "string",
             "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
             "example": "public",
-            "enum": ["public", "private"]
+            "enum": [
+              "public",
+              "private"
+            ]
           }
         },
         "example": {
@@ -10266,7 +11694,10 @@
           "summary": "Our database is really really sad, and we don't know why yet.",
           "visibility": "public"
         },
-        "required": ["idempotency_key", "visibility"]
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
       },
       "CreateRequestBody11": {
         "type": "object",
@@ -10320,7 +11751,9 @@
             "timezone": "America/Los_Angeles"
           }
         },
-        "required": ["schedule"]
+        "required": [
+          "schedule"
+        ]
       },
       "CreateRequestBody12": {
         "type": "object",
@@ -10348,7 +11781,10 @@
           "name": "Minor",
           "rank": 1
         },
-        "required": ["name", "description"]
+        "required": [
+          "name",
+          "description"
+        ]
       },
       "CreateRequestBody2": {
         "type": "object",
@@ -10362,7 +11798,13 @@
             "type": "string",
             "description": "Type of custom field",
             "example": "single_select",
-            "enum": ["single_select", "multi_select", "text", "link", "numeric"]
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
           },
           "name": {
             "type": "string",
@@ -10374,13 +11816,21 @@
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
             "example": "never",
-            "enum": ["never", "before_closure", "always"]
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ]
           },
           "required_v2": {
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle.",
             "example": "never",
-            "enum": ["never", "before_resolution", "always"]
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
           },
           "show_before_closure": {
             "type": "boolean",
@@ -10439,7 +11889,13 @@
             "type": "string",
             "description": "Type of custom field",
             "example": "single_select",
-            "enum": ["single_select", "multi_select", "text", "link", "numeric"]
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
           },
           "name": {
             "type": "string",
@@ -10522,7 +11978,10 @@
             "resource_type": "pager_duty_incident"
           }
         },
-        "required": ["incident_id", "resource"]
+        "required": [
+          "incident_id",
+          "resource"
+        ]
       },
       "CreateRequestBody5": {
         "type": "object",
@@ -10540,7 +11999,10 @@
           "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
           "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
         },
-        "required": ["user_id", "incident_id"]
+        "required": [
+          "user_id",
+          "incident_id"
+        ]
       },
       "CreateRequestBody6": {
         "type": "object",
@@ -10646,7 +12108,11 @@
             "type": "string",
             "description": "Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.",
             "example": "live",
-            "enum": ["live", "learning", "closed"]
+            "enum": [
+              "live",
+              "learning",
+              "closed"
+            ]
           },
           "description": {
             "type": "string",
@@ -10731,7 +12197,10 @@
             "type": "string",
             "description": "Whether the incident is real or test",
             "example": "real",
-            "enum": ["real", "test"]
+            "enum": [
+              "real",
+              "test"
+            ]
           },
           "name": {
             "type": "string",
@@ -10780,7 +12249,10 @@
             "type": "string",
             "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
             "example": "public",
-            "enum": ["public", "private"]
+            "enum": [
+              "public",
+              "private"
+            ]
           }
         },
         "example": {
@@ -10822,7 +12294,10 @@
           "summary": "Our database is really really sad, and we don't know why yet.",
           "visibility": "public"
         },
-        "required": ["idempotency_key", "visibility"]
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
       },
       "CreateResponseBody": {
         "type": "object",
@@ -10843,7 +12318,9 @@
             }
           }
         },
-        "required": ["incident_attachment"]
+        "required": [
+          "incident_attachment"
+        ]
       },
       "CreateResponseBody2": {
         "type": "object",
@@ -10867,7 +12344,9 @@
             }
           }
         },
-        "required": ["incident_membership"]
+        "required": [
+          "incident_membership"
+        ]
       },
       "CreateTypeRequestBody": {
         "type": "object",
@@ -10882,6 +12361,26 @@
               "type": "string",
               "example": "abc123"
             }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "issue-tracker",
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-features",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ]
+            },
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ]
           },
           "color": {
             "type": "string",
@@ -10958,6 +12457,9 @@
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
+          "categories": [
+            "issue-tracker"
+          ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "bolt",
@@ -10966,7 +12468,10 @@
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
           "type_name": "Custom[\"BackstageGroup\"]"
         },
-        "required": ["name", "description"]
+        "required": [
+          "name",
+          "description"
+        ]
       },
       "CreateTypeResponseBody": {
         "type": "object",
@@ -10980,6 +12485,9 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
+            "categories": [
+              "issue-tracker"
+            ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -10992,7 +12500,9 @@
             "name": "Kubernetes Cluster",
             "ranked": true,
             "registry_type": "PagerDutyService",
-            "required_integrations": ["pager_duty"],
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
@@ -11018,7 +12528,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["catalog_type"]
+        "required": [
+          "catalog_type"
+        ]
       },
       "CreateWorkflowRequestBody": {
         "type": "object",
@@ -11210,29 +12722,46 @@
               "example": "incident.url"
             },
             "description": "Once For strategy to apply to this workflow",
-            "example": ["incident.url"]
+            "example": [
+              "incident.url"
+            ]
           },
           "runs_on_incident_modes": {
             "type": "array",
             "items": {
               "type": "string",
               "example": "test",
-              "enum": ["standard", "test", "retrospective"]
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
             },
             "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": ["standard", "retrospective"]
+            "example": [
+              "standard",
+              "retrospective"
+            ]
           },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
             "example": "newly_created",
-            "enum": ["newly_created", "newly_created_and_active"]
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
           },
           "state": {
             "type": "string",
             "description": "The state of the workflow (e.g. is it draft, or disabled)",
             "example": "active",
-            "enum": ["active", "disabled", "draft", "error"]
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
           },
           "steps": {
             "type": "array",
@@ -11412,8 +12941,13 @@
           "folder": "My folder 01",
           "include_private_incidents": true,
           "name": "My workflow",
-          "once_for": ["incident.url"],
-          "runs_on_incident_modes": ["standard", "retrospective"],
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -11493,7 +13027,10 @@
             }
           ]
         },
-        "required": ["custom_field_id", "values"]
+        "required": [
+          "custom_field_id",
+          "values"
+        ]
       },
       "CustomFieldEntryV1": {
         "type": "object",
@@ -11510,7 +13047,10 @@
             "example": [
               {
                 "value_catalog_entry": {
-                  "aliases": ["lawrence@incident.io", "lawrence"],
+                  "aliases": [
+                    "lawrence@incident.io",
+                    "lawrence"
+                  ],
                   "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "name": "Primary On-call"
@@ -11546,7 +13086,10 @@
           "values": [
             {
               "value_catalog_entry": {
-                "aliases": ["lawrence@incident.io", "lawrence"],
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
                 "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Primary On-call"
@@ -11563,7 +13106,10 @@
             }
           ]
         },
-        "required": ["custom_field", "values"]
+        "required": [
+          "custom_field",
+          "values"
+        ]
       },
       "CustomFieldOptionV1": {
         "type": "object",
@@ -11597,7 +13143,12 @@
           "sort_key": 10,
           "value": "Product"
         },
-        "required": ["id", "custom_field_id", "value", "sort_key"]
+        "required": [
+          "id",
+          "custom_field_id",
+          "value",
+          "sort_key"
+        ]
       },
       "CustomFieldTypeInfoV1": {
         "type": "object",
@@ -11611,7 +13162,13 @@
             "type": "string",
             "description": "Type of custom field",
             "example": "single_select",
-            "enum": ["single_select", "multi_select", "text", "link", "numeric"]
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
           },
           "id": {
             "type": "string",
@@ -11694,7 +13251,13 @@
             "type": "string",
             "description": "Type of custom field",
             "example": "single_select",
-            "enum": ["single_select", "multi_select", "text", "link", "numeric"]
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
           },
           "id": {
             "type": "string",
@@ -11726,13 +13289,21 @@
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
             "example": "never",
-            "enum": ["never", "before_closure", "always"]
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ]
           },
           "required_v2": {
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle.",
             "example": "never",
-            "enum": ["never", "before_resolution", "always"]
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
           },
           "show_before_closure": {
             "type": "boolean",
@@ -11820,7 +13391,13 @@
             "type": "string",
             "description": "Type of custom field",
             "example": "single_select",
-            "enum": ["single_select", "multi_select", "text", "link", "numeric"]
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
           },
           "id": {
             "type": "string",
@@ -11935,7 +13512,10 @@
         },
         "example": {
           "value_catalog_entry": {
-            "aliases": ["lawrence@incident.io", "lawrence"],
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
             "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Primary On-call"
@@ -12005,7 +13585,10 @@
           },
           "notify_incident_channel": true
         },
-        "required": ["incident", "notify_incident_channel"]
+        "required": [
+          "incident",
+          "notify_incident_channel"
+        ]
       },
       "EmbeddedCatalogEntryV1": {
         "type": "object",
@@ -12017,7 +13600,10 @@
               "example": "abc123"
             },
             "description": "Optional aliases that can be used to reference this entry",
-            "example": ["lawrence@incident.io", "lawrence"]
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
           },
           "external_id": {
             "type": "string",
@@ -12036,12 +13622,19 @@
           }
         },
         "example": {
-          "aliases": ["lawrence@incident.io", "lawrence"],
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
           "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call"
         },
-        "required": ["id", "name", "catalog_type_id"]
+        "required": [
+          "id",
+          "name",
+          "catalog_type_id"
+        ]
       },
       "EngineParamBindingPayloadV2": {
         "type": "object",
@@ -12112,6 +13705,42 @@
           }
         }
       },
+      "EngineParamBindingV3": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV3"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV3"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
       "EngineParamBindingValuePayloadV2": {
         "type": "object",
         "properties": {
@@ -12155,7 +13784,38 @@
           "literal": "SEV123",
           "reference": "incident.severity"
         },
-        "required": ["label"]
+        "required": [
+          "label",
+          "sort_key"
+        ]
+      },
+      "EngineParamBindingValueV3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
       },
       "EngineReferenceV2": {
         "type": "object",
@@ -12194,6 +13854,1072 @@
           "array",
           "node_label",
           "hide_filter"
+        ]
+      },
+      "EscalationPathNodeIfElsePayloadV2": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionPayloadV2"
+            },
+            "description": "The condition that defines which branch to take",
+            "example": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          },
+          "else_path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "description": "The nodes that form the levels if our condition is not met",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "then_path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "description": "The nodes that form the levels if our condition is met",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": "one_of",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": "incident.severity"
+            }
+          ],
+          "else_path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "then_path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ]
+        },
+        "required": [
+          "then_path",
+          "else_path"
+        ]
+      },
+      "EscalationPathNodeIfElseV2": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV2"
+            },
+            "description": "The condition that defines which branch to take",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "else_path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodeV2"
+            },
+            "description": "The nodes that form the levels if our condition is not met",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "then_path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodeV2"
+            },
+            "description": "The nodes that form the levels if our condition is met",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "else_path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "then_path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ]
+        },
+        "required": [
+          "conditions",
+          "then_path",
+          "else_path"
+        ]
+      },
+      "EscalationPathNodeLevelV2": {
+        "type": "object",
+        "properties": {
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathTargetV2"
+            },
+            "description": "The targets for this level",
+            "example": [
+              {
+                "id": "lawrencejones",
+                "type": "user",
+                "urgency": "high"
+              }
+            ]
+          },
+          "time_to_ack_interval_condition": {
+            "type": "string",
+            "description": "If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive",
+            "example": "active",
+            "enum": [
+              "active",
+              "inactive"
+            ]
+          },
+          "time_to_ack_seconds": {
+            "type": "integer",
+            "description": "How long should we wait for this level to acknowledge before escalating?",
+            "example": 1800,
+            "format": "int64"
+          },
+          "time_to_ack_weekday_interval_config_id": {
+            "type": "string",
+            "description": "If the time to ack is relative to a time window, this identifies which window it is relative to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "targets": [
+            {
+              "id": "lawrencejones",
+              "type": "user",
+              "urgency": "high"
+            }
+          ],
+          "time_to_ack_interval_condition": "active",
+          "time_to_ack_seconds": 1800,
+          "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "targets"
+        ]
+      },
+      "EscalationPathNodePayloadV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique internal ID of the escalation path node",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "if_else": {
+            "$ref": "#/components/schemas/EscalationPathNodeIfElsePayloadV2"
+          },
+          "level": {
+            "$ref": "#/components/schemas/EscalationPathNodeLevelV2"
+          },
+          "repeat": {
+            "$ref": "#/components/schemas/EscalationPathNodeRepeatV2"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this node: level or branch",
+            "example": "if_else",
+            "enum": [
+              "if_else",
+              "repeat",
+              "level",
+              "notify_channel"
+            ]
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "if_else": {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ],
+            "else_path": [
+              {}
+            ],
+            "then_path": [
+              {}
+            ]
+          },
+          "level": {
+            "targets": [
+              {
+                "id": "lawrencejones",
+                "type": "user",
+                "urgency": "high"
+              }
+            ],
+            "time_to_ack_interval_condition": "active",
+            "time_to_ack_seconds": 1800,
+            "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "repeat": {
+            "repeat_times": 3,
+            "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "type": "if_else"
+        },
+        "required": [
+          "id",
+          "type"
+        ]
+      },
+      "EscalationPathNodeRepeatV2": {
+        "type": "object",
+        "properties": {
+          "repeat_times": {
+            "type": "integer",
+            "description": "How many times to repeat these steps",
+            "example": 3,
+            "format": "int64"
+          },
+          "to_node": {
+            "type": "string",
+            "description": "Which node ID we begin repeating from",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "repeat_times": 3,
+          "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "to_node",
+          "repeat_times"
+        ]
+      },
+      "EscalationPathNodeV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique internal ID of the escalation path node",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "if_else": {
+            "$ref": "#/components/schemas/EscalationPathNodeIfElseV2"
+          },
+          "level": {
+            "$ref": "#/components/schemas/EscalationPathNodeLevelV2"
+          },
+          "repeat": {
+            "$ref": "#/components/schemas/EscalationPathNodeRepeatV2"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this node: level or branch",
+            "example": "if_else",
+            "enum": [
+              "if_else",
+              "repeat",
+              "level",
+              "notify_channel"
+            ]
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "if_else": {
+            "conditions": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ],
+            "else_path": [
+              {}
+            ],
+            "then_path": [
+              {}
+            ]
+          },
+          "level": {
+            "targets": [
+              {
+                "id": "lawrencejones",
+                "type": "user",
+                "urgency": "high"
+              }
+            ],
+            "time_to_ack_interval_condition": "active",
+            "time_to_ack_seconds": 1800,
+            "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "repeat": {
+            "repeat_times": 3,
+            "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "type": "if_else"
+        },
+        "required": [
+          "id",
+          "type"
+        ]
+      },
+      "EscalationPathTargetV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Uniquely identifies an entity of this type",
+            "example": "lawrencejones"
+          },
+          "type": {
+            "type": "string",
+            "description": "Controls what type of entity this target identifies, such as EscalationPolicy or User",
+            "example": "user",
+            "enum": [
+              "schedule",
+              "user",
+              "slack_channel"
+            ]
+          },
+          "urgency": {
+            "type": "string",
+            "description": "The urgency of this escalation path target",
+            "example": "high",
+            "enum": [
+              "high",
+              "low"
+            ]
+          }
+        },
+        "example": {
+          "id": "lawrencejones",
+          "type": "user",
+          "urgency": "high"
+        },
+        "required": [
+          "type",
+          "id",
+          "urgency"
+        ]
+      },
+      "EscalationPathV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this escalation path.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this escalation path, for the user's reference.",
+            "example": "Urgent Support"
+          },
+          "path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodeV2"
+            },
+            "description": "The nodes that form the levels and branches of this escalation path.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "type": "user",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "working_hours": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
+            },
+            "description": "The working hours for this escalation path.",
+            "example": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "abc123"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Urgent Support",
+          "path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "type": "user",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "working_hours": [
+            {
+              "id": "abc123",
+              "name": "abc123",
+              "timezone": "abc123",
+              "weekday_intervals": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "abc123"
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "name",
+          "path",
+          "levels",
+          "repeat_times"
         ]
       },
       "ExpressionBranchPayloadV2": {
@@ -12272,7 +14998,10 @@
             }
           }
         },
-        "required": ["condition_groups", "result"]
+        "required": [
+          "condition_groups",
+          "result"
+        ]
       },
       "ExpressionBranchV2": {
         "type": "object",
@@ -12317,7 +15046,7 @@
             ]
           },
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV2"
+            "$ref": "#/components/schemas/EngineParamBindingV3"
           }
         },
         "example": {
@@ -12368,7 +15097,10 @@
             }
           }
         },
-        "required": ["condition_groups", "result"]
+        "required": [
+          "condition_groups",
+          "result"
+        ]
       },
       "ExpressionBranchesOptsPayloadV2": {
         "type": "object",
@@ -12470,7 +15202,10 @@
             "type": "IncidentStatus"
           }
         },
-        "required": ["branches", "returns"]
+        "required": [
+          "branches",
+          "returns"
+        ]
       },
       "ExpressionBranchesOptsV2": {
         "type": "object",
@@ -12592,7 +15327,10 @@
             "type": "IncidentStatus"
           }
         },
-        "required": ["branches", "returns"]
+        "required": [
+          "branches",
+          "returns"
+        ]
       },
       "ExpressionElseBranchPayloadV2": {
         "type": "object",
@@ -12615,13 +15353,15 @@
             }
           }
         },
-        "required": ["result"]
+        "required": [
+          "result"
+        ]
       },
       "ExpressionElseBranchV2": {
         "type": "object",
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV2"
+            "$ref": "#/components/schemas/EngineParamBindingV3"
           }
         },
         "example": {
@@ -12640,7 +15380,9 @@
             }
           }
         },
-        "required": ["result"]
+        "required": [
+          "result"
+        ]
       },
       "ExpressionFilterOptsPayloadV2": {
         "type": "object",
@@ -12703,7 +15445,9 @@
             }
           ]
         },
-        "required": ["condition_groups"]
+        "required": [
+          "condition_groups"
+        ]
       },
       "ExpressionFilterOptsV2": {
         "type": "object",
@@ -12782,7 +15526,9 @@
             }
           ]
         },
-        "required": ["condition_groups"]
+        "required": [
+          "condition_groups"
+        ]
       },
       "ExpressionNavigateOptsPayloadV2": {
         "type": "object",
@@ -12796,7 +15542,9 @@
         "example": {
           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
         },
-        "required": ["reference"]
+        "required": [
+          "reference"
+        ]
       },
       "ExpressionNavigateOptsV2": {
         "type": "object",
@@ -12816,7 +15564,10 @@
           "reference": "1235",
           "reference_label": "Teams"
         },
-        "required": ["reference", "reference_label"]
+        "required": [
+          "reference",
+          "reference_label"
+        ]
       },
       "ExpressionOperationPayloadV2": {
         "type": "object",
@@ -12935,7 +15686,10 @@
             "source": "metadata.annotations[\"github.com/repo\"]"
           }
         },
-        "required": ["operation_type", "returns"]
+        "required": [
+          "operation_type",
+          "returns"
+        ]
       },
       "ExpressionOperationV2": {
         "type": "object",
@@ -13080,7 +15834,10 @@
             "type": "IncidentStatus"
           }
         },
-        "required": ["operation_type", "returns"]
+        "required": [
+          "operation_type",
+          "returns"
+        ]
       },
       "ExpressionParseOptsV2": {
         "type": "object",
@@ -13101,7 +15858,10 @@
           },
           "source": "metadata.annotations[\"github.com/repo\"]"
         },
-        "required": ["source", "returns"]
+        "required": [
+          "source",
+          "returns"
+        ]
       },
       "ExpressionPayloadV2": {
         "type": "object",
@@ -13324,7 +16084,12 @@
           "reference": "abc123",
           "root_reference": "incident.status"
         },
-        "required": ["label", "reference", "root_reference", "operations"]
+        "required": [
+          "label",
+          "reference",
+          "root_reference",
+          "operations"
+        ]
       },
       "ExpressionV2": {
         "type": "object",
@@ -13774,7 +16539,11 @@
           "name": "Urgent",
           "rank": 10
         },
-        "required": ["id", "name", "rank"]
+        "required": [
+          "id",
+          "name",
+          "rank"
+        ]
       },
       "FollowUpV2": {
         "type": "object",
@@ -13819,7 +16588,12 @@
             "type": "string",
             "description": "Status of the follow-up",
             "example": "outstanding",
-            "enum": ["outstanding", "completed", "deleted", "not_doing"]
+            "enum": [
+              "outstanding",
+              "completed",
+              "deleted",
+              "not_doing"
+            ]
           },
           "title": {
             "type": "string",
@@ -13881,10 +16655,14 @@
           "identity": {
             "dashboard_url": "https://app.incident.io/my-org",
             "name": "Alertmanager token",
-            "roles": ["incident_creator"]
+            "roles": [
+              "incident_creator"
+            ]
           }
         },
-        "required": ["identity"]
+        "required": [
+          "identity"
+        ]
       },
       "IdentityV1": {
         "type": "object",
@@ -13916,19 +16694,28 @@
                 "schedules_editor",
                 "schedules_reader",
                 "workflows_editor",
-                "private_workflows_editor"
+                "private_workflows_editor",
+                "on_call_editor"
               ]
             },
             "description": "Which roles have been enabled for this key",
-            "example": ["incident_creator"]
+            "example": [
+              "incident_creator"
+            ]
           }
         },
         "example": {
           "dashboard_url": "https://app.incident.io/my-org",
           "name": "Alertmanager token",
-          "roles": ["incident_creator"]
+          "roles": [
+            "incident_creator"
+          ]
         },
-        "required": ["name", "roles", "dashboard_url"]
+        "required": [
+          "name",
+          "roles",
+          "dashboard_url"
+        ]
       },
       "IncidentAttachmentV1": {
         "type": "object",
@@ -14017,7 +16804,9 @@
           },
           "value_seconds": 1
         },
-        "required": ["duration_metric"]
+        "required": [
+          "duration_metric"
+        ]
       },
       "IncidentEditPayloadV2": {
         "type": "object",
@@ -14183,7 +16972,13 @@
             "slack_user_id": "U02AYNF2XJM"
           }
         },
-        "required": ["id", "user", "incident_id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "user",
+          "incident_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "IncidentRoleAssignmentPayloadV1": {
         "type": "object",
@@ -14205,7 +17000,10 @@
           },
           "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
         },
-        "required": ["incident_role_id", "assignee"]
+        "required": [
+          "incident_role_id",
+          "assignee"
+        ]
       },
       "IncidentRoleAssignmentPayloadV2": {
         "type": "object",
@@ -14227,7 +17025,9 @@
           },
           "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
         },
-        "required": ["incident_role_id"]
+        "required": [
+          "incident_role_id"
+        ]
       },
       "IncidentRoleAssignmentV1": {
         "type": "object",
@@ -14259,7 +17059,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "IncidentRoleV1": {
         "type": "object",
@@ -14301,7 +17103,11 @@
             "type": "string",
             "description": "Type of incident role",
             "example": "lead",
-            "enum": ["lead", "reporter", "custom"]
+            "enum": [
+              "lead",
+              "reporter",
+              "custom"
+            ]
           },
           "shortform": {
             "type": "string",
@@ -14374,7 +17180,11 @@
             "type": "string",
             "description": "Type of incident role",
             "example": "lead",
-            "enum": ["lead", "reporter", "custom"]
+            "enum": [
+              "lead",
+              "reporter",
+              "custom"
+            ]
           },
           "shortform": {
             "type": "string",
@@ -14499,7 +17309,9 @@
           "last_occurred_at": "2021-08-17T13:28:57.801578Z",
           "name": "last_activity"
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "IncidentTimestampV2": {
         "type": "object",
@@ -14559,7 +17371,12 @@
           "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
           "value": "2021-08-17T13:28:57.801578Z"
         },
-        "required": ["incident_timestamp_id", "id", "incident_id", "created_at"]
+        "required": [
+          "incident_timestamp_id",
+          "id",
+          "incident_id",
+          "created_at"
+        ]
       },
       "IncidentTimestampValueV2": {
         "type": "object",
@@ -14574,7 +17391,12 @@
         "example": {
           "value": "2021-08-17T13:28:57.801578Z"
         },
-        "required": ["id", "incident_id", "incident_timestamp_id", "created_at"]
+        "required": [
+          "id",
+          "incident_id",
+          "incident_timestamp_id",
+          "created_at"
+        ]
       },
       "IncidentTimestampWithValueV2": {
         "type": "object",
@@ -14596,7 +17418,9 @@
             "value": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident_timestamp"]
+        "required": [
+          "incident_timestamp"
+        ]
       },
       "IncidentTypeV1": {
         "type": "object",
@@ -14605,7 +17429,10 @@
             "type": "string",
             "description": "Whether incidents of this must always, or can optionally, be created in triage",
             "example": "always",
-            "enum": ["always", "optional"]
+            "enum": [
+              "always",
+              "optional"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -14801,7 +17628,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -14861,7 +17691,11 @@
             "type": "string",
             "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
             "example": "real",
-            "enum": ["real", "test", "tutorial"]
+            "enum": [
+              "real",
+              "test",
+              "tutorial"
+            ]
           },
           "name": {
             "type": "string",
@@ -14942,7 +17776,10 @@
             "type": "string",
             "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
             "example": "public",
-            "enum": ["public", "private"]
+            "enum": [
+              "public",
+              "private"
+            ]
           }
         },
         "example": {
@@ -14980,7 +17817,10 @@
               "values": [
                 {
                   "value_catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call"
@@ -15123,7 +17963,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -15224,7 +18067,12 @@
             "type": "string",
             "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
             "example": "standard",
-            "enum": ["standard", "retrospective", "test", "tutorial"]
+            "enum": [
+              "standard",
+              "retrospective",
+              "test",
+              "tutorial"
+            ]
           },
           "name": {
             "type": "string",
@@ -15279,7 +18127,10 @@
             "type": "string",
             "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
             "example": "public",
-            "enum": ["public", "private"]
+            "enum": [
+              "public",
+              "private"
+            ]
           },
           "workload_minutes_late": {
             "type": "number",
@@ -15341,7 +18192,10 @@
               "values": [
                 {
                   "value_catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call"
@@ -15522,7 +18376,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -15651,7 +18508,11 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident", "previous_status", "new_status"]
+        "required": [
+          "incident",
+          "previous_status",
+          "new_status"
+        ]
       },
       "ListEntriesResponseBody": {
         "type": "object",
@@ -15663,7 +18524,10 @@
             },
             "example": [
               {
-                "aliases": ["lawrence@incident.io", "lawrence"],
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
                 "archived_at": "2021-08-17T14:28:57.801578Z",
                 "attribute_values": {
                   "abc123": {
@@ -15725,7 +18589,10 @@
         "example": {
           "catalog_entries": [
             {
-              "aliases": ["lawrence@incident.io", "lawrence"],
+              "aliases": [
+                "lawrence@incident.io",
+                "lawrence"
+              ],
               "archived_at": "2021-08-17T14:28:57.801578Z",
               "attribute_values": {
                 "abc123": {
@@ -15780,6 +18647,9 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
+            "categories": [
+              "issue-tracker"
+            ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -15792,7 +18662,9 @@
             "name": "Kubernetes Cluster",
             "ranked": true,
             "registry_type": "PagerDutyService",
-            "required_integrations": ["pager_duty"],
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
@@ -15822,7 +18694,11 @@
             "page_size": 25
           }
         },
-        "required": ["catalog_type", "catalog_entries", "pagination_meta"]
+        "required": [
+          "catalog_type",
+          "catalog_entries",
+          "pagination_meta"
+        ]
       },
       "ListResourcesResponseBody": {
         "type": "object",
@@ -15854,7 +18730,9 @@
             }
           ]
         },
-        "required": ["resources"]
+        "required": [
+          "resources"
+        ]
       },
       "ListResponseBody": {
         "type": "object",
@@ -15916,7 +18794,9 @@
             }
           ]
         },
-        "required": ["actions"]
+        "required": [
+          "actions"
+        ]
       },
       "ListResponseBody10": {
         "type": "object",
@@ -15952,7 +18832,9 @@
             }
           ]
         },
-        "required": ["incident_statuses"]
+        "required": [
+          "incident_statuses"
+        ]
       },
       "ListResponseBody11": {
         "type": "object",
@@ -15980,7 +18862,9 @@
             }
           ]
         },
-        "required": ["incident_timestamps"]
+        "required": [
+          "incident_timestamps"
+        ]
       },
       "ListResponseBody12": {
         "type": "object",
@@ -16018,7 +18902,9 @@
             }
           ]
         },
-        "required": ["incident_types"]
+        "required": [
+          "incident_types"
+        ]
       },
       "ListResponseBody13": {
         "type": "object",
@@ -16117,7 +19003,9 @@
             "page_size": 25
           }
         },
-        "required": ["incident_updates"]
+        "required": [
+          "incident_updates"
+        ]
       },
       "ListResponseBody14": {
         "type": "object",
@@ -16163,7 +19051,10 @@
                     "values": [
                       {
                         "value_catalog_entry": {
-                          "aliases": ["lawrence@incident.io", "lawrence"],
+                          "aliases": [
+                            "lawrence@incident.io",
+                            "lawrence"
+                          ],
                           "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "name": "Primary On-call"
@@ -16284,7 +19175,10 @@
                   "values": [
                     {
                       "value_catalog_entry": {
-                        "aliases": ["lawrence@incident.io", "lawrence"],
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
                         "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "name": "Primary On-call"
@@ -16369,7 +19263,9 @@
             "total_record_count": 238
           }
         },
-        "required": ["incidents"]
+        "required": [
+          "incidents"
+        ]
       },
       "ListResponseBody15": {
         "type": "object",
@@ -16415,7 +19311,10 @@
                     "values": [
                       {
                         "value_catalog_entry": {
-                          "aliases": ["lawrence@incident.io", "lawrence"],
+                          "aliases": [
+                            "lawrence@incident.io",
+                            "lawrence"
+                          ],
                           "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "name": "Primary On-call"
@@ -16568,7 +19467,10 @@
                   "values": [
                     {
                       "value_catalog_entry": {
-                        "aliases": ["lawrence@incident.io", "lawrence"],
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
                         "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "name": "Primary On-call"
@@ -16685,7 +19587,9 @@
             "total_record_count": 238
           }
         },
-        "required": ["incidents"]
+        "required": [
+          "incidents"
+        ]
       },
       "ListResponseBody16": {
         "type": "object",
@@ -16841,7 +19745,9 @@
             }
           ]
         },
-        "required": ["schedules"]
+        "required": [
+          "schedules"
+        ]
       },
       "ListResponseBody17": {
         "type": "object",
@@ -16875,7 +19781,9 @@
             }
           ]
         },
-        "required": ["severities"]
+        "required": [
+          "severities"
+        ]
       },
       "ListResponseBody18": {
         "type": "object",
@@ -16942,7 +19850,10 @@
             }
           ]
         },
-        "required": ["users", "pagination_meta"]
+        "required": [
+          "users",
+          "pagination_meta"
+        ]
       },
       "ListResponseBody2": {
         "type": "object",
@@ -16992,7 +19903,9 @@
             }
           ]
         },
-        "required": ["actions"]
+        "required": [
+          "actions"
+        ]
       },
       "ListResponseBody3": {
         "type": "object",
@@ -17029,7 +19942,10 @@
             "page_size": 25
           }
         },
-        "required": ["custom_field_options", "pagination_meta"]
+        "required": [
+          "custom_field_options",
+          "pagination_meta"
+        ]
       },
       "ListResponseBody4": {
         "type": "object",
@@ -17093,7 +20009,9 @@
             }
           ]
         },
-        "required": ["custom_fields"]
+        "required": [
+          "custom_fields"
+        ]
       },
       "ListResponseBody5": {
         "type": "object",
@@ -17129,7 +20047,9 @@
             }
           ]
         },
-        "required": ["custom_fields"]
+        "required": [
+          "custom_fields"
+        ]
       },
       "ListResponseBody6": {
         "type": "object",
@@ -17203,7 +20123,9 @@
             }
           ]
         },
-        "required": ["follow_ups"]
+        "required": [
+          "follow_ups"
+        ]
       },
       "ListResponseBody7": {
         "type": "object",
@@ -17241,7 +20163,9 @@
             }
           ]
         },
-        "required": ["incident_attachments"]
+        "required": [
+          "incident_attachments"
+        ]
       },
       "ListResponseBody8": {
         "type": "object",
@@ -17281,7 +20205,9 @@
             }
           ]
         },
-        "required": ["incident_roles"]
+        "required": [
+          "incident_roles"
+        ]
       },
       "ListResponseBody9": {
         "type": "object",
@@ -17319,7 +20245,9 @@
             }
           ]
         },
-        "required": ["incident_roles"]
+        "required": [
+          "incident_roles"
+        ]
       },
       "ListScheduleEntriesResponseBody": {
         "type": "object",
@@ -17390,7 +20318,9 @@
             ]
           }
         },
-        "required": ["schedule_entries"]
+        "required": [
+          "schedule_entries"
+        ]
       },
       "ListTypesResponseBody": {
         "type": "object",
@@ -17405,6 +20335,9 @@
                 "annotations": {
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
+                "categories": [
+                  "issue-tracker"
+                ],
                 "color": "yellow",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -17417,7 +20350,9 @@
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "registry_type": "PagerDutyService",
-                "required_integrations": ["pager_duty"],
+                "required_integrations": [
+                  "pager_duty"
+                ],
                 "schema": {
                   "attributes": [
                     {
@@ -17451,6 +20386,9 @@
               "annotations": {
                 "incident.io/catalog-importer/id": "id-of-config"
               },
+              "categories": [
+                "issue-tracker"
+              ],
               "color": "yellow",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -17463,7 +20401,9 @@
               "name": "Kubernetes Cluster",
               "ranked": true,
               "registry_type": "PagerDutyService",
-              "required_integrations": ["pager_duty"],
+              "required_integrations": [
+                "pager_duty"
+              ],
               "schema": {
                 "attributes": [
                   {
@@ -17490,7 +20430,9 @@
             }
           ]
         },
-        "required": ["catalog_types"]
+        "required": [
+          "catalog_types"
+        ]
       },
       "ListWorkflowsResponseBody": {
         "type": "object",
@@ -17689,7 +20631,10 @@
                   }
                 ],
                 "runs_from": "2021-08-17T13:28:57.801578Z",
-                "runs_on_incident_modes": ["standard", "retrospective"],
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
                 "runs_on_incidents": "newly_created",
                 "state": "active",
                 "steps": [
@@ -17897,7 +20842,10 @@
                 }
               ],
               "runs_from": "2021-08-17T13:28:57.801578Z",
-              "runs_on_incident_modes": ["standard", "retrospective"],
+              "runs_on_incident_modes": [
+                "standard",
+                "retrospective"
+              ],
               "runs_on_incidents": "newly_created",
               "state": "active",
               "steps": [
@@ -17914,7 +20862,9 @@
             }
           ]
         },
-        "required": ["workflows"]
+        "required": [
+          "workflows"
+        ]
       },
       "ManagedResourceV2": {
         "type": "object",
@@ -17934,7 +20884,11 @@
             "type": "string",
             "description": "How is this resource managed",
             "example": "dashboard",
-            "enum": ["dashboard", "terraform", "external"]
+            "enum": [
+              "dashboard",
+              "terraform",
+              "external"
+            ]
           },
           "resource_id": {
             "type": "string",
@@ -17945,7 +20899,10 @@
             "type": "string",
             "description": "The type of the related resource",
             "example": "schedule",
-            "enum": ["workflow", "schedule"]
+            "enum": [
+              "workflow",
+              "schedule"
+            ]
           },
           "source_url": {
             "type": "string",
@@ -17987,7 +20944,11 @@
             "type": "string",
             "description": "How is this resource managed",
             "example": "dashboard",
-            "enum": ["dashboard", "terraform", "external"]
+            "enum": [
+              "dashboard",
+              "terraform",
+              "external"
+            ]
           },
           "source_url": {
             "type": "string",
@@ -18002,7 +20963,10 @@
           "managed_by": "dashboard",
           "source_url": "https://github.com/my-company/infrastructure"
         },
-        "required": ["annotations", "managed_by"]
+        "required": [
+          "annotations",
+          "managed_by"
+        ]
       },
       "PaginationMetaResult": {
         "type": "object",
@@ -18024,7 +20988,9 @@
           "after": "01FCNDV6P870EA6S7TK1DSYDG0",
           "page_size": 25
         },
-        "required": ["page_size"]
+        "required": [
+          "page_size"
+        ]
       },
       "PaginationMetaResultWithTotal": {
         "type": "object",
@@ -18053,7 +21019,9 @@
           "page_size": 25,
           "total_record_count": 238
         },
-        "required": ["page_size"]
+        "required": [
+          "page_size"
+        ]
       },
       "PrivateIncidentAccessAttemptedV1ResponseBody": {
         "type": "object",
@@ -18172,7 +21140,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.action_created_v1"]
+        "required": [
+          "event_type",
+          "private_incident.action_created_v1"
+        ]
       },
       "PrivateIncidentActionUpdatedV1ResponseBody": {
         "type": "object",
@@ -18209,7 +21180,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.action_updated_v1"]
+        "required": [
+          "event_type",
+          "private_incident.action_updated_v1"
+        ]
       },
       "PrivateIncidentFollowUpCreatedV1ResponseBody": {
         "type": "object",
@@ -18246,7 +21220,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.follow_up_created_v1"]
+        "required": [
+          "event_type",
+          "private_incident.follow_up_created_v1"
+        ]
       },
       "PrivateIncidentFollowUpUpdatedV1ResponseBody": {
         "type": "object",
@@ -18283,7 +21260,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.follow_up_updated_v1"]
+        "required": [
+          "event_type",
+          "private_incident.follow_up_updated_v1"
+        ]
       },
       "PrivateIncidentIncidentCreatedV2ResponseBody": {
         "type": "object",
@@ -18320,7 +21300,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.incident_created_v2"]
+        "required": [
+          "event_type",
+          "private_incident.incident_created_v2"
+        ]
       },
       "PrivateIncidentIncidentUpdatedV2ResponseBody": {
         "type": "object",
@@ -18357,7 +21340,10 @@
             "id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.incident_updated_v2"]
+        "required": [
+          "event_type",
+          "private_incident.incident_updated_v2"
+        ]
       },
       "PrivateIncidentMembershipGrantedV1ResponseBody": {
         "type": "object",
@@ -18396,7 +21382,10 @@
             "user_id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.membership_granted_v1"]
+        "required": [
+          "event_type",
+          "private_incident.membership_granted_v1"
+        ]
       },
       "PrivateIncidentMembershipRevokedV1ResponseBody": {
         "type": "object",
@@ -18435,7 +21424,10 @@
             "user_id": "abc123"
           }
         },
-        "required": ["event_type", "private_incident.membership_revoked_v1"]
+        "required": [
+          "event_type",
+          "private_incident.membership_revoked_v1"
+        ]
       },
       "PublicIncidentActionCreatedV1ResponseBody": {
         "type": "object",
@@ -18491,7 +21483,10 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["event_type", "public_incident.action_created_v1"]
+        "required": [
+          "event_type",
+          "public_incident.action_created_v1"
+        ]
       },
       "PublicIncidentActionUpdatedV1ResponseBody": {
         "type": "object",
@@ -18547,7 +21542,10 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["event_type", "public_incident.action_updated_v1"]
+        "required": [
+          "event_type",
+          "public_incident.action_updated_v1"
+        ]
       },
       "PublicIncidentFollowUpCreatedV1ResponseBody": {
         "type": "object",
@@ -18603,7 +21601,10 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["event_type", "public_incident.follow_up_created_v1"]
+        "required": [
+          "event_type",
+          "public_incident.follow_up_created_v1"
+        ]
       },
       "PublicIncidentFollowUpUpdatedV1ResponseBody": {
         "type": "object",
@@ -18659,7 +21660,10 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["event_type", "public_incident.follow_up_updated_v1"]
+        "required": [
+          "event_type",
+          "public_incident.follow_up_updated_v1"
+        ]
       },
       "PublicIncidentIncidentCreatedV2ResponseBody": {
         "type": "object",
@@ -18727,7 +21731,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -18818,7 +21825,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
-            "related_incidents": ["INC-237"],
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -18839,7 +21848,10 @@
             "workload_minutes_working": 20
           }
         },
-        "required": ["event_type", "public_incident.incident_created_v2"]
+        "required": [
+          "event_type",
+          "public_incident.incident_created_v2"
+        ]
       },
       "PublicIncidentIncidentStatusUpdatedV2ResponseBody": {
         "type": "object",
@@ -18908,7 +21920,10 @@
                   "values": [
                     {
                       "value_catalog_entry": {
-                        "aliases": ["lawrence@incident.io", "lawrence"],
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
                         "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "name": "Primary On-call"
@@ -19038,7 +22053,10 @@
             }
           }
         },
-        "required": ["event_type", "public_incident.incident_status_updated_v2"]
+        "required": [
+          "event_type",
+          "public_incident.incident_status_updated_v2"
+        ]
       },
       "PublicIncidentIncidentUpdatedV2ResponseBody": {
         "type": "object",
@@ -19106,7 +22124,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -19197,7 +22218,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
-            "related_incidents": ["INC-237"],
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -19218,7 +22241,10 @@
             "workload_minutes_working": 20
           }
         },
-        "required": ["event_type", "public_incident.incident_updated_v2"]
+        "required": [
+          "event_type",
+          "public_incident.incident_updated_v2"
+        ]
       },
       "RBACRoleV2": {
         "type": "object",
@@ -19250,7 +22276,11 @@
           "name": "Customer Success",
           "slug": "customer-success"
         },
-        "required": ["id", "name", "slug"]
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ]
       },
       "RetrospectiveIncidentOptionsV2": {
         "type": "object",
@@ -19289,7 +22319,10 @@
           "array": true,
           "type": "IncidentStatus"
         },
-        "required": ["type", "array"]
+        "required": [
+          "type",
+          "array"
+        ]
       },
       "ScheduleConfigCreatePayloadV2": {
         "type": "object",
@@ -19538,7 +22571,10 @@
             }
           ]
         },
-        "required": ["rotations", "version"]
+        "required": [
+          "rotations",
+          "version"
+        ]
       },
       "ScheduleCreatePayloadV2": {
         "type": "object",
@@ -19738,7 +22774,11 @@
             }
           ]
         },
-        "required": ["scheduled", "overrides", "final"]
+        "required": [
+          "scheduled",
+          "overrides",
+          "final"
+        ]
       },
       "ScheduleEntryV2": {
         "type": "object",
@@ -19792,7 +22832,11 @@
             "slack_user_id": "U02AYNF2XJM"
           }
         },
-        "required": ["external_user_id", "start_at", "end_at"]
+        "required": [
+          "external_user_id",
+          "start_at",
+          "end_at"
+        ]
       },
       "ScheduleLayerCreatePayloadV2": {
         "type": "object",
@@ -19812,7 +22856,9 @@
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Layer 1"
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "ScheduleLayerV2": {
         "type": "object",
@@ -19896,7 +22942,7 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
+              "$ref": "#/components/schemas/WeekdayIntervalV2"
             },
             "example": [
               {
@@ -19939,7 +22985,9 @@
             }
           ]
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "ScheduleRotationHandoverV2": {
         "type": "object",
@@ -19952,7 +23000,11 @@
           "interval_type": {
             "type": "string",
             "example": "daily",
-            "enum": ["hourly", "daily", "weekly"]
+            "enum": [
+              "hourly",
+              "daily",
+              "weekly"
+            ]
           }
         },
         "example": {
@@ -20136,7 +23188,7 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
+              "$ref": "#/components/schemas/WeekdayIntervalV2"
             },
             "example": [
               {
@@ -20224,41 +23276,6 @@
           "start_time": "09:00",
           "weekday": "tuesday"
         }
-      },
-      "ScheduleRotationWorkingIntervalV2": {
-        "type": "object",
-        "properties": {
-          "end_time": {
-            "type": "string",
-            "description": "End time of the interval, in 24hr format",
-            "example": "17:00"
-          },
-          "start_time": {
-            "type": "string",
-            "description": "Start time of the interval, in 24hr format",
-            "example": "09:00"
-          },
-          "weekday": {
-            "type": "string",
-            "description": "Weekday this interval applies to",
-            "example": "tuesday",
-            "enum": [
-              "monday",
-              "tuesday",
-              "wednesday",
-              "thursday",
-              "friday",
-              "saturday",
-              "sunday"
-            ]
-          }
-        },
-        "example": {
-          "end_time": "17:00",
-          "start_time": "09:00",
-          "weekday": "tuesday"
-        },
-        "required": ["weekday", "start_time", "end_time"]
       },
       "ScheduleUpdatePayloadV2": {
         "type": "object",
@@ -20627,7 +23644,10 @@
         },
         "example": {
           "catalog_entry": {
-            "aliases": ["lawrence@incident.io", "lawrence"],
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
             "archived_at": "2021-08-17T14:28:57.801578Z",
             "attribute_values": {
               "abc123": {
@@ -20681,6 +23701,9 @@
             "annotations": {
               "incident.io/catalog-importer/id": "id-of-config"
             },
+            "categories": [
+              "issue-tracker"
+            ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -20693,7 +23716,9 @@
             "name": "Kubernetes Cluster",
             "ranked": true,
             "registry_type": "PagerDutyService",
-            "required_integrations": ["pager_duty"],
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
@@ -20719,7 +23744,10 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["catalog_type", "catalog_entry"]
+        "required": [
+          "catalog_type",
+          "catalog_entry"
+        ]
       },
       "ShowResponseBody": {
         "type": "object",
@@ -20752,7 +23780,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["action"]
+        "required": [
+          "action"
+        ]
       },
       "ShowResponseBody10": {
         "type": "object",
@@ -20768,7 +23798,9 @@
             "rank": 1
           }
         },
-        "required": ["incident_timestamp"]
+        "required": [
+          "incident_timestamp"
+        ]
       },
       "ShowResponseBody11": {
         "type": "object",
@@ -20789,7 +23821,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident_type"]
+        "required": [
+          "incident_type"
+        ]
       },
       "ShowResponseBody12": {
         "type": "object",
@@ -20834,7 +23868,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -20913,7 +23950,9 @@
             "visibility": "public"
           }
         },
-        "required": ["incident"]
+        "required": [
+          "incident"
+        ]
       },
       "ShowResponseBody13": {
         "type": "object",
@@ -20958,7 +23997,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -21069,7 +24111,9 @@
             "workload_minutes_working": 20
           }
         },
-        "required": ["incident"]
+        "required": [
+          "incident"
+        ]
       },
       "ShowResponseBody14": {
         "type": "object",
@@ -21145,7 +24189,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["schedule"]
+        "required": [
+          "schedule"
+        ]
       },
       "ShowResponseBody15": {
         "type": "object",
@@ -21164,7 +24210,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["severity"]
+        "required": [
+          "severity"
+        ]
       },
       "ShowResponseBody16": {
         "type": "object",
@@ -21196,7 +24244,9 @@
             "slack_user_id": "U02AYNF2XJM"
           }
         },
-        "required": ["user"]
+        "required": [
+          "user"
+        ]
       },
       "ShowResponseBody2": {
         "type": "object",
@@ -21223,7 +24273,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["action"]
+        "required": [
+          "action"
+        ]
       },
       "ShowResponseBody3": {
         "type": "object",
@@ -21240,7 +24292,9 @@
             "value": "Product"
           }
         },
-        "required": ["custom_field_option"]
+        "required": [
+          "custom_field_option"
+        ]
       },
       "ShowResponseBody4": {
         "type": "object",
@@ -21274,7 +24328,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["custom_field"]
+        "required": [
+          "custom_field"
+        ]
       },
       "ShowResponseBody5": {
         "type": "object",
@@ -21294,7 +24350,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["custom_field"]
+        "required": [
+          "custom_field"
+        ]
       },
       "ShowResponseBody6": {
         "type": "object",
@@ -21333,7 +24391,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["follow_up"]
+        "required": [
+          "follow_up"
+        ]
       },
       "ShowResponseBody7": {
         "type": "object",
@@ -21355,7 +24415,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident_role"]
+        "required": [
+          "incident_role"
+        ]
       },
       "ShowResponseBody8": {
         "type": "object",
@@ -21376,7 +24438,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident_role"]
+        "required": [
+          "incident_role"
+        ]
       },
       "ShowResponseBody9": {
         "type": "object",
@@ -21396,7 +24460,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
-        "required": ["incident_status"]
+        "required": [
+          "incident_status"
+        ]
       },
       "ShowWorkflowResponseBody": {
         "type": "object",
@@ -21604,7 +24670,10 @@
               }
             ],
             "runs_from": "2021-08-17T13:28:57.801578Z",
-            "runs_on_incident_modes": ["standard", "retrospective"],
+            "runs_on_incident_modes": [
+              "standard",
+              "retrospective"
+            ],
             "runs_on_incidents": "newly_created",
             "state": "active",
             "steps": [
@@ -21638,7 +24707,10 @@
             "version": 3
           }
         },
-        "required": ["workflow", "management_meta"]
+        "required": [
+          "workflow",
+          "management_meta"
+        ]
       },
       "StepConfig": {
         "type": "object",
@@ -21666,7 +24738,7 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV2"
+              "$ref": "#/components/schemas/EngineParamBindingV3"
             },
             "description": "Bindings for the step parameters",
             "example": [
@@ -21804,7 +24876,12 @@
           "label": "PagerDuty Escalate",
           "name": "pagerduty.escalate"
         },
-        "required": ["name", "label", "description", "params"]
+        "required": [
+          "name",
+          "label",
+          "description",
+          "params"
+        ]
       },
       "TriggerSlim": {
         "type": "object",
@@ -21824,7 +24901,10 @@
           "label": "Incident Updated",
           "name": "incident.updated"
         },
-        "required": ["name", "label"]
+        "required": [
+          "name",
+          "label"
+        ]
       },
       "UpdateEntryRequestBody": {
         "type": "object",
@@ -21836,7 +24916,10 @@
               "example": "abc123"
             },
             "description": "Optional aliases that can be used to reference this entry",
-            "example": ["lawrence@incident.io", "lawrence"]
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
           },
           "attribute_values": {
             "type": "object",
@@ -21877,7 +24960,10 @@
           }
         },
         "example": {
-          "aliases": ["lawrence@incident.io", "lawrence"],
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
           "attribute_values": {
             "abc123": {
               "array_value": [
@@ -21896,7 +24982,10 @@
           "name": "Primary On-call",
           "rank": 3
         },
-        "required": ["name", "attribute_values"]
+        "required": [
+          "name",
+          "attribute_values"
+        ]
       },
       "UpdateRequestBody": {
         "type": "object",
@@ -21918,7 +25007,11 @@
           "sort_key": 10,
           "value": "Product"
         },
-        "required": ["value", "custom_field_id", "sort_key"]
+        "required": [
+          "value",
+          "custom_field_id",
+          "sort_key"
+        ]
       },
       "UpdateRequestBody2": {
         "type": "object",
@@ -21938,13 +25031,21 @@
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
             "example": "never",
-            "enum": ["never", "before_closure", "always"]
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ]
           },
           "required_v2": {
             "type": "string",
             "description": "When this custom field must be set during the incident lifecycle.",
             "example": "never",
-            "enum": ["never", "before_resolution", "always"]
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ]
           },
           "show_before_closure": {
             "type": "boolean",
@@ -22215,6 +25316,26 @@
               "example": "abc123"
             }
           },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "issue-tracker",
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-features",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ]
+            },
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ]
+          },
           "color": {
             "type": "string",
             "description": "Sets the display color of this type in the dashboard",
@@ -22285,6 +25406,9 @@
           "annotations": {
             "incident.io/catalog-importer/id": "id-of-config"
           },
+          "categories": [
+            "issue-tracker"
+          ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "bolt",
@@ -22292,7 +25416,10 @@
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog"
         },
-        "required": ["name", "description"]
+        "required": [
+          "name",
+          "description"
+        ]
       },
       "UpdateTypeSchemaRequestBody": {
         "type": "object",
@@ -22352,6 +25479,7 @@
           "ranked",
           "schema",
           "icon",
+          "categories",
           "color",
           "is_editable",
           "annotations",
@@ -22552,29 +25680,46 @@
               "example": "incident.url"
             },
             "description": "Once For strategy to apply to this workflow",
-            "example": ["incident.url"]
+            "example": [
+              "incident.url"
+            ]
           },
           "runs_on_incident_modes": {
             "type": "array",
             "items": {
               "type": "string",
               "example": "test",
-              "enum": ["standard", "test", "retrospective"]
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
             },
             "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": ["standard", "retrospective"]
+            "example": [
+              "standard",
+              "retrospective"
+            ]
           },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
             "example": "newly_created",
-            "enum": ["newly_created", "newly_created_and_active"]
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
           },
           "state": {
             "type": "string",
             "description": "The state of the workflow (e.g. is it draft, or disabled)",
             "example": "active",
-            "enum": ["active", "disabled", "draft", "error"]
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
           },
           "steps": {
             "type": "array",
@@ -22749,8 +25894,13 @@
           "folder": "My folder 01",
           "include_private_incidents": true,
           "name": "My workflow",
-          "once_for": ["incident.url"],
-          "runs_on_incident_modes": ["standard", "retrospective"],
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -22919,7 +26069,13 @@
             "type": "string",
             "description": "DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.",
             "example": "viewer",
-            "enum": ["viewer", "responder", "administrator", "owner", "unset"]
+            "enum": [
+              "viewer",
+              "responder",
+              "administrator",
+              "owner",
+              "unset"
+            ]
           },
           "slack_user_id": {
             "type": "string",
@@ -22982,7 +26138,13 @@
             "type": "string",
             "description": "DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.",
             "example": "viewer",
-            "enum": ["viewer", "responder", "administrator", "owner", "unset"]
+            "enum": [
+              "viewer",
+              "responder",
+              "administrator",
+              "owner",
+              "unset"
+            ]
           },
           "slack_user_id": {
             "type": "string",
@@ -23046,7 +26208,10 @@
           "incident_id": "abc123",
           "user_id": "abc123"
         },
-        "required": ["incident_id", "user_id"]
+        "required": [
+          "incident_id",
+          "user_id"
+        ]
       },
       "WebhookIncidentV2": {
         "type": "object",
@@ -23090,7 +26255,10 @@
                 "values": [
                   {
                     "value_catalog_entry": {
-                      "aliases": ["lawrence@incident.io", "lawrence"],
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
                       "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
@@ -23191,7 +26359,12 @@
             "type": "string",
             "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
             "example": "standard",
-            "enum": ["standard", "retrospective", "test", "tutorial"]
+            "enum": [
+              "standard",
+              "retrospective",
+              "test",
+              "tutorial"
+            ]
           },
           "name": {
             "type": "string",
@@ -23220,7 +26393,9 @@
               "example": "abc123"
             },
             "description": "Incident IDs of incidents related to this incident",
-            "example": ["INC-237"]
+            "example": [
+              "INC-237"
+            ]
           },
           "severity": {
             "$ref": "#/components/schemas/SeverityV2"
@@ -23255,7 +26430,10 @@
             "type": "string",
             "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
             "example": "public",
-            "enum": ["public", "private"]
+            "enum": [
+              "public",
+              "private"
+            ]
           },
           "workload_minutes_late": {
             "type": "number",
@@ -23317,7 +26495,10 @@
               "values": [
                 {
                   "value_catalog_entry": {
-                    "aliases": ["lawrence@incident.io", "lawrence"],
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
                     "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call"
@@ -23408,7 +26589,9 @@
           "permalink": "https://app.incident.io/incidents/123",
           "postmortem_document_url": "https://docs.google.com/my_doc_id",
           "reference": "INC-123",
-          "related_incidents": ["INC-237"],
+          "related_incidents": [
+            "INC-237"
+          ],
           "severity": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Issues with **low impact**.",
@@ -23462,7 +26645,90 @@
         "example": {
           "id": "abc123"
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
+      },
+      "WeekdayIntervalConfigV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier for this set of working intervals",
+            "example": "abc123"
+          },
+          "name": {
+            "type": "string",
+            "description": "A human readable label for this set of working intervals",
+            "example": "abc123"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "How to interpret all the intervals",
+            "example": "abc123"
+          },
+          "weekday_intervals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalV2"
+            },
+            "example": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "abc123"
+              }
+            ]
+          }
+        },
+        "example": {
+          "id": "abc123",
+          "name": "abc123",
+          "timezone": "abc123",
+          "weekday_intervals": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "abc123"
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "name",
+          "timezone",
+          "weekday_intervals"
+        ]
+      },
+      "WeekdayIntervalV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekday this interval applies to",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "abc123"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
+        ]
       },
       "Workflow": {
         "type": "object",
@@ -23704,22 +26970,37 @@
             "items": {
               "type": "string",
               "example": "test",
-              "enum": ["standard", "test", "retrospective"]
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
             },
             "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": ["standard", "retrospective"]
+            "example": [
+              "standard",
+              "retrospective"
+            ]
           },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
             "example": "newly_created",
-            "enum": ["newly_created", "newly_created_and_active"]
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
           },
           "state": {
             "type": "string",
             "description": "The state of the workflow (e.g. is it draft, or disabled)",
             "example": "active",
-            "enum": ["active", "disabled", "draft", "error"]
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
           },
           "steps": {
             "type": "array",
@@ -23950,7 +27231,10 @@
             }
           ],
           "runs_from": "2021-08-17T13:28:57.801578Z",
-          "runs_on_incident_modes": ["standard", "retrospective"],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -24018,7 +27302,10 @@
           "conditions_apply_over_delay": false,
           "for_seconds": 60
         },
-        "required": ["for_seconds", "conditions_apply_over_delay"]
+        "required": [
+          "for_seconds",
+          "conditions_apply_over_delay"
+        ]
       },
       "WorkflowSlim": {
         "type": "object",
@@ -24260,22 +27547,37 @@
             "items": {
               "type": "string",
               "example": "test",
-              "enum": ["standard", "test", "retrospective"]
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
             },
             "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": ["standard", "retrospective"]
+            "example": [
+              "standard",
+              "retrospective"
+            ]
           },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
             "example": "newly_created",
-            "enum": ["newly_created", "newly_created_and_active"]
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
           },
           "state": {
             "type": "string",
             "description": "The state of the workflow (e.g. is it draft, or disabled)",
             "example": "active",
-            "enum": ["active", "disabled", "draft", "error"]
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
           },
           "steps": {
             "type": "array",
@@ -24488,7 +27790,10 @@
             }
           ],
           "runs_from": "2021-08-17T13:28:57.801578Z",
-          "runs_on_incident_modes": ["standard", "retrospective"],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -24549,6 +27854,10 @@
     {
       "name": "Custom Fields V2",
       "description": "Manage custom fields.\n\nCustom fields are used to attach metadata to incidents, which you can use when searching\nfor incidents in the dashboard, triggering workflows, building announcement rules or for\nyour own data needs.\n\nEach field has a type:\n\n- Single-select, single value selected from a predefined list of options (e.g. Detection Method)\n- Multi-select, as above but you can pick more than one option (e.g. Affected Teams)\n- Text, freeform text field (e.g. Customer ID)\n- Link, link URL that is synced to Slack bookmarks on the incident channel (e.g. External Status Page)\n- Number, integer or fractional numbers (e.g. # Customers Affected)\n\nSingle-select and multi-select fields can also be powered by the Catalog. This will mean a field has a\ncatalog_type_id, which links it to the catalog type that it references.\n\nWe may add more custom field types in the future - we'd love to hear any other types you'd like to use!\n"
+    },
+    {
+      "name": "Escalations V2",
+      "description": "Create and manage escalations.\n\nWith incident.io On-call you can create escalation paths that describe how a page should\nbe escalated to people and schedules, and create escalations that will execute those\npaths.\n"
     },
     {
       "name": "Follow-ups V2",
@@ -24630,7 +27939,9 @@
   "x-webhooks": {
     "/x-webhooks/private_incident.action_created_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentActionCreatedV1",
         "description": "This webhook is emitted whenever a follow-up for a private incident is created.",
         "operationId": "Webhooks#PrivateIncidentActionCreatedV1",
@@ -24656,7 +27967,9 @@
     },
     "/x-webhooks/private_incident.action_updated_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentActionUpdatedV1",
         "description": "This webhook is emitted whenever a follow-up for a private incident is updated.",
         "operationId": "Webhooks#PrivateIncidentActionUpdatedV1",
@@ -24682,7 +27995,9 @@
     },
     "/x-webhooks/private_incident.follow_up_created_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentFollowUpCreatedV1",
         "description": "This webhook is emitted whenever a follow-up for a private incident is created.",
         "operationId": "Webhooks#PrivateIncidentFollowUpCreatedV1",
@@ -24708,7 +28023,9 @@
     },
     "/x-webhooks/private_incident.follow_up_updated_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentFollowUpUpdatedV1",
         "description": "This webhook is emitted whenever a follow-up for a private incident is updated.",
         "operationId": "Webhooks#PrivateIncidentFollowUpUpdatedV1",
@@ -24734,7 +28051,9 @@
     },
     "/x-webhooks/private_incident.incident_created_v2": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentIncidentCreatedV2",
         "description": "This webhook is emitted whenever a new private incident is created.",
         "operationId": "Webhooks#PrivateIncidentIncidentCreatedV2",
@@ -24760,7 +28079,9 @@
     },
     "/x-webhooks/private_incident.incident_updated_v2": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentIncidentUpdatedV2",
         "description": "This webhook is emitted whenever a private incident is updated.",
         "operationId": "Webhooks#PrivateIncidentIncidentUpdatedV2",
@@ -24786,7 +28107,9 @@
     },
     "/x-webhooks/private_incident.membership_granted_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentMembershipGrantedV1",
         "description": "This webhook is emitted whenever a user is given access to a private incident.",
         "operationId": "Webhooks#PrivateIncidentMembershipGrantedV1",
@@ -24814,7 +28137,9 @@
     },
     "/x-webhooks/private_incident.membership_revoked_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PrivateIncidentMembershipRevokedV1",
         "description": "This webhook is emitted whenever a user's access to a private incident is revoked.",
         "operationId": "Webhooks#PrivateIncidentMembershipRevokedV1",
@@ -24842,7 +28167,9 @@
     },
     "/x-webhooks/public_incident.action_created_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentActionCreatedV1",
         "description": "This webhook is emitted whenever a follow-up is created.",
         "operationId": "Webhooks#PublicIncidentActionCreatedV1",
@@ -24887,7 +28214,9 @@
     },
     "/x-webhooks/public_incident.action_updated_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentActionUpdatedV1",
         "description": "This webhook is emitted whenever a follow-up is updated.",
         "operationId": "Webhooks#PublicIncidentActionUpdatedV1",
@@ -24932,7 +28261,9 @@
     },
     "/x-webhooks/public_incident.follow_up_created_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentFollowUpCreatedV1",
         "description": "This webhook is emitted whenever a follow-up is created.",
         "operationId": "Webhooks#PublicIncidentFollowUpCreatedV1",
@@ -24977,7 +28308,9 @@
     },
     "/x-webhooks/public_incident.follow_up_updated_v1": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentFollowUpUpdatedV1",
         "description": "This webhook is emitted whenever a follow-up is updated.",
         "operationId": "Webhooks#PublicIncidentFollowUpUpdatedV1",
@@ -25022,7 +28355,9 @@
     },
     "/x-webhooks/public_incident.incident_created_v2": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentIncidentCreatedV2",
         "description": "This webhook is emitted whenever a new incident is created.",
         "operationId": "Webhooks#PublicIncidentIncidentCreatedV2",
@@ -25071,7 +28406,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -25162,7 +28500,9 @@
                     "permalink": "https://app.incident.io/incidents/123",
                     "postmortem_document_url": "https://docs.google.com/my_doc_id",
                     "reference": "INC-123",
-                    "related_incidents": ["INC-237"],
+                    "related_incidents": [
+                      "INC-237"
+                    ],
                     "severity": {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Issues with **low impact**.",
@@ -25191,7 +28531,9 @@
     },
     "/x-webhooks/public_incident.incident_status_updated_v2": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentIncidentStatusUpdatedV2",
         "description": "This webhook is emitted whenever an incident's status changes.",
         "operationId": "Webhooks#PublicIncidentIncidentStatusUpdatedV2",
@@ -25241,7 +28583,10 @@
                           "values": [
                             {
                               "value_catalog_entry": {
-                                "aliases": ["lawrence@incident.io", "lawrence"],
+                                "aliases": [
+                                  "lawrence@incident.io",
+                                  "lawrence"
+                                ],
                                 "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "name": "Primary On-call"
@@ -25379,7 +28724,9 @@
     },
     "/x-webhooks/public_incident.incident_updated_v2": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "PublicIncidentIncidentUpdatedV2",
         "description": "This webhook is emitted whenever an incident is updated.",
         "operationId": "Webhooks#PublicIncidentIncidentUpdatedV2",
@@ -25428,7 +28775,10 @@
                         "values": [
                           {
                             "value_catalog_entry": {
-                              "aliases": ["lawrence@incident.io", "lawrence"],
+                              "aliases": [
+                                "lawrence@incident.io",
+                                "lawrence"
+                              ],
                               "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "name": "Primary On-call"
@@ -25519,7 +28869,9 @@
                     "permalink": "https://app.incident.io/incidents/123",
                     "postmortem_document_url": "https://docs.google.com/my_doc_id",
                     "reference": "INC-123",
-                    "related_incidents": ["INC-237"],
+                    "related_incidents": [
+                      "INC-237"
+                    ],
                     "severity": {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Issues with **low impact**.",
@@ -25548,7 +28900,9 @@
     },
     "/x-audit-logs/alert_route.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertRouteCreatedV1",
         "description": "This entry is created whenever an alert route is created",
         "operationId": "Audit logs#AlertRouteCreatedV1",
@@ -25593,7 +28947,9 @@
     },
     "/x-audit-logs/alert_route.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertRouteDeletedV1",
         "description": "This entry is created whenever an alert route is deleted",
         "operationId": "Audit logs#AlertRouteDeletedV1",
@@ -25638,7 +28994,9 @@
     },
     "/x-audit-logs/alert_route.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertRouteUpdatedV1",
         "description": "This entry is created whenever an alert route is updated",
         "operationId": "Audit logs#AlertRouteUpdatedV1",
@@ -25683,7 +29041,9 @@
     },
     "/x-audit-logs/alert_schema.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertSchemaUpdatedV1",
         "description": "This entry is created whenever alert attributes are updated",
         "operationId": "Audit logs#AlertSchemaUpdatedV1",
@@ -25728,7 +29088,9 @@
     },
     "/x-audit-logs/alert_source_config.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertSourceConfigCreatedV1",
         "description": "This entry is created whenever an alert source is created",
         "operationId": "Audit logs#AlertSourceConfigCreatedV1",
@@ -25773,7 +29135,9 @@
     },
     "/x-audit-logs/alert_source_config.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertSourceConfigDeletedV1",
         "description": "This entry is created whenever an alert source is deleted",
         "operationId": "Audit logs#AlertSourceConfigDeletedV1",
@@ -25818,7 +29182,9 @@
     },
     "/x-audit-logs/alert_source_config.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AlertSourceConfigUpdatedV1",
         "description": "This entry is created whenever an alert source is updated",
         "operationId": "Audit logs#AlertSourceConfigUpdatedV1",
@@ -25863,7 +29229,9 @@
     },
     "/x-audit-logs/announcement_rule.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AnnouncementRuleCreatedV1",
         "description": "This entry is created whenever a announcement rule is created",
         "operationId": "Audit logs#AnnouncementRuleCreatedV1",
@@ -25908,7 +29276,9 @@
     },
     "/x-audit-logs/announcement_rule.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AnnouncementRuleDeletedV1",
         "description": "This entry is created whenever a announcement rule is deleted",
         "operationId": "Audit logs#AnnouncementRuleDeletedV1",
@@ -25953,7 +29323,9 @@
     },
     "/x-audit-logs/announcement_rule.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "AnnouncementRuleUpdatedV1",
         "description": "This entry is created whenever a announcement rule is updated",
         "operationId": "Audit logs#AnnouncementRuleUpdatedV1",
@@ -25998,7 +29370,9 @@
     },
     "/x-audit-logs/api_key.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ApiKeyCreatedV1",
         "description": "This entry is created whenever a api key is created",
         "operationId": "Audit logs#ApiKeyCreatedV1",
@@ -26043,7 +29417,9 @@
     },
     "/x-audit-logs/api_key.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ApiKeyDeletedV1",
         "description": "This entry is created whenever a api key is deleted",
         "operationId": "Audit logs#ApiKeyDeletedV1",
@@ -26088,7 +29464,9 @@
     },
     "/x-audit-logs/catalog_type.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CatalogTypeCreatedV1",
         "description": "This entry is created whenever a catalog type is created",
         "operationId": "Audit logs#CatalogTypeCreatedV1",
@@ -26133,7 +29511,9 @@
     },
     "/x-audit-logs/catalog_type.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CatalogTypeDeletedV1",
         "description": "This entry is created whenever a catalog type is deleted",
         "operationId": "Audit logs#CatalogTypeDeletedV1",
@@ -26178,7 +29558,9 @@
     },
     "/x-audit-logs/catalog_type.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CatalogTypeUpdatedV1",
         "description": "This entry is created whenever a catalog type is updated",
         "operationId": "Audit logs#CatalogTypeUpdatedV1",
@@ -26223,7 +29605,9 @@
     },
     "/x-audit-logs/custom_field.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CustomFieldCreatedV1",
         "description": "This entry is created whenever a custom field is created",
         "operationId": "Audit logs#CustomFieldCreatedV1",
@@ -26268,7 +29652,9 @@
     },
     "/x-audit-logs/custom_field.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CustomFieldDeletedV1",
         "description": "This entry is created whenever a custom field is deleted",
         "operationId": "Audit logs#CustomFieldDeletedV1",
@@ -26313,7 +29699,9 @@
     },
     "/x-audit-logs/custom_field.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "CustomFieldUpdatedV1",
         "description": "This entry is created whenever a custom field is updated",
         "operationId": "Audit logs#CustomFieldUpdatedV1",
@@ -26358,7 +29746,9 @@
     },
     "/x-audit-logs/debrief_invite_rule.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "DebriefInviteRuleCreatedV1",
         "description": "This entry is created whenever a debrief invite rule is created",
         "operationId": "Audit logs#DebriefInviteRuleCreatedV1",
@@ -26403,7 +29793,9 @@
     },
     "/x-audit-logs/debrief_invite_rule.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "DebriefInviteRuleDeletedV1",
         "description": "This entry is created whenever a debrief invite rule is deleted",
         "operationId": "Audit logs#DebriefInviteRuleDeletedV1",
@@ -26448,7 +29840,9 @@
     },
     "/x-audit-logs/debrief_invite_rule.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "DebriefInviteRuleUpdatedV1",
         "description": "This entry is created whenever a debrief invite rule is updated",
         "operationId": "Audit logs#DebriefInviteRuleUpdatedV1",
@@ -26493,7 +29887,9 @@
     },
     "/x-audit-logs/escalation_path.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "EscalationPathCreatedV1",
         "description": "This entry is created whenever an escalation path is created",
         "operationId": "Audit logs#EscalationPathCreatedV1",
@@ -26538,7 +29934,9 @@
     },
     "/x-audit-logs/escalation_path.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "EscalationPathDeletedV1",
         "description": "This entry is created whenever an escalation path is deleted",
         "operationId": "Audit logs#EscalationPathDeletedV1",
@@ -26583,7 +29981,9 @@
     },
     "/x-audit-logs/escalation_path.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "EscalationPathUpdatedV1",
         "description": "This entry is created whenever an escalation path is updated",
         "operationId": "Audit logs#EscalationPathUpdatedV1",
@@ -26628,7 +30028,9 @@
     },
     "/x-audit-logs/follow_up_priority.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "FollowUpPriorityCreatedV1",
         "description": "This entry is created whenever a follow up priority is created",
         "operationId": "Audit logs#FollowUpPriorityCreatedV1",
@@ -26673,7 +30075,9 @@
     },
     "/x-audit-logs/follow_up_priority.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "FollowUpPriorityDeletedV1",
         "description": "This entry is created whenever a follow up priority is deleted",
         "operationId": "Audit logs#FollowUpPriorityDeletedV1",
@@ -26718,7 +30122,9 @@
     },
     "/x-audit-logs/follow_up_priority.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "FollowUpPriorityUpdatedV1",
         "description": "This entry is created whenever a follow up priority is updated",
         "operationId": "Audit logs#FollowUpPriorityUpdatedV1",
@@ -26763,7 +30169,9 @@
     },
     "/x-audit-logs/incident_duration_metric.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentDurationMetricCreatedV1",
         "description": "This entry is created whenever a incident duration metric is created",
         "operationId": "Audit logs#IncidentDurationMetricCreatedV1",
@@ -26808,7 +30216,9 @@
     },
     "/x-audit-logs/incident_duration_metric.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentDurationMetricDeletedV1",
         "description": "This entry is created whenever a incident duration metric is deleted",
         "operationId": "Audit logs#IncidentDurationMetricDeletedV1",
@@ -26853,7 +30263,9 @@
     },
     "/x-audit-logs/incident_duration_metric.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentDurationMetricUpdatedV1",
         "description": "This entry is created whenever a incident duration metric is updated",
         "operationId": "Audit logs#IncidentDurationMetricUpdatedV1",
@@ -26898,7 +30310,9 @@
     },
     "/x-audit-logs/incident_role.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentRoleCreatedV1",
         "description": "This entry is created whenever a incident role is created",
         "operationId": "Audit logs#IncidentRoleCreatedV1",
@@ -26943,7 +30357,9 @@
     },
     "/x-audit-logs/incident_role.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentRoleDeletedV1",
         "description": "This entry is created whenever a incident role is deleted",
         "operationId": "Audit logs#IncidentRoleDeletedV1",
@@ -26988,7 +30404,9 @@
     },
     "/x-audit-logs/incident_role.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentRoleUpdatedV1",
         "description": "This entry is created whenever a incident role is updated",
         "operationId": "Audit logs#IncidentRoleUpdatedV1",
@@ -27033,7 +30451,9 @@
     },
     "/x-audit-logs/incident_status.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentStatusCreatedV1",
         "description": "This entry is created whenever a incident status is created",
         "operationId": "Audit logs#IncidentStatusCreatedV1",
@@ -27078,7 +30498,9 @@
     },
     "/x-audit-logs/incident_status.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentStatusDeletedV1",
         "description": "This entry is created whenever a incident status is deleted",
         "operationId": "Audit logs#IncidentStatusDeletedV1",
@@ -27123,7 +30545,9 @@
     },
     "/x-audit-logs/incident_status.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentStatusUpdatedV1",
         "description": "This entry is created whenever a incident status is updated",
         "operationId": "Audit logs#IncidentStatusUpdatedV1",
@@ -27168,7 +30592,9 @@
     },
     "/x-audit-logs/incident_timestamp.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTimestampCreatedV1",
         "description": "This entry is created whenever a incident timestamp is created",
         "operationId": "Audit logs#IncidentTimestampCreatedV1",
@@ -27213,7 +30639,9 @@
     },
     "/x-audit-logs/incident_timestamp.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTimestampDeletedV1",
         "description": "This entry is created whenever a incident timestamp is deleted",
         "operationId": "Audit logs#IncidentTimestampDeletedV1",
@@ -27258,7 +30686,9 @@
     },
     "/x-audit-logs/incident_timestamp.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTimestampUpdatedV1",
         "description": "This entry is created whenever a incident timestamp is updated",
         "operationId": "Audit logs#IncidentTimestampUpdatedV1",
@@ -27303,7 +30733,9 @@
     },
     "/x-audit-logs/incident_type.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTypeCreatedV1",
         "description": "This entry is created whenever a incident type is created",
         "operationId": "Audit logs#IncidentTypeCreatedV1",
@@ -27348,7 +30780,9 @@
     },
     "/x-audit-logs/incident_type.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTypeDeletedV1",
         "description": "This entry is created whenever a incident type is deleted",
         "operationId": "Audit logs#IncidentTypeDeletedV1",
@@ -27393,7 +30827,9 @@
     },
     "/x-audit-logs/incident_type.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IncidentTypeUpdatedV1",
         "description": "This entry is created whenever a incident type is updated",
         "operationId": "Audit logs#IncidentTypeUpdatedV1",
@@ -27438,7 +30874,9 @@
     },
     "/x-audit-logs/integration.installed.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IntegrationInstalledV1",
         "description": "This entry is created whenever an integration is installed",
         "operationId": "Audit logs#IntegrationInstalledV1",
@@ -27483,7 +30921,9 @@
     },
     "/x-audit-logs/integration.uninstalled.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "IntegrationUninstalledV1",
         "description": "This entry is created whenever an integration is uninstalled",
         "operationId": "Audit logs#IntegrationUninstalledV1",
@@ -27528,7 +30968,9 @@
     },
     "/x-audit-logs/internal_status_page.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "InternalStatusPageCreatedV1",
         "description": "This entry is created whenever an internal status page is created",
         "operationId": "Audit logs#InternalStatusPageCreatedV1",
@@ -27573,7 +31015,9 @@
     },
     "/x-audit-logs/internal_status_page.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "InternalStatusPageDeletedV1",
         "description": "This entry is created whenever an internal status page is deleted",
         "operationId": "Audit logs#InternalStatusPageDeletedV1",
@@ -27618,7 +31062,9 @@
     },
     "/x-audit-logs/internal_status_page.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "InternalStatusPageUpdatedV1",
         "description": "This entry is created whenever an internal status page has its configuration updated",
         "operationId": "Audit logs#InternalStatusPageUpdatedV1",
@@ -27663,7 +31109,9 @@
     },
     "/x-audit-logs/nudge.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "NudgeCreatedV1",
         "description": "This entry is created whenever a nudge is created",
         "operationId": "Audit logs#NudgeCreatedV1",
@@ -27708,7 +31156,9 @@
     },
     "/x-audit-logs/nudge.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "NudgeDeletedV1",
         "description": "This entry is created whenever a nudge is deleted",
         "operationId": "Audit logs#NudgeDeletedV1",
@@ -27753,7 +31203,9 @@
     },
     "/x-audit-logs/nudge.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "NudgeUpdatedV1",
         "description": "This entry is created whenever a nudge is updated",
         "operationId": "Audit logs#NudgeUpdatedV1",
@@ -27798,7 +31250,9 @@
     },
     "/x-audit-logs/policy.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PolicyCreatedV1",
         "description": "This entry is created whenever a policy is created",
         "operationId": "Audit logs#PolicyCreatedV1",
@@ -27843,7 +31297,9 @@
     },
     "/x-audit-logs/policy.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PolicyDeletedV1",
         "description": "This entry is created whenever a policy is deleted",
         "operationId": "Audit logs#PolicyDeletedV1",
@@ -27888,7 +31344,9 @@
     },
     "/x-audit-logs/policy.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PolicyUpdatedV1",
         "description": "This entry is created whenever a policy is updated",
         "operationId": "Audit logs#PolicyUpdatedV1",
@@ -27933,7 +31391,9 @@
     },
     "/x-audit-logs/post_incident_task.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PostIncidentTaskCreatedV1",
         "description": "This entry is created whenever a post-incident task is created",
         "operationId": "Audit logs#PostIncidentTaskCreatedV1",
@@ -27978,7 +31438,9 @@
     },
     "/x-audit-logs/post_incident_task.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PostIncidentTaskDeletedV1",
         "description": "This entry is created whenever a post-incident task is deleted",
         "operationId": "Audit logs#PostIncidentTaskDeletedV1",
@@ -28023,7 +31485,9 @@
     },
     "/x-audit-logs/post_incident_task.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PostIncidentTaskUpdatedV1",
         "description": "This entry is created whenever a post-incident task is updated",
         "operationId": "Audit logs#PostIncidentTaskUpdatedV1",
@@ -28068,7 +31532,9 @@
     },
     "/x-audit-logs/private_incident.access_attempted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PrivateIncidentAccessAttemptedV1",
         "description": "This entry is created whenever someone attempts to access a private incident.",
         "operationId": "Audit logs#PrivateIncidentAccessAttemptedV1",
@@ -28116,7 +31582,9 @@
     },
     "/x-audit-logs/private_incident.access_requested.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PrivateIncidentAccessRequestedV1",
         "description": "This entry is created whenever someone requests access to a private incident.",
         "operationId": "Audit logs#PrivateIncidentAccessRequestedV1",
@@ -28161,7 +31629,9 @@
     },
     "/x-audit-logs/private_incident_membership.granted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PrivateIncidentMembershipGrantedV1",
         "description": "This entry is created whenever someone is granted access to a private incident. If they have the 'manage private incidents' permission, then it'll appear that the system has given them access to the incident.",
         "operationId": "Audit logs#PrivateIncidentMembershipGrantedV1",
@@ -28211,7 +31681,9 @@
     },
     "/x-audit-logs/private_incident_membership.revoked.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "PrivateIncidentMembershipRevokedV1",
         "description": "This entry is created whenever someone's access to a private incident is revoked.",
         "operationId": "Audit logs#PrivateIncidentMembershipRevokedV1",
@@ -28261,7 +31733,9 @@
     },
     "/x-audit-logs/rbac_role.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "RbacRoleCreatedV1",
         "description": "This entry is created whenever a rbac role is created",
         "operationId": "Audit logs#RbacRoleCreatedV1",
@@ -28306,7 +31780,9 @@
     },
     "/x-audit-logs/rbac_role.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "RbacRoleDeletedV1",
         "description": "This entry is created whenever a rbac role is deleted",
         "operationId": "Audit logs#RbacRoleDeletedV1",
@@ -28351,7 +31827,9 @@
     },
     "/x-audit-logs/rbac_role.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "RbacRoleUpdatedV1",
         "description": "This entry is created whenever a rbac role is updated",
         "operationId": "Audit logs#RbacRoleUpdatedV1",
@@ -28396,7 +31874,9 @@
     },
     "/x-audit-logs/schedule.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ScheduleCreatedV1",
         "description": "This entry is created whenever a schedule is created",
         "operationId": "Audit logs#ScheduleCreatedV1",
@@ -28441,7 +31921,9 @@
     },
     "/x-audit-logs/schedule.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ScheduleDeletedV1",
         "description": "This entry is created whenever a schedule is deleted",
         "operationId": "Audit logs#ScheduleDeletedV1",
@@ -28486,7 +31968,9 @@
     },
     "/x-audit-logs/schedule.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ScheduleUpdatedV1",
         "description": "This entry is created whenever a schedule is updated",
         "operationId": "Audit logs#ScheduleUpdatedV1",
@@ -28531,7 +32015,9 @@
     },
     "/x-audit-logs/scim_group.role_mappings_updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "ScimGroupRoleMappingsUpdatedV1",
         "description": "This entry is created whenever a SCIM group is mapped to a new RBAC role",
         "operationId": "Audit logs#ScimGroupRoleMappingsUpdatedV1",
@@ -28582,7 +32068,9 @@
     },
     "/x-audit-logs/severity.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "SeverityCreatedV1",
         "description": "This entry is created whenever a severity is created",
         "operationId": "Audit logs#SeverityCreatedV1",
@@ -28627,7 +32115,9 @@
     },
     "/x-audit-logs/severity.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "SeverityDeletedV1",
         "description": "This entry is created whenever a severity is deleted",
         "operationId": "Audit logs#SeverityDeletedV1",
@@ -28672,7 +32162,9 @@
     },
     "/x-audit-logs/severity.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "SeverityUpdatedV1",
         "description": "This entry is created whenever a severity is updated",
         "operationId": "Audit logs#SeverityUpdatedV1",
@@ -28717,7 +32209,9 @@
     },
     "/x-audit-logs/status_page.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageCreatedV1",
         "description": "This entry is created whenever a status page is created",
         "operationId": "Audit logs#StatusPageCreatedV1",
@@ -28762,7 +32256,9 @@
     },
     "/x-audit-logs/status_page.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageDeletedV1",
         "description": "This entry is created whenever a status page is deleted",
         "operationId": "Audit logs#StatusPageDeletedV1",
@@ -28807,7 +32303,9 @@
     },
     "/x-audit-logs/status_page.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageUpdatedV1",
         "description": "This entry is created whenever a status page has its configuration updated",
         "operationId": "Audit logs#StatusPageUpdatedV1",
@@ -28852,7 +32350,9 @@
     },
     "/x-audit-logs/status_page_sub_page.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageSubPageCreatedV1",
         "description": "This entry is created whenever a status page sub-page is created",
         "operationId": "Audit logs#StatusPageSubPageCreatedV1",
@@ -28897,7 +32397,9 @@
     },
     "/x-audit-logs/status_page_sub_page.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageSubPageDeletedV1",
         "description": "This entry is created whenever a status page sub-page is deleted",
         "operationId": "Audit logs#StatusPageSubPageDeletedV1",
@@ -28942,7 +32444,9 @@
     },
     "/x-audit-logs/status_page_sub_page.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageSubPageUpdatedV1",
         "description": "This entry is created whenever a status page sub-page has its configuration updated",
         "operationId": "Audit logs#StatusPageSubPageUpdatedV1",
@@ -28987,7 +32491,9 @@
     },
     "/x-audit-logs/status_page_template.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageTemplateCreatedV1",
         "description": "This entry is created whenever a status page template is created",
         "operationId": "Audit logs#StatusPageTemplateCreatedV1",
@@ -29032,7 +32538,9 @@
     },
     "/x-audit-logs/status_page_template.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageTemplateDeletedV1",
         "description": "This entry is created whenever a status page template is deleted",
         "operationId": "Audit logs#StatusPageTemplateDeletedV1",
@@ -29077,7 +32585,9 @@
     },
     "/x-audit-logs/status_page_template.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "StatusPageTemplateUpdatedV1",
         "description": "This entry is created whenever a status page template is updated",
         "operationId": "Audit logs#StatusPageTemplateUpdatedV1",
@@ -29122,7 +32632,9 @@
     },
     "/x-audit-logs/user.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "UserCreatedV1",
         "description": "This entry is created whenever a user is created",
         "operationId": "Audit logs#UserCreatedV1",
@@ -29167,7 +32679,9 @@
     },
     "/x-audit-logs/user.deactivated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "UserDeactivatedV1",
         "description": "This entry is created whenever a user is deactivated",
         "operationId": "Audit logs#UserDeactivatedV1",
@@ -29212,7 +32726,9 @@
     },
     "/x-audit-logs/user.reinstated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "UserReinstatedV1",
         "description": "This entry is created when a user is reinstated after being deactivated",
         "operationId": "Audit logs#UserReinstatedV1",
@@ -29257,7 +32773,9 @@
     },
     "/x-audit-logs/user.role_memberships_updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "UserRoleMembershipsUpdatedV1",
         "description": "This entry is created whenever a user's role memberships are changed.",
         "operationId": "Audit logs#UserRoleMembershipsUpdatedV1",
@@ -29308,7 +32826,9 @@
     },
     "/x-audit-logs/user.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "UserUpdatedV1",
         "description": "This entry is created whenever a user is updated",
         "operationId": "Audit logs#UserUpdatedV1",
@@ -29353,7 +32873,9 @@
     },
     "/x-audit-logs/workflow.created.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "WorkflowCreatedV1",
         "description": "This entry is created whenever a workflow is created",
         "operationId": "Audit logs#WorkflowCreatedV1",
@@ -29398,7 +32920,9 @@
     },
     "/x-audit-logs/workflow.deleted.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "WorkflowDeletedV1",
         "description": "This entry is created whenever a workflow is deleted",
         "operationId": "Audit logs#WorkflowDeletedV1",
@@ -29443,7 +32967,9 @@
     },
     "/x-audit-logs/workflow.updated.1": {
       "get": {
-        "tags": ["Audit logs"],
+        "tags": [
+          "Audit logs"
+        ],
         "summary": "WorkflowUpdatedV1",
         "description": "This entry is created whenever a workflow is updated",
         "operationId": "Audit logs#WorkflowUpdatedV1",

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -199,11 +199,16 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 				}
 			} else {
 				logger.Log("msg", "catalog type does not already exist, creating")
+				categories := lo.Map(model.Categories, func(category string, _ int) client.CreateTypeRequestBodyCategories {
+					return client.CreateTypeRequestBodyCategories(category)
+				})
+
 				result, err := cl.CatalogV2CreateTypeWithResponse(ctx, client.CreateTypeRequestBody{
 					Name:          model.Name,
 					Description:   model.Description,
 					Ranked:        &model.Ranked,
 					TypeName:      lo.ToPtr(model.TypeName),
+					Categories:    lo.ToPtr(categories),
 					Annotations:   lo.ToPtr(getAnnotations(cfg.SyncID)),
 					SourceRepoUrl: &opt.SourceRepoUrl,
 				})
@@ -271,6 +276,10 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 							path = &newPath
 						}
 
+						updatedCatalogType.Categories = lo.Map(model.Categories, func(category string, _ int) client.CatalogTypeV2Categories {
+							return client.CatalogTypeV2Categories(category)
+						})
+
 						updatedCatalogType.Schema.Attributes = append(updatedCatalogType.Schema.Attributes, client.CatalogTypeAttributeV2{
 							Id:                *attr.Id,
 							Name:              attr.Name,
@@ -324,11 +333,16 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 					}
 				}
 
+				categories := lo.Map(model.Categories, func(category string, _ int) client.UpdateTypeRequestBodyCategories {
+					return client.UpdateTypeRequestBodyCategories(category)
+				})
+
 				logger.Log("msg", "updating catalog type", "catalog_type_id", catalogType.Id)
 				result, err := cl.CatalogV2UpdateTypeWithResponse(ctx, catalogType.Id, client.CatalogV2UpdateTypeJSONRequestBody{
 					Name:          model.Name,
 					Description:   model.Description,
 					Ranked:        &model.Ranked,
+					Categories:    lo.ToPtr(categories),
 					Annotations:   lo.ToPtr(getAnnotations(cfg.SyncID)),
 					SourceRepoUrl: &opt.SourceRepoUrl,
 				})

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -18,6 +18,7 @@ type CatalogTypeModel struct {
 	TypeName        string
 	Ranked          bool
 	Attributes      []client.CatalogTypeAttributePayloadV2
+	Categories      []string
 	SourceAttribute *Attribute // tracks the origin attribute, if an enum model
 	SourceRepoUrl   string
 }
@@ -39,6 +40,7 @@ func MarshalType(output *Output) (base *CatalogTypeModel, enumTypes []*CatalogTy
 		TypeName:    output.TypeName,
 		Ranked:      output.Ranked,
 		Attributes:  []client.CatalogTypeAttributePayloadV2{},
+		Categories:  output.Categories,
 	}
 	for _, attr := range output.Attributes {
 		var attrType string

--- a/output/output.go
+++ b/output/output.go
@@ -17,6 +17,7 @@ type Output struct {
 	Ranked      bool         `json:"ranked"`
 	Source      SourceConfig `json:"source"`
 	Attributes  []*Attribute `json:"attributes"`
+	Categories  []string     `json:"categories"`
 }
 
 func (o Output) Validate() error {


### PR DESCRIPTION
Categories are an optional way of organising your catalog.

Example diff:
```
  ✔ Custom["DocsTeam"] (id=01HSTDDA8AAPGNVYFEAWFZD21V)
    map[string]any{
    	"annotations": map[string]any{"incident.io/catalog-importer/last-sync-at": string("2024-06-26T22:46:36+01:00"), "incident.io/catalog-importer/sync-id": string("incident-io/catalog"), "incident.io/catalog-importer/version": string("2.2.3")},
  - 	"categories":  []any{},
  + 	"categories":  []any{string("team")},
    	"color":       string("cyan"),
    	"created_at":  string("2024-03-25T09:00:08.944Z"),
    	... // 12 identical entries
    }
```