### PR TITLE
Log response information on missing 201 response

### DIFF
--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -43,11 +43,13 @@ func EntriesClientFromClient(cl *client.ClientWithResponses) EntriesClient {
 				return nil, err
 			}
 
-			if result == nil {
-				return nil, errors.New("unexpected nil response")
-			}
 			if result.JSON201 == nil {
-				return nil, errors.New("unexpected nil 201 response")
+				return nil, errors.Errorf(
+					`unexpected nil 201 response. Status Code: %d, Content-Type: %s, Bytes Length: %d`,
+					result.HTTPResponse.StatusCode,
+					result.HTTPResponse.Header.Get("Content-Type"),
+					len(result.Body),
+				)
 			}
 
 			return &result.JSON201.CatalogEntry, nil


### PR DESCRIPTION
Related to #157

The nil dereference has been avoided however the catalog importer is still aborted mid-flow.
Despite erroring, the catalog entry is successfully created, so the next retry succeeds.

I can't reproduce this error locally, and from inspection our app code does not seem capable of returning an empty payload with a 201 status code.
The customer reported seeing a 201 status code in their proxy, and our logs indicate that we responded with a 592 Byte response, which is larger than many other successful requests from their previous run.

My only remaining theory is that the "Content-Type" header is missing - either it was never set or it was stripped mid-way.
This would prevent us from marshalling the response in `client.gen.go`