### PR TITLE
PR-524: Scan the published image on a schedule

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,32 +11,103 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
       -
-        # Fails the job. A CRITICAL with a patched package available is
-        # something we can act on today, and it is what downstream registry
-        # scanners block their users on.
-        name: Fail on actionable CRITICAL
+        # exit-code stays 0 so we always reach the reporting steps below. The
+        # decision about what is worth acting on is made here, not by trivy.
+        name: Scan the published image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: incidentio/catalog-importer:latest
-          severity: CRITICAL
-          ignore-unfixed: true
-          exit-code: '1'
-      -
-        # Reported, never enforced. HIGH findings regularly sit in the base
-        # image with no patched package published yet. Failing on those leaves
-        # the job red for weeks through no fault of ours, and a job that is
-        # always red gets muted, which costs us the CRITICAL signal above.
-        name: Report everything else
-        if: always()
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: incidentio/catalog-importer:latest
+          format: json
+          output: trivy.json
           severity: CRITICAL,HIGH,MEDIUM
           ignore-unfixed: false
           exit-code: '0'
+      -
+        # Everything found, on the run page itself, so nobody has to open a log
+        # to see the state of the image.
+        name: Write the run summary
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Scan of \`incidentio/catalog-importer:latest\`"
+            echo
+            echo "| Severity | Package | Vulnerability | Installed | Fixed in |"
+            echo "| -- | -- | -- | -- | -- |"
+            jq -r '
+              [.Results[]?.Vulnerabilities[]?]
+              | sort_by(.Severity)
+              | .[]
+              | "| \(.Severity) | \(.PkgName) | \(.VulnerabilityID) | \(.InstalledVersion) | \(.FixedVersion // "no fix yet") |"
+            ' trivy.json
+          } >> "$GITHUB_STEP_SUMMARY"
+      -
+        # We report a CRITICAL only when a patched package exists, because that
+        # is the subset we can actually do something about today. HIGH findings
+        # regularly sit in the base image for weeks with nothing published to
+        # upgrade to, and raising an issue nobody can close teaches people to
+        # ignore the issues.
+        name: Report actionable findings as an issue
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          set -euo pipefail
+
+          jq -r '
+            [.Results[]?.Vulnerabilities[]?
+             | select(.Severity == "CRITICAL" and ((.FixedVersion // "") != ""))]
+            | unique_by(.VulnerabilityID)
+            | sort_by(.VulnerabilityID)
+          ' trivy.json > actionable.json
+
+          count=$(jq 'length' actionable.json)
+          if [ "$count" -eq 0 ]; then
+            echo "No actionable CRITICAL findings."
+            exit 0
+          fi
+
+          # Identify this finding set by its CVE ids, so a scan that finds the
+          # same thing tomorrow does not open a second issue, but a scan that
+          # finds something new does.
+          fingerprint=$(jq -r '[.[].VulnerabilityID] | join(",")' actionable.json)
+
+          gh label create security-scan \
+            --description 'Raised by the scheduled image scan' \
+            --color B60205 --force
+
+          if gh issue list --label security-scan --state open \
+               --json body --jq '.[].body' | grep -qF "scan-fingerprint: ${fingerprint}"; then
+            echo "An open issue already tracks this exact finding set. Nothing to do."
+            exit 0
+          fi
+
+          {
+            echo "The scheduled scan found ${count} CRITICAL vulnerability(ies) in"
+            echo "\`incidentio/catalog-importer:latest\` that have a patched version available."
+            echo
+            echo "| Package | Vulnerability | Installed | Fixed in |"
+            echo "| -- | -- | -- | -- |"
+            jq -r '.[] | "| \(.PkgName) | [\(.VulnerabilityID)](\(.PrimaryURL // "")) | \(.InstalledVersion) | \(.FixedVersion) |"' actionable.json
+            echo
+            echo "Reproduce with:"
+            echo
+            echo '```'
+            echo "trivy image incidentio/catalog-importer:latest --severity CRITICAL --ignore-unfixed"
+            echo '```'
+            echo
+            echo "[Run that found this](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo
+            echo "<!-- scan-fingerprint: ${fingerprint} -->"
+          } > issue.md
+
+          gh issue create \
+            --title "Scheduled scan: ${count} actionable CRITICAL in the published image" \
+            --label security-scan \
+            --body-file issue.md

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,42 @@
+name: Scan
+
+# The published image gains vulnerabilities without any commit landing here,
+# because they come from the base image and from advisories published after we
+# built it. Scanning on push cannot see that, so scan the tag users pull on a
+# schedule instead.
+on:
+  schedule:
+    - cron: '17 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        # Fails the job. A CRITICAL with a patched package available is
+        # something we can act on today, and it is what downstream registry
+        # scanners block their users on.
+        name: Fail on actionable CRITICAL
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: incidentio/catalog-importer:latest
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+      -
+        # Reported, never enforced. HIGH findings regularly sit in the base
+        # image with no patched package published yet. Failing on those leaves
+        # the job red for weeks through no fault of ours, and a job that is
+        # always red gets muted, which costs us the CRITICAL signal above.
+        name: Report everything else
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: incidentio/catalog-importer:latest
+          severity: CRITICAL,HIGH,MEDIUM
+          ignore-unfixed: false
+          exit-code: '0'


### PR DESCRIPTION
A customer told us our published image carried 3 CRITICAL and 37 HIGH CVEs (#351). The findings were real and the fixes were mostly sitting in unmerged Dependabot PRs, but the part worth fixing is that the report reached us from outside. The image had been drifting for weeks and nothing here said so.

The build workflow cannot catch this, and no change to it would. It runs `on: [push]`, so it only ever sees the tree at the moment of a commit. The findings that accumulate in a published image come from somewhere else: the base image gains CVEs after we pin it, and advisories get published against dependencies we already shipped. Both happen while the repository sits still. Detecting drift needs something that runs when nothing has changed, and that scans the artifact users actually pull rather than the source we built it from.

This adds a daily scan of `incidentio/catalog-importer:latest`. Findings that we can act on today, meaning a CRITICAL with a patched version available, are raised as a GitHub issue labelled `security-scan`, which is a channel somebody reads. The issue carries a fingerprint of the CVE ids it covers, so tomorrow's scan finding the same thing again stays quiet while a scan finding something new still raises it. The full table of CRITICAL, HIGH and MEDIUM goes to the run summary regardless, so the current state of the image is always one click away.

Two things are deliberately excluded. HIGH findings do not raise an issue, because they regularly sit in the base image for weeks with no patched package published, and an issue nobody can close teaches people to ignore the label. Findings with no available fix do not raise one either, for the same reason. The build workflow is left alone: scanning on push would add time to every build to re-check a tree we have not published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)