### PR TITLE
Set MaxConnsPerHost to 10 in the client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,9 @@ func New(ctx context.Context, apiKey, apiEndpoint, version string, logger kitlog
 	retryClient.Logger = &retryableHttpLogger{logger}
 	retryClient.RetryMax = maxRetries
 	retryClient.Backoff = attentiveBackoff
+	retryClient.HTTPClient.Transport = &http.Transport{
+		MaxConnsPerHost: 10,
+	}
 
 	base := retryClient.StandardClient()
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,168 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/samber/lo"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("New", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	var logger kitlog.Logger
+
+	BeforeEach(func() {
+		logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+	})
+
+	var (
+		server     *httptest.Server
+		testClient *ClientWithResponses
+		connCount  chan int
+	)
+
+	BeforeEach(func() {
+		// Channel to track active connections
+		connCount = make(chan int, 100)
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate something slow that keeps the connection alive
+			time.Sleep(100 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Replace the test server's listener with our counting listener
+		originalListener := server.Listener
+		countingListener := &connectionCountingListener{
+			Listener:  originalListener,
+			connCount: connCount,
+		}
+		server.Listener = countingListener
+
+		By(server.URL)
+
+		// Set up the client that we're testing
+		apiKey := lo.RandomString(10, lo.AlphanumericCharset)
+		c, clientErr := New(ctx, apiKey, server.URL, "1", logger)
+		Expect(clientErr).NotTo(HaveOccurred())
+		testClient = c
+	})
+
+	AfterEach(func() {
+		defer server.Close()
+	})
+
+	When("making concurrent requests", func() {
+		It("does not exceed the connection count", func() {
+			maxConns := 0
+			var mu sync.Mutex
+
+			// Start a goroutine to monitor connection counts
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for {
+					select {
+					case count := <-connCount:
+						mu.Lock()
+						if count > maxConns {
+							maxConns = count
+						}
+						mu.Unlock()
+					case <-time.After(2 * time.Second):
+						return
+					}
+				}
+			}()
+
+			requestCount := 200
+
+			var wg sync.WaitGroup
+			for i := 0; i < requestCount; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+
+					_, err := testClient.CatalogV2ListTypesWithResponse(ctx)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+			}
+
+			waitDone := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(waitDone)
+			}()
+
+			select {
+			case <-waitDone:
+			case <-time.After(10 * time.Second):
+				Fail("Timed out waiting for requests to complete")
+			}
+
+			// Wait for connection counter to finish
+			<-done
+
+			mu.Lock()
+			defer mu.Unlock()
+			Expect(maxConns).To(BeNumerically("<=", 10), "Should not open too many connections")
+		})
+	})
+})
+
+// connectionCountingListener wraps a net.Listener to count active connections
+type connectionCountingListener struct {
+	net.Listener
+	currentConns int
+	connMutex    sync.Mutex
+	connCount    chan int
+}
+
+func (l *connectionCountingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	l.connMutex.Lock()
+	l.currentConns++
+	l.connCount <- l.currentConns
+	l.connMutex.Unlock()
+
+	return &countingConn{
+		Conn:     conn,
+		listener: l,
+	}, nil
+}
+
+// countingConn wraps a net.Conn to track when connections are closed
+type countingConn struct {
+	net.Conn
+	listener *connectionCountingListener
+	once     sync.Once
+}
+
+func (c *countingConn) Close() error {
+	c.once.Do(func() {
+		c.listener.connMutex.Lock()
+		c.listener.currentConns--
+		c.listener.connCount <- c.listener.currentConns
+		c.listener.connMutex.Unlock()
+	})
+	return c.Conn.Close()
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -53,8 +53,6 @@ var _ = Describe("New", func() {
 		}
 		server.Listener = countingListener
 
-		By(server.URL)
-
 		// Set up the client that we're testing
 		apiKey := lo.RandomString(10, lo.AlphanumericCharset)
 		c, clientErr := New(ctx, apiKey, server.URL, "1", logger)
@@ -63,7 +61,7 @@ var _ = Describe("New", func() {
 	})
 
 	AfterEach(func() {
-		defer server.Close()
+		server.Close()
 	})
 
 	When("making concurrent requests", func() {

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "config")
+}


### PR DESCRIPTION
We've seen some cases where clients open a large number of connections to a single host. This PR sets `MaxConnsPerHost` to 10 in the underlying HTTP client, and also asserts that the implementation of that works correctly.