### PR TITLE
Improve validation of pipelines, sources and outputs

### DIFF
--- a/cmd/catalog-importer/cmd/app.go
+++ b/cmd/catalog-importer/cmd/app.go
@@ -173,6 +173,7 @@ View reference config file in GitHub: https://github.com/incident-io/catalog-imp
 	if err != nil {
 		return nil, errors.Wrap(err, "loading config")
 	}
+
 	if err := cfg.Validate(); err != nil {
 		data, _ := json.MarshalIndent(err, "", "  ")
 

--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -437,6 +437,7 @@ createCatalogType:
 		{
 			OUT("\n  ↻ Loading data from sources...")
 			for _, source := range pipeline.Sources {
+
 				sourceLabel := lo.Must(source.Backend()).String()
 
 				sourceEntries, err := source.Load(ctx, logger)

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,8 @@ func (c Config) Validate() error {
 	return validation.ValidateStruct(&c,
 		validation.Field(&c.SyncID, validation.Required.
 			Error("must provide a sync_id to track which resources are managed by this config, and to support clean-up when an output is removed")),
-		validation.Field(&c.Pipelines),
+		validation.Field(&c.Pipelines, validation.Required, validation.Length(1, 0).
+			Error("must specify at least one pipeline")),
 	)
 }
 
@@ -91,5 +92,10 @@ type Pipeline struct {
 }
 
 func (p Pipeline) Validate() error {
-	return validation.ValidateStruct(&p)
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.Sources, validation.Required, validation.Length(1, 0).
+			Error("must specify at least one source")),
+		validation.Field(&p.Outputs, validation.Required, validation.Length(1, 0).
+			Error("must specify at least one output")),
+	)
 }


### PR DESCRIPTION
If you don't include pipelines, or those pipelines don't contain any sources or outputs, we should show an error. The resulting error looks like this:

```
View reference config file in GitHub: https://github.com/incident-io/catalog-importer/blob/master/config/reference.jsonnet

main: error: validating config:
{
  "pipelines": {
    "0": {
      "sources": "cannot be blank"
    }
  }
}
```