### PR TITLE
Make sure we save the context we cancel on Ctrl-C

### DIFF
--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -76,7 +76,7 @@ func Run(ctx context.Context) (err error) {
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 
 	// Root context to the application.
-	_, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Setup signal handling.


### PR DESCRIPTION
So that control-c kills the app properly.

Fixes https://github.com/incident-io/catalog-importer/issues/133