### PR TITLE
docs: fix broken links and typos in source, config and deployment pages

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,10 +62,10 @@ View more details in [Outputs](outputs.md).
 
 ## File format
 
-Our config examples use [Jsonnet][jsonnet], a tool which makes working with more
+Our config examples use [Jsonnet](https://jsonnet.org/), a tool which makes working with more
 complex JSON files easier. The `catalog-importer` tool includes Jsonnet support,
 but installing language support to your editor will make the process a lot
-smoother (e.g. [VSCode extension][vscode]).
+smoother (e.g. [VSCode extension](https://github.com/grafana/vscode-jsonnet).
 
 If you don't want to use Jsonnet, switch to whichever you prefer of JSON or
 YAML: both will work fine.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Sync
           command: |
-            if [[ "${$CIRCLE_BRANCH}" == "master" ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" || "${CIRCLE_BRANCH}" == "main" ]]; then
               /tmp/catalog-importer sync --config importer.jsonnet
             else
               /tmp/catalog-importer sync --config importer.jsonnet --dry-run

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -9,7 +9,7 @@ These are:
 - [`local`](#local) from local files
 - [`backstage`](#backstage) for catalog data pulled from the Backstage API
 - [`github`](#github) to load from files in GitHub repositories
-- [`exec`](#local) from the output of a command
+- [`exec`](#exec) from the output of a command
 - [`graphql`](#graphql) for GraphQL APIs
 
 For each of the sources, we support parsing JSON, YAML – both single and


### PR DESCRIPTION
A very small PR that fixes some nits from the documentation after going through the TSE assessment. 

Might also roll in some higher level docs suggestions into this branch, or create a separate PR. They are mainly about adding more description in the docs about certain CMD commands, enriching some of the Docker setup instructions and adding some more information on use-cases (i.e when should you use this tool and when shouldn't you use this tool?) 

Still working on the above, but let me know if the suggested changes are good at the moment. 