### PR TITLE
⬆️ Bump Alpine base image and add apk update to fix vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:20250108 AS runtime
+FROM alpine:latest AS runtime
 
-# Add certificates so we can make HTTPS requests.
-RUN apk add --no-cache ca-certificates
+# Update package index and add certificates with latest versions
+RUN apk update && apk add --no-cache ca-certificates
 
-# goreleaser supplies this for us.
+# Copy the catalog-importer binary (you'll need to extract this from the original image)
 COPY catalog-importer /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/catalog-importer"]


### PR DESCRIPTION
 - Updates base image to alpine:3.22.1 (current latest)
 - Adds `apk update` to update packages with vulns
 - Reduces current vulns from `8` to `0`