### PR TITLE
Fix/empty array idempotency and quiet flags

### DIFF
--- a/cmd/catalog-importer/cmd/init.go
+++ b/cmd/catalog-importer/cmd/init.go
@@ -136,8 +136,8 @@ func (opt *InitOptions) Run(ctx context.Context, logger kitlog.Logger) error {
 		return err
 	}
 
-	OUT("\nYour template has been installed at:\n  %s\n", path.Join(chosenDest, chosenTemplate.Name))
-	OUT("View the README.md for instructions on how to use it.")
+	ALWAYS_OUT("\nYour template has been installed at:\n  %s\n", path.Join(chosenDest, chosenTemplate.Name))
+	ALWAYS_OUT("View the README.md for instructions on how to use it.")
 
 	return nil
 }

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -221,7 +221,10 @@ func MarshalEntries(ctx context.Context, logger kitlog.Logger, output *Output, e
 					})
 				}
 
-				binding.ArrayValue = &arrayValue
+				// Only set ArrayValue if there are actual items
+				if len(arrayValue) > 0 {
+					binding.ArrayValue = &arrayValue
+				}
 			} else {
 				literal, err := evaluateEntryWithAttributeType(ctx, src, entry, attributeByID[attributeID], logger)
 				if err != nil {

--- a/reconcile/entries.go
+++ b/reconcile/entries.go
@@ -344,7 +344,7 @@ func bindingToPayload(binding client.CatalogEntryEngineParamBindingV3) client.Ca
 		}
 	}
 
-	if binding.ArrayValue != nil {
+	if binding.ArrayValue != nil && len(*binding.ArrayValue) > 0 {
 		payload.ArrayValue = &[]client.CatalogEngineParamBindingValuePayloadV3{}
 		for _, value := range *binding.ArrayValue {
 			*payload.ArrayValue = append(*payload.ArrayValue, client.CatalogEngineParamBindingValuePayloadV3{


### PR DESCRIPTION
This PR addresses two key issues affecting automation and user experience:

### 1. Empty array values cause no-op updates
An empty array was represented as either an empty binding, or a binding with `array_value: []`. These result in the same outcome, but aren't strictly equal, so we would attempt to apply an update with `UpdateEntry()` even though there's no actual change, resulting in loads more requests than necessary.

`output/marshal.go` and `reconcile/entries.go` now treat both an empty binding and a binding with an empty array in it the same, to avoid these updates.

### 2. `--quiet` and `--no-progress` flags
The `--quiet` flag suppresses all non-error output across all commands, to make the output more compact if this is being run in a cron.

`--no-progress` suppresses progress bars in the sync command. Progress bars can interfere with output redirection, since they're doing fancy terminal things!

## Usage Examples

```bash
# Cron-friendly: only show changes/errors
catalog-importer sync --config=importer.jsonnet --quiet > changes.log

# Enable output redirection
catalog-importer sync --config=importer.jsonnet --no-progress > full.log 2>&1

# Both together for automation
catalog-importer --quiet sync --config=importer.jsonnet --no-progress > summary.log 2>&1
```
