### PR TITLE
schema_only for attributes

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -473,7 +473,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 				logger.Log("msg", "reconciling catalog entries", "output", outputType.TypeName)
 				catalogType := catalogTypesByOutput[outputType.TypeName]
 
-				err = reconcile.Entries(ctx, logger, entriesClient, catalogType, entryModels, newEntriesProgress(!opt.DryRun))
+				err = reconcile.Entries(ctx, logger, entriesClient, outputType, catalogType, entryModels, newEntriesProgress(!opt.DryRun))
 				if err != nil {
 					return errors.Wrap(err, fmt.Sprintf("outputs (type_name = '%s'): reconciling catalog entries", outputType.TypeName))
 				}
@@ -509,7 +509,7 @@ func (opt *SyncOptions) Run(ctx context.Context, logger kitlog.Logger, cfg *conf
 
 				OUT("\n    ↻ %s (enum)", enumModel.TypeName)
 				catalogType := catalogTypesByOutput[enumModel.TypeName]
-				err := reconcile.Entries(ctx, logger, entriesClient, catalogType, enumModels, newEntriesProgress(!opt.DryRun))
+				err := reconcile.Entries(ctx, logger, entriesClient, outputType, catalogType, enumModels, newEntriesProgress(!opt.DryRun))
 				if err != nil {
 					return errors.Wrap(err,
 						fmt.Sprintf("outputs (type_name = '%s'): enum for attribute (id = '%s'): %s: reconciling catalog entries",

--- a/config/reference.jsonnet
+++ b/config/reference.jsonnet
@@ -228,6 +228,12 @@
               //
               // Will default to the id of this attribute.
               source: '$.metadata.description',
+
+              // If true we will only create the attribute in the schema and won't sync
+              // the value of the attribute. This is useful when you want to specify the
+              // schema but leave this field available to be controlled from the dashboard
+              // manually, separately from the importer.
+              schema_only: false,
             },
 
             // Most of the time you can be much less verbose, as source will

--- a/output/output.go
+++ b/output/output.go
@@ -57,6 +57,7 @@ type Attribute struct {
 	Enum              *AttributeEnum `json:"enum"`
 	BacklinkAttribute null.String    `json:"backlink_attribute"`
 	Path              []string       `json:"path"`
+	SchemaOnly        bool           `json:"schema_only"`
 }
 
 func (a Attribute) Validate() error {


### PR DESCRIPTION
Allow specifying that an attribute is 'schema_only' so that we sync the schema but preserve any values modified in the dashboard, rather than syncing the values we get from our source.