### PR TITLE
Add doc links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The catalog importer is the official CLI tool for syncing catalog data into [inc
 - **Rich data transformation**: Filter, transform, and enrich your catalog data during import
 - **Team ownership**: Maintain catalog data alongside your code where teams can easily update it
 
+## Questions about the Catalog?
+
+If you're just getting started with your Catalog, you can [find basic info on Catalog types, setup, and data here](https://docs.incident.io/catalog/catalog-setup).
+
+While using the importer, you may find it useful to use the API for debugging or reference:
+- [Full API reference](https://docs.incident.io/api-reference/introduction)
+- [Catalog Types API reference](https://docs.incident.io/api-reference/catalog-types-v3)
+
 ## Quick start
 
 ### 1. Install the importer


### PR DESCRIPTION
## Summary

Add Catalog help docs link and API reference links (both to the API in general and to the Catalog Types reference specifically) to a new section of README.md.

## Why

For users new to Incident IO who want to use the importer, it's helpful to be able to quickly find more information on the Catalog in general and what data is generally good to sync. Users may also find it helpful to know where the API reference lives, to facilitate more in-depth troubleshooting during sync setup.

Since the importer API key also allows connection to the API directly, this update enables LLMs to find and make API calls to troubleshoot errors as needed.