### PR TITLE
Don't require a source to have non-empty attributes

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -26,7 +26,6 @@ func (o Output) Validate() error {
 		validation.Field(&o.Description, validation.Required),
 		validation.Field(&o.TypeName, validation.Required, validation.Match(regexp.MustCompile(`^Custom\["[A-Z][a-zA-Z]*"\]$`))),
 		validation.Field(&o.Source, validation.Required),
-		validation.Field(&o.Attributes, validation.Required),
 	)
 }
 


### PR DESCRIPTION
An inadvertent consequence of #254 is that the call to `validation.Field(&p.Outputs...` meant that `Validate()` is also called on `Output`. This highlights some incorrect validation: that attributes must be a non-nil slice with a length greater than zero. It is valid for an output Catalog type to not have any attributes: it could be the case that you just wish to have a name recorded, with no additional attributes.

This change ensures that outputs with no attributes are considered valid, as they should be.

Closes #257.