### PR TITLE
enables JSON logging when --log-json is passed in

### DIFF
--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -30,6 +30,7 @@ var (
 	// Global flags
 	debug   = app.Flag("debug", "Enable debug logging").Default("false").Bool()
 	noColor = app.Flag("no-color", "Disable colored output").Default("false").Bool()
+	logJson = app.Flag("log-json", "Enable JSON logs").Default("false").Bool()
 
 	// Init
 	initCmd     = app.Command("init", "Initialises a new config from a template")
@@ -67,7 +68,12 @@ var (
 func Run(ctx context.Context) (err error) {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+	writer := kitlog.NewSyncWriter(os.Stderr)
+	if *logJson {
+		logger = kitlog.NewJSONLogger(writer)
+	} else {
+		logger = kitlog.NewLogfmtLogger(writer)
+	}
 	if *debug {
 		logger = level.NewFilter(logger, level.AllowDebug())
 	} else {


### PR DESCRIPTION
as requested by @alexstojda in: https://github.com/incident-io/catalog-importer/issues/188

tested by adding a temporary log line:

```sh
$ ./bin/catalog-importer --log-json --debug jsonnet docs/simple/catalog.jsonnet
{"caller":"jsonnet.go:24","level":"debug","msg":"i speak JSON","ts":"2025-06-29T15:46:02.598223Z"}
{
   "features": [
      {
         "description": "Task management during an incident.",
         "external_id": "actions",
         "name": "Actions",
         "owner": "response"
      },
...
```