### PR TITLE
Fix noisy diff output when using update_attributes

### DIFF
--- a/cmd/catalog-importer/cmd/sync.go
+++ b/cmd/catalog-importer/cmd/sync.go
@@ -657,12 +657,11 @@ func newEntriesClient(cl *client.ClientWithResponses, existingCatalogTypes []cli
 
 				// Convert PartialEntryPayloadV3 to UpdatePayloadV3 for diff display
 				payload := client.CatalogUpdateEntryPayloadV3{
-					Name:             lo.FromPtrOr(partialEntry.Name, ""),
-					Rank:             partialEntry.Rank,
-					ExternalId:       partialEntry.ExternalId,
-					Aliases:          partialEntry.Aliases,
-					AttributeValues:  partialEntry.AttributeValues,
-					UpdateAttributes: updateAttributes,
+					Name:            lo.FromPtrOr(partialEntry.Name, ""),
+					Rank:            partialEntry.Rank,
+					ExternalId:      partialEntry.ExternalId,
+					Aliases:         partialEntry.Aliases,
+					AttributeValues: partialEntry.AttributeValues,
 				}
 
 				// Build existing payload for comparison
@@ -683,7 +682,7 @@ func newEntriesClient(cl *client.ClientWithResponses, existingCatalogTypes []cli
 							Literal: attr.Value.Literal,
 						}
 					}
-					if attr.ArrayValue != nil {
+					if attr.ArrayValue != nil && len(*attr.ArrayValue) > 0 {
 						arrayValue := []client.CatalogEngineParamBindingValuePayloadV3{}
 						for _, elementValue := range *attr.ArrayValue {
 							arrayValue = append(arrayValue, client.CatalogEngineParamBindingValuePayloadV3{
@@ -693,6 +692,24 @@ func newEntriesClient(cl *client.ClientWithResponses, existingCatalogTypes []cli
 						result.ArrayValue = &arrayValue
 					}
 					existingPayload.AttributeValues[attrID] = result
+				}
+
+				// Filter payloads to only show updated attributes
+				if updateAttributes != nil {
+					allowed := lo.SliceToMap(*updateAttributes, func(id string) (string, bool) {
+						return id, true
+					})
+
+					filterAttrs := func(attrs map[string]client.CatalogEngineParamBindingPayloadV3) {
+						for attrID := range attrs {
+							if !allowed[attrID] {
+								delete(attrs, attrID)
+							}
+						}
+					}
+
+					filterAttrs(payload.AttributeValues)
+					filterAttrs(existingPayload.AttributeValues)
 				}
 
 				DIFF("      ", existingPayload, payload)

--- a/reconcile/entries_test.go
+++ b/reconcile/entries_test.go
@@ -579,4 +579,45 @@ var _ = Describe("Entries", func() {
 			Expect(updatedEntries[249].payload.Name).To(Equal("Entry 249 Updated"))
 		})
 	})
+
+	When("an existing entry has an empty array attribute and source has no value", func() {
+		BeforeEach(func() {
+			catalogType = &client.CatalogTypeV3{
+				Id:       "type-123",
+				TypeName: "Test Type",
+			}
+
+			outputType = &output.Output{
+				Attributes: []*output.Attribute{
+					{ID: "tags", Name: "Tags", SchemaOnly: false},
+				},
+			}
+
+			existingEntries = []client.CatalogEntryV3{
+				{
+					Id:         "entry-1",
+					ExternalId: lo.ToPtr("ext-1"),
+					Name:       "Entry 1",
+					AttributeValues: map[string]client.CatalogEntryEngineParamBindingV3{
+						"tags": {
+							ArrayValue: &[]client.CatalogEntryEngineParamBindingValueV3{},
+						},
+					},
+				},
+			}
+
+			entryModels = []*output.CatalogEntryModel{
+				{
+					Name:            "Entry 1",
+					ExternalID:      "ext-1",
+					AttributeValues: map[string]client.CatalogEngineParamBindingPayloadV3{},
+				},
+			}
+		})
+
+		It("does not trigger an update", func() {
+			mustReconcile()
+			Expect(updatedEntries).To(HaveLen(0))
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- After building the diff payloads, filter both sides to only include attributes present in `update_attributes`.
- Removed `update_attributes` from the payload because it is a control field not a data field.
-  Guard the empty array conversion with `len(*attr.ArrayValue) > 0` so that an empty array in the catalog is treated the same as no value. (Although I think the regression mentioned in resp-15746 was already fixed. I added a test to ensure the behaviour is kept.)

## Context

Following instructions given on [RESP-15746](https://linear.app/incident-io/issue/RESP-15746/fix-catalog-importer-output-around-update-attributes) to 'Fix catalog importer output around update_attributes'

## Testing

Manually tested using `--dry-run` against a local incident.io instance:
  Created a catalog type with importer-controlled attributes and a schema_only attribute. Synced an entry with array values, then cleared them to leave an empty array in the catalog. Ran --dry-run with a name change and confirmed:
  - attributes not in update_attributes did not appear in the diff (points 1 & 2)
  - empty array attribute did not appear in the diff (point 3)
  - update_attributes did not appear in the diff (point 2)
  - only the real name change was shown
  
<img width="520" height="172" alt="Screenshot 2026-04-07 at 09 55 24" src="https://github.com/user-attachments/assets/51ce3778-f5fb-46fc-86e0-c6dc8954e9b4" />
