### PR TITLE
Add CSV edge case tests for Parse

### DIFF
--- a/source/parse_test.go
+++ b/source/parse_test.go
@@ -240,5 +240,25 @@ P125,My name is,Slim Shady
 				}))
 			})
 		})
+		
+		When("only headers, no data rows", func() {
+			BeforeEach(func() {
+				input = "id,name,description\n"
+			})
+
+			It("returns no entries", func() {
+				Expect(entries).To(BeEmpty())
+			})
+		})
+
+		When("malformed CSV", func() {
+			BeforeEach(func() {
+				input = "id,name\na,\"b\"c\n"
+			})
+
+			It("returns no entries", func() {
+				Expect(entries).To(BeEmpty())
+			})
+		})
 	})
 })


### PR DESCRIPTION
The CSV parsing path had two untested branches:
- CSV with only a header row and no data rows
- Malformed CSV that fails to parse

Inspired by the go-jsonnet v0.22.0 bump, though these paths are unaffected by that change.