### PR TITLE
Catch nil-deref when creating catalog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ catalog UI, and add a link in the UI from those types to your repository.
 
 We're happy to accept open-source contributions or feedback. Just open a
 PR/issue and we'll get back to you. This repo contains details on
-[how to get started with local development](./development.md), and [how to publish a new release](./release.md).
+[how to get started with local development](./development.md), and [how to publish a new release](./RELEASE.md).

--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -43,6 +43,13 @@ func EntriesClientFromClient(cl *client.ClientWithResponses) EntriesClient {
 				return nil, err
 			}
 
+			if result == nil {
+				return nil, errors.New("unexpected nil response")
+			}
+			if result.JSON201 == nil {
+				return nil, errors.New("unexpected nil 201 response")
+			}
+
 			return &result.JSON201.CatalogEntry, nil
 		},
 		Update: func(ctx context.Context, entry *client.CatalogEntryV2, payload client.UpdateEntryRequestBody) (*client.CatalogEntryV2, error) {


### PR DESCRIPTION
A customer reported an error dereferencing `result.JSON201.CatalogEntry`

All responses to this customer that morning were 201s, and `ParseCatalogV2CreateEntryResponse` appears solid

It's near impossible to debug this without identifying the exact request, so we're adding nil-handling and will look again if it reappears