### PR TITLE
The sample config shouldn't depend on Linear integration being installed

### DIFF
--- a/docs/simple/importer.jsonnet
+++ b/docs/simple/importer.jsonnet
@@ -74,12 +74,6 @@ local catalog = import 'catalog.jsonnet';
               source: '$.alert_channel',
             },
             {
-              id: 'linear_team',
-              name: 'Linear team',
-              type: 'LinearTeam',
-              source: '$.linear_team',
-            },
-            {
               id: 'members',
               name: 'Members',
               type: 'User',


### PR DESCRIPTION
Norberto just hit this while using the sample config. Our sample config should just work, without needing any integrations installed.