### PR TITLE
Build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,14 @@ jobs:
           version: "~> v1"
           args: release --snapshot --clean
       -
+        # Prove the cross-built images actually execute, not just build
+        # (arm64 runs under QEMU emulation).
+        name: Smoke test snapshot images
+        if: github.ref != 'refs/heads/master'
+        run: |
+          docker run --rm --platform linux/amd64 incidentio/catalog-importer:latest-amd64 --help
+          docker run --rm --platform linux/arm64 incidentio/catalog-importer:latest-arm64 --help
+      -
         id: tag
         name: Tag if new version
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,12 @@ jobs:
         name: Run tests
         run: ginkgo -r .
       -
-        # Needed to cross-build the arm64 Docker image on the amd64 runner.
+        # Not needed to *build* the arm64 image (buildx handles cross-arch
+        # builds on its own, RUN steps included) — but the smoke test below
+        # runs the arm64 image on the host engine, which needs binfmt
+        # handlers registered. Verified empirically: without this, the
+        # snapshot build passes and the arm64 smoke run fails with an exec
+        # format error.
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,24 @@ jobs:
         name: Run tests
         run: ginkgo -r .
       -
+        # Needed to cross-build the arm64 Docker image on the amd64 runner.
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        # The real release only runs on master, so validate the release
+        # config (including the multi-arch Docker builds) on every branch to
+        # catch breakage before it reaches a release.
+        name: Validate release config (snapshot)
+        if: github.ref != 'refs/heads/master'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v1"
+          args: release --snapshot --clean
+      -
         id: tag
         name: Tag if new version
         if: github.ref == 'refs/heads/master'
@@ -40,22 +58,23 @@ jobs:
           CURRENT_VERSION="v$(cat cmd/catalog-importer/cmd/VERSION)"
           if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
             echo "Version ${CURRENT_VERSION} is already released"
+            echo "release=no" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git tag "${CURRENT_VERSION}"
           git push --tags
+          echo "release=yes" >> "$GITHUB_OUTPUT"
       -
         name: Login to Docker Hub
-        if: github.ref == 'refs/heads/master'
+        if: steps.tag.outputs.release == 'yes'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_PUBLISHER_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PUBLISHER_KEY }}
       -
         name: Run GoReleaser
-        if: github.ref == 'refs/heads/master'
-        continue-on-error: true
+        if: steps.tag.outputs.release == 'yes'
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -34,8 +34,38 @@ brews:
     homepage: https://incident.io/
     description: Official incident.io catalog importer, for syncing catalog entries.
 
+# Build one Docker image per architecture, then roll them up into multi-arch
+# manifests under the public tags so the image runs on both amd64 and arm64
+# nodes. buildx (plus QEMU in CI) is required to cross-build the arm64 image
+# on the amd64 runner.
 dockers:
   - image_templates:
-      - incidentio/{{ .ProjectName }}:latest
-      - incidentio/{{ .ProjectName }}:{{ .Tag }}
-      - incidentio/{{ .ProjectName }}:v{{ .Major }}
+      - incidentio/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - incidentio/{{ .ProjectName }}:v{{ .Major }}-amd64
+      - incidentio/{{ .ProjectName }}:latest-amd64
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - --platform=linux/amd64
+  - image_templates:
+      - incidentio/{{ .ProjectName }}:{{ .Tag }}-arm64
+      - incidentio/{{ .ProjectName }}:v{{ .Major }}-arm64
+      - incidentio/{{ .ProjectName }}:latest-arm64
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+      - --platform=linux/arm64
+
+docker_manifests:
+  - name_template: incidentio/{{ .ProjectName }}:{{ .Tag }}
+    image_templates:
+      - incidentio/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - incidentio/{{ .ProjectName }}:{{ .Tag }}-arm64
+  - name_template: incidentio/{{ .ProjectName }}:v{{ .Major }}
+    image_templates:
+      - incidentio/{{ .ProjectName }}:v{{ .Major }}-amd64
+      - incidentio/{{ .ProjectName }}:v{{ .Major }}-arm64
+  - name_template: incidentio/{{ .ProjectName }}:latest
+    image_templates:
+      - incidentio/{{ .ProjectName }}:latest-amd64
+      - incidentio/{{ .ProjectName }}:latest-arm64


### PR DESCRIPTION
Closes #344

## Problem

The published `incidentio/catalog-importer` Docker image was built for `linux/amd64` only. On mixed-architecture clusters (e.g. Kubernetes with ARM nodes, which are cheaper on AWS), pods scheduled onto ARM nodes fail at startup with an `exec format error`. The release archives and Homebrew formula already ship `linux_arm64` binaries — only the Docker image was affected.

## Changes

**`goreleaser.yml`**
- Split the single `dockers` entry into per-architecture builds (`amd64` + `arm64`) using buildx.
- Added a `docker_manifests` section that rolls the per-arch images up into multi-arch manifests under the existing public tags (`:latest`, `:vX`, `:vX.Y.Z`).

**`.github/workflows/build.yml`**
- Added `docker/setup-qemu-action` and `docker/setup-buildx-action` so the arm64 image can be cross-built on the amd64 runner.
- Added a snapshot build (`goreleaser release --snapshot --clean`) on non-master branches, so release config breakage — previously only observable during a real release — is caught in PRs. This PR's CI run built both images as proof.
- The "Tag if new version" step now emits a `release=yes/no` output, and the Docker Hub login + GoReleaser steps are gated on it, replacing `continue-on-error: true`. Previously a genuinely broken release failed silently; now GoReleaser only runs when there's a new version to release, and failures fail the build.

## Impact on existing users

Purely additive — no action needed:
- The public tags become multi-arch manifest lists; pulls on amd64 resolve exactly as before, and already-published tags are untouched.
- ARM users no longer need to pin workloads to amd64 nodes or fall back to the release tarball.
- Per-arch tags (`-amd64` / `-arm64`) now appear on Docker Hub alongside the manifest tags; this is expected with `docker_manifests`.

## Validation

- `goreleaser check` (v1.26.2) passes; `actionlint` clean.
- CI snapshot build on this branch cross-built both the amd64 and arm64 images on the same runner configuration the release uses.
- Post-release: `docker buildx imagetools inspect incidentio/catalog-importer:latest` should list both `linux/amd64` and `linux/arm64`, and `docker run --rm --platform linux/arm64 incidentio/catalog-importer:latest --help` should run.