### PR TITLE
PR-524: Track the latest stable Go release in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.27.0'
+          # Track the latest stable Go patch rather than pinning one. A
+          # hardcoded version only moves when somebody remembers to move it,
+          # and the released binary carries whatever toolchain built it.
+          go-version: 'stable'
       -
         name: Build
         run: go run cmd/catalog-importer/main.go --help


### PR DESCRIPTION
A customer reported (#351) that our published image failed their scanner, and part of the cause was the Go toolchain baked into the released binary. It reported as 1.26.4 while 1.26.5 was current, which meant the image shipped CVE-2026-39822 and CVE-2026-42505 several weeks after upstream had fixed both.

Nothing in this repository was ever going to catch that. The Go version lives as a hardcoded string in the build workflow, and no automation touches it. Dependabot's `github-actions` ecosystem bumps the `actions/setup-go` action itself, which is what PR #343 did, but it has no view into the `go-version` input, so the pin only moves when a human happens to notice. The `toolchain` directive in `go.mod` does not help either, because it sets a floor rather than a ceiling. The result is a value that silently rots, and the only visible symptom is a CVE count on an image nobody scans.

Setting `go-version: 'stable'` makes the workflow resolve the current stable patch at build time, so a released binary always carries a current toolchain. This does trade away build reproducibility across time, in that the same commit built twice may use different Go patches, and a Go release could in principle break the build. The existing gate is what makes that acceptable: the workflow runs `ginkgo -r .` and a full goreleaser snapshot across all six cross-compiled targets before anything publishes. The `toolchain` line in `go.mod` is deliberately left alone, since it still serves as the minimum version for local development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)