### PR TITLE
Add JSM Assets integration example

### DIFF
--- a/docs/simple/README.md
+++ b/docs/simple/README.md
@@ -65,3 +65,45 @@ data into the `catalog.jsonnet` and modifiying the type attributes and schema in
 `importer.jsonnet`.
 
 Any questions, get in touch with support@incident.io.
+
+## JSM Assets Integration Example
+
+The `jsm-assets-importer.jsonnet` file demonstrates how to import objects from Jira Service Management (JSM) Assets into your incident.io catalog. This example queries JSM Assets using their AQL (Assets Query Language) API and imports objects based on their object type.
+
+### What it does
+
+- Connects to the JSM Assets API using your Atlassian credentials
+- Queries for objects matching a specific object type (defaults to "Component")
+- Creates catalog entries with the object name and adds the JSM object key as an attribute
+- Uses environment variables for secure credential handling
+
+### Setup
+
+1. **Create a Jira API token**: Generate from https://id.atlassian.com/manage-profile/security/api-tokens
+
+2. **Get your JSM Assets workspace ID**: 
+   
+   Refer to the [JSM Assets API documentation](https://developer.atlassian.com/cloud/assets/rest/) for details on how to discover your workspace ID. The workspace ID will be included in the response body of various Assets API calls.
+
+3. **Set environment variables**:
+
+```bash
+export JSM_EMAIL="your-email@company.com"
+export JSM_API_TOKEN="your-api-token"
+export JSM_WORKSPACE_ID="your-workspace-id"
+export INCIDENT_API_KEY="your-incident-api-key"
+```
+
+### Usage
+
+```console
+catalog-importer validate --config jsm-assets-importer.jsonnet
+catalog-importer sync --config jsm-assets-importer.jsonnet
+```
+
+This will import all objects of the "Component" type from JSM Assets into your incident.io catalog as custom catalog entries, with the JSM object key stored as an attribute for reference.
+
+### Customization
+
+- **Object Type**: To change from "Component" to other types (e.g., "Server", "Application", "Database"), edit the `objectType` variable at the top of the `jsm-assets-importer.jsonnet` file
+- **Additional Attributes**: You can add more attributes by extending the `attributes` array in the template to map additional JSM Assets fields

--- a/docs/simple/jsm-assets-importer.jsonnet
+++ b/docs/simple/jsm-assets-importer.jsonnet
@@ -1,0 +1,41 @@
+// Configuration - customize the object type as needed
+local objectType = 'Component';
+
+{
+  sync_id: "jsm-assets-sync",
+
+  pipelines: [
+    {
+      sources: [
+        {
+          exec: {
+            command: [
+              "bash",
+              "-c",
+              'curl -u "$JSM_EMAIL:$JSM_API_TOKEN" -H "Accept: application/json" -H "Content-Type: application/json" -d "{\\"qlQuery\\": \\"objectType = ' + objectType + '\\"}" -X POST https://api.atlassian.com/jsm/assets/workspace/$JSM_WORKSPACE_ID/v1/object/aql | jq ".values"',
+            ],
+          },
+        },
+      ],
+      outputs: [
+        {
+          name: "JSM " + objectType,
+          description: objectType + " objects imported from JSM Assets",
+          type_name: 'Custom["JSM' + objectType + '"]',
+          source: {
+            name: "$.name",
+            external_id: "$.id",
+          },
+          attributes: [
+            {
+              name: "Object Key",
+              id: "object_key",
+              source: "$.objectKey",
+              type: "Text",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
- Add jsm-assets-importer.jsonnet template for importing JSM Assets objects
- Uses environment variables for secure credential handling
- Supports configurable object types (defaults to Component)
- Includes comprehensive documentation in README
- Template creates Custom["JSMComponent"] catalog type with object key attribute

🤖 Generated with [Claude Code](https://claude.ai/code)