### PR TITLE
fix(help): remove reference to unsupported 'docs' command

### DIFF
--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -159,11 +159,7 @@ func loadConfigOrError(ctx context.Context, configFile string) (cfg *config.Conf
 }`)
 
 		OUT(`
-Run the docs command to see a reference config file:
-
-$ catalog-importer docs
-
-Or view it in GitHub: https://github.com/incident-io/catalog-importer/blob/master/config/reference.jsonnet
+View reference config file in GitHub: https://github.com/incident-io/catalog-importer/blob/master/config/reference.jsonnet
 `)
 	}()
 


### PR DESCRIPTION
# Issue
```sh
> catalog-importer source
No config file (--config) was provided, but is required.
...

Run the docs command to see a reference config file:

$ catalog-importer docs

Or view it in GitHub: https://github.com/incident-io/catalog-importer/blob/master/config/reference.jsonnet

> catalog-importer docs
catalog-importer: error: expected command but got "docs", try --help
```

# Fix
Remove reference to unsupported 'docs' command.