### PR TITLE
Add support for Backstage URLs with a prefixed path

### DIFF
--- a/source/source_backstage.go
+++ b/source/source_backstage.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -50,14 +51,15 @@ func (s SourceBackstage) Load(ctx context.Context, logger kitlog.Logger, client 
 		return nil, errors.Wrap(err, "parsing Backstage URL")
 	}
 
-	if endpointURL.Path == "/api/catalog/entities" {
+	if strings.HasSuffix(endpointURL.Path, "/api/catalog/entities") {
 		logger.Log(
 			"msg",
 			"Deprecated: The Backstage API endpoint '/api/catalog/entities' is deprecated. Use '/api/catalog/entities/by-query' instead.",
 		)
 		return s.fetchEntries(ctx, client, token)
 	}
-	if endpointURL.Path == "/api/catalog/entities/by-query" {
+
+	if strings.HasSuffix(endpointURL.Path, "/api/catalog/entities/by-query") {
 		return s.fetchEntriesByQuery(ctx, client, token)
 	}
 


### PR DESCRIPTION
If you have an installation of Backstage that is hosted at a URL with a prefixed path, like this:

```
https://tools.example.org/backstage/api/catalog/entities/by-query
```

Then our validation rejects that as an invalid URL. This change fixes our validation logic by only checking the suffix of the URL, to ensure that we're still pointing at one of the catalog entities endpoints that we support.