### PR TITLE
add sign_jwt: false to Backstage import block example

### DIFF
--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -39,7 +39,7 @@
       backstage: {
         endpoint: 'https://backstage-internal.example.com/api/catalog/entities/by-query',
         token: '$(BACKSTAGE_TOKEN)',  // from environment variable
-        sign_jwt: false,
+        sign_jwt: false, // only pass this if your instance prefers unsigned tokens
       },
     },
     */

--- a/docs/backstage/pipelines/entries.jsonnet
+++ b/docs/backstage/pipelines/entries.jsonnet
@@ -39,6 +39,7 @@
       backstage: {
         endpoint: 'https://backstage-internal.example.com/api/catalog/entities/by-query',
         token: '$(BACKSTAGE_TOKEN)',  // from environment variable
+        sign_jwt: false,
       },
     },
     */


### PR DESCRIPTION
The [Backstage documentation](https://github.com/incident-io/catalog-importer/blob/master/docs/sources.md#backstage) suggests adding `sign_jwt: false` to the Backstage source block.

Let's just add that in the default sample, to save folks the effort of doing that!