### PR TITLE
PR-524: Upgrade base packages to clear the OpenSSL CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM alpine:3.24.1 AS runtime
 
-# Add certificates so we can make HTTPS requests.
+# Bring the base image up to the current patch versions, then add certificates
+# so we can make HTTPS requests.
 #
-# Use ca-certificates-bundle rather than ca-certificates. The latter depends on
-# libcrypto3 (for the update-ca-certificates script), which pulls OpenSSL into
-# the image. We build with CGO_ENABLED=0, so TLS comes from crypto/tls in the Go
-# standard library and never links OpenSSL. The bundle package has no
-# dependencies and provides the same certificate file.
-RUN apk add --no-cache ca-certificates-bundle
+# The upgrade is doing the security work here. OpenSSL is present in the base
+# image regardless of what we install, because busybox's ssl_client depends on
+# it, so pinning the base alone leaves us on whatever OpenSSL that base release
+# happened to ship. Alpine publishes fixes into the 3.24 repository well before
+# it cuts a new base image, and this is how we pick them up.
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 
 # goreleaser supplies this for us.
 COPY catalog-importer /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
 FROM alpine:3.24.1 AS runtime
 
-# Bring the base image up to the current patch versions, then add certificates
-# so we can make HTTPS requests.
-#
-# The upgrade is doing the security work here. OpenSSL is present in the base
-# image regardless of what we install, because busybox's ssl_client depends on
-# it, so pinning the base alone leaves us on whatever OpenSSL that base release
-# happened to ship. Alpine publishes fixes into the 3.24 repository well before
-# it cuts a new base image, and this is how we pick them up.
+# Add certificates so we can make HTTPS requests, and upgrade the base
+# packages: the versions in the base image have vulnerabilities that an
+# update addresses.
 RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 
 # goreleaser supplies this for us.


### PR DESCRIPTION
The published image still carries 2 HIGH, 6 MEDIUM and 12 LOW findings, all of them in `libcrypto3` and `libssl3`. This is the same set a customer reported in #351, and v2.12.3 did not move it. That release changed `ca-certificates` to `ca-certificates-bundle` on the theory that `ca-certificates` was what pulled OpenSSL into the image. That theory was wrong, and the release shipped no security improvement at all.

OpenSSL is in the base image before our Dockerfile runs a line. `ssl_client`, busybox's HTTPS helper, is part of Alpine's minirootfs and depends on `so:libssl.so.3`, so `libcrypto3` and `libssl3` are installed no matter what we add on top. `ca-certificates-bundle` is in the base already too, which made that `apk add` a no-op. The only real effect of the change was to remove `update-ca-certificates` from the image, which anyone injecting a corporate CA into a derived build would need. That is a regression, and it is live in v2.12.3.

This restores `ca-certificates` and adds `apk upgrade --no-cache`. The upgrade is what does the security work: Alpine published the patched OpenSSL as `3.5.8-r0` into the 3.24 repository, but has not yet cut an `alpine:3.24.2` base image, so pinning the base alone cannot reach it. The tradeoff is that image contents now depend on when the image is built rather than on the pin alone. Given the base pin demonstrably does not carry patch-level fixes, that seems the right way round.

Verified end to end rather than argued from package metadata. Both architectures were built locally against the real goreleaser inputs and scanned: 21 findings become 1, and the remaining one is the `golang.org/x/crypto/openpgp` advisory, which is unmaintained upstream and has no fixed version. `libcrypto3` and `libssl3` move from `3.5.7-r0` to `3.5.8-r0` on both. The binary runs, `update-ca-certificates` is present again, and a real call to the API returns a 401 on both architectures, which only happens once the TLS handshake has succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)