### PR TITLE
ONC-7399 Include generated enum types when pruning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,16 @@ func (c Config) Filter(typeNames []string) *Config {
 	return &clone
 }
 
+func (c Config) AllOutputTypes() []*output.CatalogTypeModel {
+	types := []*output.CatalogTypeModel{}
+	for _, outputType := range c.Outputs() {
+		baseType, enumTypes := output.MarshalType(outputType)
+		types = append(types, baseType)
+		types = append(types, enumTypes...)
+	}
+	return types
+}
+
 func (c Config) Outputs() []*output.Output {
 	outputs := []*output.Output{}
 	for _, pipeline := range c.Pipelines {


### PR DESCRIPTION
The `--prune` logic was only looking at 'base' types (i.e., those directly configured in an output), and not any enum types that are inferred from this.

I've added a `.AllOutputTypes()` helper on `Config` to simplify a bunch of loops over "every type in the config", which were correct but duplicative in the create/update-schema loops.