### PR TITLE
Don't include backlinks or path attributes when updating entries

### DIFF
--- a/output/marshal_test.go
+++ b/output/marshal_test.go
@@ -14,6 +14,49 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
+var _ = Describe("Attribute", func() {
+	Describe("IncludeInPayload", func() {
+		It("includes normal attributes", func() {
+			attr := Attribute{
+				ID:   "normal_attr",
+				Name: "Normal Attribute",
+				Type: null.StringFrom("String"),
+			}
+			Expect(attr.IncludeInPayload()).To(BeTrue())
+		})
+
+		It("excludes schema-only attributes", func() {
+			attr := Attribute{
+				ID:         "schema_only_attr",
+				Name:       "Schema Only Attribute",
+				Type:       null.StringFrom("String"),
+				SchemaOnly: true,
+			}
+			Expect(attr.IncludeInPayload()).To(BeFalse())
+		})
+
+		It("excludes backlink attributes", func() {
+			attr := Attribute{
+				ID:                "backlink_attr",
+				Name:              "Backlink Attribute",
+				Type:              null.StringFrom("OtherType"),
+				BacklinkAttribute: null.StringFrom("source_attr"),
+			}
+			Expect(attr.IncludeInPayload()).To(BeFalse())
+		})
+
+		It("excludes path attributes", func() {
+			attr := Attribute{
+				ID:   "path_attr",
+				Name: "Path Attribute",
+				Type: null.StringFrom("String"),
+				Path: []string{"step1", "step2"},
+			}
+			Expect(attr.IncludeInPayload()).To(BeFalse())
+		})
+	})
+})
+
 var _ = Describe("Marshalling data", func() {
 	var (
 		ctx               context.Context

--- a/output/output.go
+++ b/output/output.go
@@ -75,6 +75,23 @@ func (a Attribute) Validate() error {
 	)
 }
 
+func (a Attribute) IncludeInPayload() bool {
+	if a.SchemaOnly {
+		// These are left for the dashboard to set
+		return false
+	}
+	if a.BacklinkAttribute.Valid {
+		// Automatically set by the backlink
+		return false
+	}
+	if a.Path != nil {
+		// These are derived from other attributes
+		return false
+	}
+
+	return true
+}
+
 type AttributeEnum struct {
 	Name           string `json:"name"`
 	Description    string `json:"description"`

--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -223,7 +223,7 @@ func Entries(ctx context.Context, logger kitlog.Logger, cl EntriesClient, output
 	// value instead of setting it outselves.
 	attributesToUpdate := []*output.Attribute{}
 	for _, attr := range outputType.Attributes {
-		if !attr.SchemaOnly {
+		if attr.IncludeInPayload() {
 			attributesToUpdate = append(attributesToUpdate, attr)
 		}
 	}


### PR DESCRIPTION
Previously the CatalogV2 API would accept these and ignore them. However, the new CatalogV3 API validates that you're not including attribute values which won't do anything - meaning that managing backlinks and derived attributes with catalog-importer stopped working, unless you explicitly tagged these as `schema_only`.

This change means they are automatically treated as schema-only, without explicitly tagging them as such.