### PR TITLE
Feature: Support use_name_as_identifier, icon, color for catalog type sync

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -219,11 +219,23 @@ createCatalogType:
 		var createdCatalogType client.CatalogTypeV3
 		if opt.DryRun {
 			logger.Log("msg", "catalog type does not already exist, simulating create for --dry-run")
+
+			color := client.CatalogTypeV3Color("")
+			if model.Color != nil {
+				color = client.CatalogTypeV3Color(*model.Color)
+			}
+			icon := client.CatalogTypeV3Icon("")
+			if model.Icon != nil {
+				icon = client.CatalogTypeV3Icon(*model.Icon)
+			}
+
 			createdCatalogType = client.CatalogTypeV3{
 				Id:                  fmt.Sprintf("DRY-RUN-%s", model.TypeName),
 				Name:                model.Name,
 				Description:         model.Description,
 				TypeName:            model.TypeName,
+				Color:               color,
+				Icon:                icon,
 				UseNameAsIdentifier: model.UseNameAsIdentifier,
 				SourceRepoUrl:       &opt.SourceRepoUrl,
 			}
@@ -232,6 +244,16 @@ createCatalogType:
 			categories := lo.Map(model.Categories, func(category string, _ int) client.CatalogCreateTypePayloadV3Categories {
 				return client.CatalogCreateTypePayloadV3Categories(category)
 			})
+			var color *client.CatalogCreateTypePayloadV3Color
+			if model.Color != nil {
+				val := client.CatalogCreateTypePayloadV3Color(*model.Color)
+				color = &val
+			}
+			var icon *client.CatalogCreateTypePayloadV3Icon
+			if model.Icon != nil {
+				val := client.CatalogCreateTypePayloadV3Icon(*model.Icon)
+				icon = &val
+			}
 
 			result, err := cl.CatalogV3CreateTypeWithResponse(ctx, client.CatalogCreateTypePayloadV3{
 				Name:                model.Name,
@@ -240,6 +262,8 @@ createCatalogType:
 				TypeName:            lo.ToPtr(model.TypeName),
 				Categories:          lo.ToPtr(categories),
 				Annotations:         lo.ToPtr(getAnnotations(cfg.SyncID)),
+				Color:               color,
+				Icon:                icon,
 				UseNameAsIdentifier: lo.ToPtr(model.UseNameAsIdentifier),
 				SourceRepoUrl:       &opt.SourceRepoUrl,
 			})
@@ -288,6 +312,12 @@ createCatalogType:
 			logger.Log("msg", "dry-run active, which means we fake a response")
 			updatedCatalogType = *catalogType // they start the same
 			updatedCatalogType.UseNameAsIdentifier = model.UseNameAsIdentifier
+			if model.Color != nil {
+				updatedCatalogType.Color = client.CatalogTypeV3Color(*model.Color)
+			}
+			if model.Icon != nil {
+				updatedCatalogType.Icon = client.CatalogTypeV3Icon(*model.Icon)
+			}
 
 			// Then we pretend like we've already updated the schema, which means we rebuild the
 			// attributes.
@@ -364,6 +394,16 @@ createCatalogType:
 			categories := lo.Map(model.Categories, func(category string, _ int) client.CatalogUpdateTypePayloadV3Categories {
 				return client.CatalogUpdateTypePayloadV3Categories(category)
 			})
+			var color *client.CatalogUpdateTypePayloadV3Color
+			if model.Color != nil {
+				val := client.CatalogUpdateTypePayloadV3Color(*model.Color)
+				color = &val
+			}
+			var icon *client.CatalogUpdateTypePayloadV3Icon
+			if model.Icon != nil {
+				val := client.CatalogUpdateTypePayloadV3Icon(*model.Icon)
+				icon = &val
+			}
 
 			logger.Log("msg", "updating catalog type", "catalog_type_id", catalogType.Id)
 			result, err := cl.CatalogV3UpdateTypeWithResponse(ctx, catalogType.Id, client.CatalogV3UpdateTypeJSONRequestBody{
@@ -372,6 +412,8 @@ createCatalogType:
 				Ranked:              &model.Ranked,
 				Categories:          lo.ToPtr(categories),
 				Annotations:         lo.ToPtr(getAnnotations(cfg.SyncID)),
+				Color:               color,
+				Icon:                icon,
 				UseNameAsIdentifier: lo.ToPtr(model.UseNameAsIdentifier),
 				SourceRepoUrl:       &opt.SourceRepoUrl,
 			})

--- a/config/reference.jsonnet
+++ b/config/reference.jsonnet
@@ -168,6 +168,10 @@
           // prefix (e.g. GitHubRepository) and this avoids collisions.
           type_name: 'Custom["Team"]',
 
+          // Optional visual settings for this type in the dashboard.
+          color: 'blue',
+          icon: 'users',
+
           // If true, allows referring to entries by their name as well as external_id and
           // aliases. Defaults to false.
           use_name_as_identifier: false,

--- a/output/marshal.go
+++ b/output/marshal.go
@@ -17,6 +17,8 @@ type CatalogTypeModel struct {
 	Description         string
 	TypeName            string
 	Ranked              bool
+	Color               *string
+	Icon                *string
 	UseNameAsIdentifier bool
 	Attributes          []client.CatalogTypeAttributePayloadV3
 	Categories          []string
@@ -40,6 +42,8 @@ func MarshalType(output *Output) (base *CatalogTypeModel, enumTypes []*CatalogTy
 		Description:         output.Description,
 		TypeName:            output.TypeName,
 		Ranked:              output.Ranked,
+		Color:               lo.Ternary(output.Color.Valid, lo.ToPtr(output.Color.String), nil),
+		Icon:                lo.Ternary(output.Icon.Valid, lo.ToPtr(output.Icon.String), nil),
 		UseNameAsIdentifier: output.UseNameAsIdentifier,
 		Attributes:          []client.CatalogTypeAttributePayloadV3{},
 		Categories:          output.Categories,

--- a/output/marshal_test.go
+++ b/output/marshal_test.go
@@ -164,6 +164,8 @@ var _ = Describe("MarshalType", func() {
 			Description:         "Test description",
 			TypeName:            "test_type",
 			Ranked:              true,
+			Color:               null.StringFrom("blue"),
+			Icon:                null.StringFrom("users"),
 			UseNameAsIdentifier: true,
 			Categories:          []string{"Category1", "Category2"},
 			Attributes:          []*Attribute{},
@@ -178,6 +180,8 @@ var _ = Describe("MarshalType", func() {
 		Expect(base.Description).To(Equal("Test description"))
 		Expect(base.TypeName).To(Equal("test_type"))
 		Expect(base.Ranked).To(BeTrue())
+		Expect(base.Color).To(PointTo(Equal("blue")))
+		Expect(base.Icon).To(PointTo(Equal("users")))
 		Expect(base.UseNameAsIdentifier).To(BeTrue())
 		Expect(base.Categories).To(Equal([]string{"Category1", "Category2"}))
 		Expect(base.Attributes).To(HaveLen(0))

--- a/output/output.go
+++ b/output/output.go
@@ -15,6 +15,8 @@ type Output struct {
 	Description         string       `json:"description"`
 	TypeName            string       `json:"type_name"`
 	Ranked              bool         `json:"ranked"`
+	Color               null.String  `json:"color"`
+	Icon                null.String  `json:"icon"`
 	UseNameAsIdentifier bool         `json:"use_name_as_identifier"`
 	Source              SourceConfig `json:"source"`
 	Attributes          []*Attribute `json:"attributes"`


### PR DESCRIPTION
Hey!

We noticed that we could not set `use_name_as_identifier` or `color` to our catalog types, managed by catalog-importer.

Although the properties are generated in the client and available in the API, they are not allowed fields in the JSON.

This PR adds `use_name_as_identifier`, `color` and `icon` fields.

We've tested the PR with our own sync process, and are happy with the results: no issues when JSON is good, correct errors when icon/color is invalid.

Note: we are mostly interested in `use_name_as_identifier`, I'll be happy to split `icon` and `color` and the enum handling in another PR if this can help getting the use_name_as_identifier part merged faster!

_PR code co-authored with AI_