### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "incident-io/engineering"
+    labels:
+      - "dependencies"
+      - "go"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "incident-io/engineering"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "incident-io/engineering"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
- Configure weekly updates for Go modules, Docker base images, and GitHub Actions
- Set incident-io/engineering as reviewers for all dependency PRs
- Limit open PRs to prevent overwhelming the team (10 for Go modules, 5 for others)
- Add appropriate labels for easy categorization

🤖 Generated with [Claude Code](https://claude.ai/code)